### PR TITLE
Remove prefix from prompt-engineering skill reference in prompt-reviewer

### DIFF
--- a/.claude/agents/prompt-reviewer.md
+++ b/.claude/agents/prompt-reviewer.md
@@ -9,7 +9,7 @@ Review LLM prompts. Report findings without modifying files.
 
 ## Foundation
 
-**First**: Invoke `prompt-engineering:prompt-engineering` to load the principles. Review the prompt against those principles (WHAT/WHY not HOW, trust capability/enforce discipline, information density, avoid arbitrary values, issue types, anti-patterns).
+**First**: Invoke `prompt-engineering` to load the principles. Review the prompt against those principles (WHAT/WHY not HOW, trust capability/enforce discipline, information density, avoid arbitrary values, issue types, anti-patterns).
 
 ## Input
 


### PR DESCRIPTION
The prompt-engineering skill doesn't need the plugin namespace prefix
when invoked from within the same plugin context.

https://claude.ai/code/session_01BzLFr3YBB36enoRLrgQ9jH