### PR TITLE
docs: position manifest-driven as SDD cousin, clarify ephemeral nature

### DIFF
--- a/.launch/blog-post.md
+++ b/.launch/blog-post.md
@@ -58,6 +58,8 @@ The workflow:
 
 The loop continues until everything passes—or until a blocker requires human intervention.
 
+If you know spec-driven development, this is a cousin—adapted for LLM execution. The manifest is a spec, but ephemeral: it drives one task, then the code is the source of truth. No spec maintenance. No drift problem. The interview surfaces criteria you'd miss. The verify-fix loop enforces them.
+
 ---
 
 ## Why This Works (The LLM Science)

--- a/.launch/reddit-claudeai.md
+++ b/.launch/reddit-claudeai.md
@@ -37,6 +37,8 @@ Instead of detailed implementation steps, I define:
 
 Then I let Claude implement toward those criteria. A verify-fix loop handles cleanup. What fails gets fixed. What passes is locked in.
 
+If you know spec-driven development, this is a cousin—adapted for LLMs. Key difference: the manifest is ephemeral. It drives one task, then the code is truth. No spec maintenance.
+
 **The key insight:**
 
 The interview phase surfaces stuff I'd miss. "Should there be rate limiting?" (Yes—I'd reject a PR without it, but I wouldn't have specified it.) Those latent criteria come out of the conversation, not my upfront thinking.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ When you ask "what would make me accept this?", you define success criteria. You
 
 This is manifest-driven development.
 
+If you know spec-driven development, this is a cousin—adapted for LLM execution. The manifest is a spec, but ephemeral: it drives one task, then the code is the source of truth. No spec maintenance. No drift problem.
+
 ## How It Works
 
 Manifest-driven development separates three concerns:


### PR DESCRIPTION
Add clarification that manifest-driven development is related to
spec-driven development but adapted for LLM execution. Key distinction:
manifests are ephemeral (task-scoped), code stays the source of truth.

https://claude.ai/code/session_01Ujn6o87kVQAYTj8mvUcaRB