### PR TITLE
fix(define): sharpen cross-cutting architecture and interface contract detection

### DIFF
--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "description": "Manifest-driven workflows for structured task execution with verification gates.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/agents/manifest-verifier.md
+++ b/claude-plugins/manifest-dev/agents/manifest-verifier.md
@@ -58,6 +58,8 @@ User statements and discovered insights must appear in the manifest. Flag when:
 Complex tasks need initial direction (expect adjustment when reality diverges). Flag when:
 - Multiple deliverables but no execution order or dependencies
 - Architectural decisions implicit rather than explicit
+- Architectural choice affects multiple deliverables but manifest doesn't identify which deliverables depend on it or what changes if the choice proves wrong
+- Deliverables have producer-consumer dependencies but no specification of the interface between them (data shape, contract, or integration point)
 - Competing concerns discussed but no trade-offs (T-*) captured
 - High-risk task but no risk areas (R-*) defined
 

--- a/claude-plugins/manifest-dev/skills/define/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/define/SKILL.md
@@ -115,7 +115,7 @@ After defining deliverables, probe for **initial** implementation direction. Ski
 
 **Why "initial"**: Approach provides starting direction, not a rigid plan. Plans break when hitting reality—unexpected constraints, better patterns discovered, dependencies that don't work as expected. The goal is enough direction to start confidently, with trade-offs documented so implementation can adjust autonomously when reality diverges.
 
-**Architecture** - Generate concrete options based on existing patterns. "Given the intent, here are approaches: [A], [B], [C]. Which fits best?" Architecture is direction (structure, patterns, flow), not step-by-step script.
+**Architecture** - Generate concrete options based on existing patterns. "Given the intent, here are approaches: [A], [B], [C]. Which fits best?" Architecture is direction (structure, patterns, flow), not step-by-step script. When a choice affects multiple deliverables, surface which deliverables depend on it and what would need to change if the choice proves wrong during implementation.
 
 **Execution Order** - Propose order based on dependencies. "Suggested order: D1 → D2 → D3. Rationale: [X]. Adjust?" Include why (dependencies, risk reduction, etc.).
 


### PR DESCRIPTION
Add two flag conditions to manifest-verifier's "Approach for complexity"
principle: detect when architectural choices affect multiple deliverables
without documenting coupling, and when producer-consumer deliverables lack
interface specifications. Add corresponding prompt in /define's Architecture
section to surface blast radius before user commits to a choice.

https://claude.ai/code/session_01B9VVij41b7ziG9B2EdoG9R