### PR TITLE
feat: add execution mode slider (--mode efficient|balanced|thorough)

### DIFF
--- a/.claude/skills/sync-tools/SKILL.md
+++ b/.claude/skills/sync-tools/SKILL.md
@@ -31,7 +31,7 @@ For each target CLI, read its reference file first. The reference file is **the 
 
 | Component | Goal |
 |-----------|------|
-| **Skills** | Copy unchanged (Agent Skills Open Standard = universal). Include all subdirectories. Replace operational CLAUDE.md references (e.g., "write to CLAUDE.md") with CLI context file name per reference file. Leave research/reference content unchanged. |
+| **Skills** | Copy unchanged (Agent Skills Open Standard = universal). Include all subdirectories. Replace operational CLAUDE.md references (e.g., "write to CLAUDE.md") with CLI context file name per reference file. Leave research/reference content unchanged. **Exception**: `references/BUDGET_MODES.md` — replace Claude-specific model names (haiku, sonnet, opus) with `inherit`. Model tier routing is Claude Code-only; other CLIs use session model for all tiers. |
 | **Agents** | Convert frontmatter per reference file. Keep prompt body as identical as possible to Claude Code original — categories, actionability filters, severity guidelines, output formats, out-of-scope sections are the core value. Only change: frontmatter format, namespace suffix, context file name (CLAUDE.md → CLI name per reference file), genuinely unsupported features (document as limitation, don't remove). |
 | **Hooks** | Adapt to the target hook protocol per reference file. Generate complete, installable hook/plugin payloads. Document unavoidable runtime gaps, but do not ship stubs or require manual post-install wiring. |
 | **Commands** | Generate command files from user-invocable skills (`user-invocable: true`, the default). Per reference file. |

--- a/.claude/skills/sync-tools/references/codex-cli.md
+++ b/.claude/skills/sync-tools/references/codex-cli.md
@@ -436,3 +436,4 @@ The `context-file-adherence-reviewer` agent already uses generic "context file" 
 9. **Notify is fire-and-forget** — Cannot block or modify agent behavior.
 10. **Experimental tools availability** — `read_file`, `list_dir`, `grep_files` are gated server-side by model's `experimental_supported_tools`. Not all users may have access.
 11. **TaskCreate ≠ Agent** — Claude Code's TaskCreate/TaskUpdate/TaskGet/TaskList map to `update_plan` (todo), NOT to `spawn_agent` (multi-agent).
+12. **Model tier routing is Claude Code-only** — `BUDGET_MODES.md` references Claude model names (haiku, sonnet, opus). Replace all with `inherit` during sync. Codex has no runtime `inherit` — use the default model configured in the role's TOML. Execution mode parallelism, loop limits, and gate-skipping still apply.

--- a/.claude/skills/sync-tools/references/gemini-cli.md
+++ b/.claude/skills/sync-tools/references/gemini-cli.md
@@ -376,3 +376,4 @@ The `context-file-adherence-reviewer` agent already uses generic "context file" 
 6. **`grep_search` is canonical** — Source code (`base-declarations.ts`) defines `GREP_TOOL_NAME = 'grep_search'`. The docs index page showing `search_file_content` is stale. Always use `grep_search`.
 7. **`generalist` not `generalist_agent`** — The built-in subagent tool name is `generalist`, not `generalist_agent`.
 8. **TaskCreate ≠ Agent** — Claude Code's TaskCreate/TaskUpdate/TaskGet/TaskList are todo management tools (map to `write_todos`), NOT subagent tools. Only `Agent` maps to subagent names.
+9. **Model tier routing is Claude Code-only** — `BUDGET_MODES.md` references Claude model names (haiku, sonnet, opus). Replace all with `inherit` during sync. Gemini supports `model: inherit` natively. Execution mode parallelism, loop limits, and gate-skipping still apply.

--- a/.claude/skills/sync-tools/references/opencode-cli.md
+++ b/.claude/skills/sync-tools/references/opencode-cli.md
@@ -461,3 +461,4 @@ The `context-file-adherence-reviewer` agent already uses generic "context file" 
 13. **TaskCreate ≠ Agent** — Claude Code's TaskCreate/TaskUpdate/TaskGet/TaskList are todo management tools (map to `todowrite`/`todoread`), NOT subagent tools. Only `Agent` maps to `task`.
 14. **apply_patch vs edit/write** — GPT models get `apply_patch` instead of `edit`/`write`. Non-GPT models (Anthropic, etc.) get `edit`/`write`. The swap is automatic in OpenCode's registry.
 15. **tui.prompt.append is NOT context injection** — It fills the TUI input field, not system messages. Use `experimental.chat.system.transform` for system context.
+16. **Model tier routing is Claude Code-only** — `BUDGET_MODES.md` references Claude model names (haiku, sonnet, opus). Replace all with `inherit` during sync. OpenCode is provider-agnostic — all tiers use the session model. Execution mode parallelism, loop limits, and gate-skipping still apply.

--- a/.manifest/execution-mode-slider-2026-03-12.md
+++ b/.manifest/execution-mode-slider-2026-03-12.md
@@ -1,0 +1,312 @@
+# Definition: Execution Mode Slider for /do, /verify, and /define
+
+## 1. Intent & Context
+- **Goal:** Add an execution mode slider (`--mode efficient|balanced|thorough`) that controls subagent model routing, quality gate inclusion, parallelism, and verification loop limits across the manifest-dev workflow. Addresses GitHub issue #38 — quota-aware execution during /do.
+- **Mental Model:** Mode is an execution policy, not a requirements concern. It controls HOW work is verified, not WHAT gets built. The default (`thorough`) preserves all current behavior unchanged. Users opt in to cheaper modes explicitly. Mode flows through the workflow: manifest `mode:` field → /do reads it (or `--mode` arg overrides) → /do passes to /verify. Implementation is primarily prompt changes to skills, plus one new reference file.
+
+## 2. Approach
+
+- **Architecture:**
+  - New `references/BUDGET_MODES.md` file under `skills/do/references/` — single source of truth for all mode routing tables, escalation rules, and per-level behavior.
+  - BUDGET_MODES.md uses **Claude-specific model names** (haiku) in the source. Model tier routing (using cheaper models in efficient mode) is a **Claude Code-only feature**. For all other CLIs, sync-tools replaces Claude model names with `inherit` — all tiers use the session model. The parallelism, loop limits, and gate-skipping aspects of budget modes still apply universally.
+  - Core skills (`/do`, `/verify`, `/define`) get minimal additions — 2-3 lines each pointing to the reference file when mode != thorough.
+  - `/verify` receives mode as `--mode` argument from /do.
+  - Manifest schema gets an optional `mode` field at the top level.
+  - Skill descriptions updated with `--mode` parameter syntax for model visibility.
+  - Sync-tools reference files updated: model tier routing is Claude Code-only, all other CLIs use `inherit` for all tiers.
+  - After all changes: run `/sync-tools` to regenerate dist/ for all target CLIs.
+
+- **Execution Order:**
+  - D1 (BUDGET_MODES.md reference file) → D2 (/do SKILL.md) → D3 (/verify SKILL.md) → D4 (/define SKILL.md schema) → D5 (docs, README, version) → D6 (sync-tools references) → D7 (run /sync-tools)
+  - Rationale: Reference file first (source of truth), then consumers in dependency order. /do depends on reference file. /verify depends on /do's argument passing. /define depends on schema being defined. Docs and sync-tools updates after core feature. Run sync-tools last to regenerate dist/.
+
+- **Risk Areas:**
+  - [R-1] Cheapest-tier model criteria-checker inadequacy | Detect: >50% of efficient-mode verification criteria require escalation in a single /do run
+  - [R-2] Prompt complexity creep in /do | Detect: /do SKILL.md grows by more than 10 lines due to mode logic
+  - [R-3] Regression in default (thorough) behavior | Detect: any test or usage of thorough mode behaves differently than current behavior
+
+- **Trade-offs:**
+  - [T-1] Quota savings vs quality assurance → Prefer quality (thorough is default; efficient is opt-in and explicitly accepts lower verification coverage)
+  - [T-2] Prompt brevity vs explicit mode rules → Prefer brevity in core skills (detail in reference file)
+  - [T-3] Prescriptive routing tables vs flexible guidance → Prefer prescriptive tables (clear rules are easier to follow than judgment calls)
+
+## 3. Global Invariants (The Constitution)
+
+- [INV-G1] Default behavior unchanged: when no `mode` field in manifest AND no `--mode` argument to /do, all behavior must be identical to the current (pre-feature) /do and /verify behavior.
+  ```yaml
+  verify:
+    method: subagent
+    agent: criteria-checker
+    prompt: "Read /do SKILL.md and /verify SKILL.md. Confirm that when mode is not specified (or is 'thorough'), the behavior described matches the pre-change behavior: all verifiers launch in a single message, all quality gate reviewers run, no parallelism limits, no escalation caps, manifest-verifier runs in /define. Compare against git diff to verify no default-path behavior changed."
+  ```
+
+- [INV-G2] Mode routing table accuracy: the reference file's routing table must match the agreed design exactly.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "In skills/do/references/BUDGET_MODES.md, verify the routing table contains exactly: efficient (haiku checker, reviewers SKIPPED, sequential, max 1 fix-verify loop, manifest-verifier SKIPPED, auto-escalate after 2 fails, cap 3 escalations), balanced (inherit checker, inherit reviewers, max 4 parallel, max 2 fix-verify loops, manifest-verifier SKIPPED, escalate after loop limit), thorough (inherit checker, inherit reviewers, unlimited parallel, unlimited loops, manifest-verifier runs, no escalation)."
+  ```
+
+- [INV-G3] No prompt anti-patterns: changes to skill files must not introduce prescriptive HOW instructions, arbitrary limits without rationale, weak language, or buried critical info.
+  ```yaml
+  verify:
+    method: subagent
+    agent: prompt-reviewer
+    prompt: "Review the changed sections of skills/do/SKILL.md, skills/verify/SKILL.md, and skills/define/SKILL.md for prompt anti-patterns: prescriptive HOW (should state goals), arbitrary limits (should have rationale), weak language ('try to', 'maybe'), buried critical info. Also check that mode-related instructions are WHAT/WHY not HOW."
+  ```
+
+- [INV-G4] Skill descriptions include --mode parameter: /do and /verify skill descriptions must show the `--mode` syntax so it's visible to the model.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Check that skills/do/SKILL.md and skills/verify/SKILL.md frontmatter 'description' fields include '--mode' parameter syntax."
+  ```
+
+- [INV-G5] Information density: reference file and skill additions must have no redundant content — every sentence earns its place.
+  ```yaml
+  verify:
+    method: subagent
+    agent: code-simplicity-reviewer
+    prompt: "Review skills/do/references/BUDGET_MODES.md and the mode-related additions to skills/do/SKILL.md, skills/verify/SKILL.md, and skills/define/SKILL.md. Flag any redundant content, unnecessary verbosity, or information that doesn't earn its place."
+  ```
+
+- [INV-G6] CLAUDE.md adherence: all changes follow project conventions (kebab-case naming, prompt-engineering principles, plugin structure).
+  ```yaml
+  verify:
+    method: subagent
+    agent: context-file-adherence-reviewer
+    prompt: "Verify all changed files follow CLAUDE.md conventions: kebab-case naming, plugin structure, prompt-engineering principles."
+  ```
+
+- [INV-G7] Project gates pass: lint, format, typecheck pass.
+  ```yaml
+  verify:
+    method: bash
+    command: "ruff check claude-plugins/ && black --check claude-plugins/ && mypy 2>&1 | tail -5"
+  ```
+
+- [INV-G8] Criterion-level model override precedence: when a manifest criterion specifies `model: <value>` in its verify block, that overrides the mode-level model routing. Mode sets defaults; criterion-level is explicit.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify skills/do/references/BUDGET_MODES.md states that per-criterion model overrides in manifest verify blocks take precedence over mode-level routing."
+  ```
+
+## 4. Process Guidance (Non-Verifiable)
+
+- [PG-1] Use prompt-engineering skill for all prompt changes — ensures WHAT/WHY not HOW approach.
+- [PG-2] Document load-bearing assumptions — identify what must remain true for modes to work (Agent tool model param, inherit behavior).
+- [PG-3] Reference file approach — mode details in `references/BUDGET_MODES.md`, core skills get minimal pointers. Zero complexity added for default (thorough) path users.
+
+## 5. Known Assumptions
+
+- [ASM-1] Agent tool `model` param works as documented (sonnet/opus/haiku) | Default: works | Impact if wrong: mode can't route subagents to cheaper models — feature is ineffective
+- [ASM-2] `inherit` means parent session model | Default: yes | Impact if wrong: balanced/thorough might not use user's preferred model
+- [ASM-3] Cheapest-tier model (haiku on Claude, flash on Gemini, etc.) can run criteria-checker competently for bash/codebase verification | Default: mostly competent | Impact if wrong: efficient mode has high false-failure rate — mitigated by escalation mechanism (R-1)
+- [ASM-4] Manifest schema is forward-compatible (adding optional `mode` field doesn't break older parsers) | Default: yes, skills parse manifests loosely | Impact if wrong: older /do versions error on new manifests
+- [ASM-5] post_compact_hook.py preserves --mode in /do args recovery (VERIFIED: hook passes full `do_args` string, line 71). Additionally, mode is in the manifest `mode:` field which /do re-reads after compaction (AC-2.1 precedence) | Default: safe | Impact if wrong: n/a — two recovery paths
+
+## 6. Deliverables (The Work)
+
+### Deliverable 1: Mode Reference File
+*New file: `claude-plugins/manifest-dev/skills/do/references/BUDGET_MODES.md`*
+
+**Acceptance Criteria:**
+- [AC-1.1] File contains the complete mode routing table with all three levels (efficient/balanced/thorough) and all 6 dimensions (checker model, reviewers, parallelism, fix-verify loops, manifest-verifier, escalation). Uses Claude-specific model names (haiku) since sync-tools converts per CLI.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify skills/do/references/BUDGET_MODES.md contains a table with columns for all 6 dimensions and rows for all 3 mode levels matching: efficient (haiku/SKIPPED/sequential/max 1/SKIPPED/auto after 2, cap 3), balanced (inherit/inherit/max 4/max 2/SKIPPED/after loop limit), thorough (inherit/inherit/unlimited/unlimited/runs/no escalation)."
+  ```
+
+- [AC-1.2] File contains escalation rules: efficient auto-escalates after 2 failures on same criterion, cap at 3 total escalations per /do run (then suggest switching to balanced). Balanced escalates after fix-verify loop limit hit.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify BUDGET_MODES.md defines escalation rules: efficient = auto-escalate after 2 failures per criterion, cap 3 total escalations then suggest mode switch. Balanced = escalate after loop limit."
+  ```
+
+- [AC-1.3] File contains /verify parallelism overrides: efficient=sequential, balanced=max 4 concurrent, thorough=all at once.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify BUDGET_MODES.md specifies verification parallelism per level: efficient=one at a time, balanced=batches of max 4, thorough=all in single message."
+  ```
+
+- [AC-1.4] File contains /define manifest-verifier rules: efficient+balanced skip it, thorough runs it.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify BUDGET_MODES.md specifies manifest-verifier behavior: skipped for efficient and balanced, runs for thorough."
+  ```
+
+- [AC-1.5] File states override precedence: (1) per-criterion `model:` overrides mode-level routing, (2) explicit model override also overrides the "reviewers SKIPPED" rule (criterion runs even in efficient mode), (3) INV-G verification always runs regardless of mode (skip only applies to deliverable-level quality gates).
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify BUDGET_MODES.md contains all three override rules: criterion-level model overrides mode routing, explicit model overrides reviewer skip, and INV-G verification always runs (skip only affects deliverable-level gates)."
+  ```
+
+### Deliverable 2: /do Skill Mode Integration
+*Edit: `claude-plugins/manifest-dev/skills/do/SKILL.md`*
+
+**Acceptance Criteria:**
+- [AC-2.1] /do SKILL.md parses mode from: (1) `--mode <level>` argument, (2) manifest `mode:` field, with argument taking precedence. Default: thorough. Invalid value → error and halt.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify /do SKILL.md describes mode parsing: --mode arg > manifest mode field > default thorough. All three sources mentioned with precedence order. Invalid mode value produces error and halts."
+  ```
+
+- [AC-2.2] /do SKILL.md contains a conditional pointer to the reference file: when mode != thorough, read `references/BUDGET_MODES.md`.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify /do SKILL.md has a conditional instruction to read references/BUDGET_MODES.md only when mode is not thorough."
+  ```
+
+- [AC-2.3] /do passes mode to /verify as argument: `/verify <manifest> <log> --mode <level>`.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify /do SKILL.md instructs passing mode to /verify invocation as --mode argument."
+  ```
+
+- [AC-2.4] Skill description (frontmatter) includes `--mode` parameter syntax.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify /do SKILL.md frontmatter description field mentions --mode parameter."
+  ```
+
+- [AC-2.5] /do enforces fix-verify loop limits per mode: tracks iteration count, stops at the mode's limit, and escalates when limit is reached.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify /do SKILL.md (or the reference file it points to) instructs /do to track fix-verify loop iterations and enforce mode-specific limits: efficient=max 1, balanced=max 2, thorough=unlimited. When limit is hit, /do must escalate."
+  ```
+
+- [AC-2.6] /do enforces escalation cap in efficient mode: tracks total escalations, suggests mode switch to user after 3.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify /do SKILL.md (or the reference file it points to) instructs /do to count escalations in efficient mode and suggest switching to balanced after 3 total escalations in a single /do run."
+  ```
+
+### Deliverable 3: /verify Skill Mode Integration
+*Edit: `claude-plugins/manifest-dev/skills/verify/SKILL.md`*
+
+**Acceptance Criteria:**
+- [AC-3.1] /verify SKILL.md accepts `--mode <level>` in its arguments, defaulting to thorough.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify /verify SKILL.md describes accepting --mode argument with thorough default."
+  ```
+
+- [AC-3.2] /verify SKILL.md has a mode-aware parallelism section that explicitly overrides the default 'launch all in single message' rule per mode level.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify /verify SKILL.md has a section that overrides default parallelism based on mode: efficient=sequential, balanced=max 4, thorough=all at once. The override must be explicit (not ambiguous with the existing parallelism rule)."
+  ```
+
+- [AC-3.3] /verify routes subagent model per mode level: efficient=haiku for criteria-checker (reviewers skipped), balanced+thorough=inherit.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify /verify SKILL.md instructs model routing: efficient mode uses haiku for criteria-checker and skips reviewer subagents. Balanced and thorough use inherit."
+  ```
+
+- [AC-3.4] Skill description (frontmatter) includes `--mode` parameter syntax.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify /verify SKILL.md frontmatter description field mentions --mode parameter."
+  ```
+
+### Deliverable 4: /define Manifest Schema Update
+*Edit: `claude-plugins/manifest-dev/skills/define/SKILL.md`*
+
+**Acceptance Criteria:**
+- [AC-4.1] Manifest schema in /define includes optional `mode: efficient|balanced|thorough` field at the top level.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify /define SKILL.md manifest schema template includes an optional mode field with the three valid values."
+  ```
+
+- [AC-4.2] /define respects mode for its own manifest-verifier step: reads mode from manifest, skips manifest-verifier for efficient+balanced.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify /define SKILL.md verification loop section checks the manifest's mode field and skips manifest-verifier invocation when mode is efficient or balanced."
+  ```
+
+### Deliverable 5: Documentation and Versioning
+*Edit: READMEs, plugin.json*
+
+**Acceptance Criteria:**
+- [AC-5.1] Root README.md documents the execution mode feature: what it is, how to use it (`--mode` arg or manifest field), the three levels and their behavior summary.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify README.md has a section documenting execution modes: the three levels, how to specify (--mode arg or manifest field), and a summary of each level's behavior."
+  ```
+
+- [AC-5.2] Plugin version bumped to 0.64.0 (minor: new feature).
+  ```yaml
+  verify:
+    method: bash
+    command: "grep '\"version\"' claude-plugins/manifest-dev/.claude-plugin/plugin.json | grep -q '0.64.0'"
+  ```
+
+- [AC-5.3] Plugin README (`claude-plugins/manifest-dev/README.md`) updated to mention execution modes.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify claude-plugins/manifest-dev/README.md mentions execution modes feature."
+  ```
+
+### Deliverable 6: Sync-Tools Budget Mode Conversion
+*Edit: `.claude/skills/sync-tools/SKILL.md` and `.claude/skills/sync-tools/references/{codex,gemini,opencode}-cli.md`*
+
+**Acceptance Criteria:**
+- [AC-6.1] Sync-tools SKILL.md includes a conversion rule for BUDGET_MODES.md: replace Claude-specific model names (haiku, sonnet, opus) with `inherit` for all target CLIs. Model tier routing is Claude Code-only; other CLIs use session model for all tiers.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify .claude/skills/sync-tools/SKILL.md includes a conversion rule for skill reference files containing Claude model names: replace haiku/sonnet/opus with 'inherit' for all target CLIs."
+  ```
+
+- [AC-6.2] Each sync-tools reference file documents that model tier routing is Claude Code-only and all budget tiers use `inherit` on that CLI.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Verify all three sync-tools reference files note that BUDGET_MODES.md model names are replaced with 'inherit' — model tier routing is Claude Code-specific."
+  ```
+
+### Deliverable 7: Run /sync-tools
+*Execute: `/sync-tools` to regenerate dist/ for all target CLIs*
+
+**Acceptance Criteria:**
+- [AC-7.1] `/sync-tools` has been run successfully after all other changes, regenerating dist/ for gemini, opencode, and codex.
+  ```yaml
+  verify:
+    method: bash
+    command: "git diff --name-only | grep -c '^dist/' | xargs -I{} test {} -gt 0 && echo 'dist/ has changes' || echo 'FAIL: dist/ not updated'"
+  ```
+
+- [AC-7.2] The generated dist/ files include a CLI-adapted BUDGET_MODES.md reference file in each CLI's skill distribution (with CLI-specific model names, not Claude names).
+  ```yaml
+  verify:
+    method: bash
+    command: "for cli in gemini opencode codex; do test -f dist/$cli/skills/do/references/BUDGET_MODES.md && echo \"$cli: OK\" || echo \"$cli: MISSING\"; done"
+  ```
+
+- [AC-7.3] The generated dist/ READMEs mention execution modes feature.
+  ```yaml
+  verify:
+    method: bash
+    command: "for cli in gemini opencode codex; do grep -qi 'mode\\|budget\\|efficient\\|thorough' dist/$cli/README.md && echo \"$cli README: OK\" || echo \"$cli README: MISSING mode docs\"; done"
+  ```

--- a/README.md
+++ b/README.md
@@ -133,6 +133,22 @@ This is spec-driven development adapted for LLM execution. The manifest is a spe
 
 </details>
 
+<details>
+<summary><strong>Execution Modes</strong></summary>
+
+`/do` supports `--mode efficient|balanced|thorough` to control verification intensity. Default is `thorough` (current behavior). Only pass `--mode` when you explicitly want to trade verification depth for quota savings.
+
+| Mode | What changes | When to use |
+|------|-------------|-------------|
+| **thorough** (default) | Full verification: all quality gates, all models inherit from session, unlimited parallelism and fix loops | Most tasks. Don't change unless you have a reason. |
+| **balanced** | Same models, but limits parallelism (max 4 concurrent verifiers) and fix loops (max 2) | Long-running tasks where you want to limit concurrent quota burn |
+| **efficient** | Uses haiku for criteria-checker, skips quality gate reviewers, sequential verification, max 1 fix loop | Quick iterations where speed matters more than verification depth |
+
+Set per-execution: `/do manifest.md --mode balanced`
+Set in manifest: add `mode: balanced` to the Intent & Context section.
+
+</details>
+
 ### Best Practice: Two Sessions, One Source of Truth
 
 Run `/define` and `/do` in separate sessions. The define session holds your intent; the do session holds implementation state. Keep both open.

--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.63.3",
+  "version": "0.64.0",
   "description": "Manifest-driven workflows for structured task execution with verification gates.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/README.md
+++ b/claude-plugins/manifest-dev/README.md
@@ -106,6 +106,18 @@ The manifest has three moving parts:
 | `/escalate` | When something's blocked, surfaces the issue for you to decide |
 | `/learn-define-patterns` | Analyzes recent /define sessions, extracts user preference patterns, writes them to CLAUDE.md |
 
+### Execution Modes
+
+`/do` supports `--mode efficient|balanced|thorough` (default: thorough). Controls verification intensity — cheaper modes use less quota at the cost of verification depth. Only specify when you explicitly want to change it.
+
+| Mode | Key Differences |
+|------|----------------|
+| **thorough** | Full verification, all quality gates, unlimited parallelism (default) |
+| **balanced** | Same models, limited parallelism (max 4), limited fix loops (max 2) |
+| **efficient** | Haiku for verification, skips reviewer agents, sequential, max 1 fix loop |
+
+See `skills/do/references/BUDGET_MODES.md` for full routing table and escalation rules.
+
 ### Task-Specific Guidance
 
 `/define` works for any task. Domain-specific guidance loads automatically when relevant:

--- a/claude-plugins/manifest-dev/skills/define/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/define/SKILL.md
@@ -339,6 +339,7 @@ Three categories, each covering **output** or **process**:
 ## 1. Intent & Context
 - **Goal:** [High-level purpose]
 - **Mental Model:** [Key concepts to understand]
+- **Mode:** efficient | balanced | thorough *(optional, default: thorough — controls verification intensity during /do)*
 
 ## 2. Approach (Complex Tasks Only)
 *Initial direction, not rigid plan. Provides enough to start confidently; expect adjustment when reality diverges.*
@@ -417,7 +418,13 @@ Manifests support amendments during execution:
 
 ## Verification Loop
 
-After writing the manifest, invoke the manifest-verifier agent. Pass only the file paths — no summary, framing, or commentary:
+After writing the manifest, check the manifest's `mode:` field and the `/define manifest-verifier` row in `skills/do/references/BUDGET_MODES.md`:
+
+- **efficient**: Skip the manifest-verifier. Proceed directly to Summary for Approval.
+- **balanced**: Run the manifest-verifier **once**. If it returns CONTINUE, present its questions, update the manifest, then proceed to Summary for Approval (no repeat loop).
+- **thorough** (default, or unspecified): Run the manifest-verifier with the full repeat loop until COMPLETE.
+
+When running the verifier, pass only the file paths — no summary, framing, or commentary:
 
 ```
 Invoke the manifest-dev:manifest-verifier agent with: "Manifest: /tmp/manifest-{timestamp}.md | Log: /tmp/define-discovery-{timestamp}.md"

--- a/claude-plugins/manifest-dev/skills/do/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/do/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: do
-description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Use when executing a manifest, running a plan, implementing a defined task.'
+description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Optional --mode efficient|balanced|thorough controls verification intensity (default: thorough). Only pass --mode when the user explicitly requests a different mode. Use when executing a manifest, running a plan, implementing a defined task.'
 ---
 
 # /do - Manifest Executor
@@ -13,9 +13,17 @@ Execute a Manifest: satisfy all Deliverables' Acceptance Criteria while followin
 
 ## Input
 
-`$ARGUMENTS` = manifest file path (REQUIRED), optionally with execution log path
+`$ARGUMENTS` = manifest file path (REQUIRED), optionally with execution log path and `--mode <level>`
 
-If no arguments: Output error "Usage: /do <manifest-file-path> [log-file-path]"
+If no arguments: Output error "Usage: /do <manifest-file-path> [log-file-path] [--mode efficient|balanced|thorough]"
+
+## Execution Mode
+
+Resolve mode from (highest precedence first): `--mode` argument → manifest `mode:` field → default `thorough`.
+
+Invalid mode value → error and halt: "Invalid mode '<value>'. Valid modes: efficient | balanced | thorough"
+
+If mode is not `thorough`: read `references/BUDGET_MODES.md` for routing rules, escalation logic, and parallelism overrides. Follow those rules for the remainder of this /do run.
 
 ## Existing Execution Log
 
@@ -35,9 +43,11 @@ If input includes a log file path (iteration on previous work): **treat it as so
 
 **Log after every action** - Write to execution log immediately after each AC attempt. No exceptions. This is disaster recovery—if context is lost, the log is the only record of what happened.
 
-**Must call /verify** - Can't declare done without verification. Invoke manifest-dev:verify with manifest and log paths.
+**Must call /verify** - Can't declare done without verification. Invoke manifest-dev:verify with manifest, log paths, and the resolved mode: `/verify <manifest> <log> --mode <level>`.
 
-**Escalation boundary** - Escalate when: (1) ACs can't be met as written (contract broken), (2) user requests a pause mid-workflow, or (3) you discover an AC or invariant should be amended (use "Proposed Amendment" escalation type). If ACs remain achievable as written and no user interrupt, continue autonomously. Approach pivots don't require escalation — log adjustments with rationale and continue.
+**Escalation boundary** - Escalate when: (1) ACs can't be met as written (contract broken), (2) user requests a pause mid-workflow, (3) you discover an AC or invariant should be amended (use "Proposed Amendment" escalation type), or (4) mode-specific fix-verify loop limit is reached (see `references/BUDGET_MODES.md`). If ACs remain achievable as written and no user interrupt, continue autonomously. Approach pivots don't require escalation — log adjustments with rationale and continue.
+
+**Mode-aware loop tracking** - Track fix-verify iteration count and escalation count in the execution log. When mode limits are reached, follow the escalation rules in `references/BUDGET_MODES.md`. In efficient mode, also track total escalations and suggest mode switch after 3.
 
 **Stop requires /escalate** - During /do, you cannot stop without calling /verify→/done or /escalate. If you need to pause (user requested, waiting on external action), call /escalate with "User-Requested Pause" format. Short outputs like "Done." or "Waiting." will be blocked.
 

--- a/claude-plugins/manifest-dev/skills/do/references/BUDGET_MODES.md
+++ b/claude-plugins/manifest-dev/skills/do/references/BUDGET_MODES.md
@@ -1,0 +1,42 @@
+# Execution Modes
+
+Execution modes control verification intensity across the manifest-dev workflow (/define, /do, /verify). The mode affects subagent model selection, quality gate inclusion, parallelism, fix-verify loop limits, and manifest validation depth. It does NOT affect what gets built — only how thoroughly the output is verified.
+
+## Mode Routing Table
+
+| Dimension | efficient | balanced | thorough (default) |
+|-----------|-----------|----------|--------------------|
+| Criteria-checker model | haiku | inherit | inherit |
+| Quality gate reviewers | SKIPPED | inherit | inherit |
+| Verification parallelism | Sequential (one at a time) | Batched (max 4 concurrent) | All at once (single message) |
+| Fix-verify loops | Max 1 | Max 2 | Unlimited |
+| /define manifest-verifier | SKIPPED | Runs once (no repeat loop) | Runs (with repeat loop) |
+| Escalation | Auto-escalate after 2 failures per criterion; cap 3 total | Escalate after loop limit hit | None |
+
+**Why these levels exist**: thorough preserves the current quality bar (default). balanced saves quota by limiting parallelism and verification cycles while keeping full model capability. efficient maximizes savings by using a cheaper model for verification and skipping reviewer agents — accept this only when iteration speed matters more than verification depth.
+
+## Escalation Rules
+
+**Efficient mode**: When a criterion fails twice at haiku, auto-escalate that criterion's verifier to inherit (session model). Track total escalations — after 3 in a single /do run, suggest to the user: "Efficient mode is escalating frequently. Consider switching to balanced." This prevents runaway costs from repeated escalation.
+
+**Balanced mode**: When the fix-verify loop limit (2) is hit, escalate via /escalate. The fix isn't converging — human judgment needed.
+
+**Thorough mode**: No escalation mechanism. Unlimited loops, full model capability.
+
+## Verification Parallelism
+
+These override /verify's default "launch all verifiers in a single message" rule:
+
+- **efficient**: Launch verifiers one at a time. Minimizes concurrent quota usage.
+- **balanced**: Launch in batches of max 4 concurrent verifiers. When any batch completes, launch the next batch.
+- **thorough**: Launch all verifiers in a single message (current default behavior).
+
+## Override Precedence
+
+Three rules govern how mode interacts with other settings:
+
+1. **Criterion-level model wins**: When a manifest criterion specifies `model:` in its verify block, that overrides the mode's model routing. Mode sets defaults; criterion-level `model:` is explicit intent.
+
+2. **Explicit model overrides skip**: In efficient mode, quality gate reviewers are skipped. But if a criterion explicitly sets `model:` (e.g., `model: opus`), it runs even when efficient mode would otherwise skip it. The explicit model signals the user deliberately wants this verification.
+
+3. **Global Invariants always run**: "Reviewers SKIPPED" in efficient mode applies only to deliverable-level quality gate reviewer agents (code-bugs-reviewer, type-safety-reviewer, etc.). Global Invariant (INV-G*) verification agents always run regardless of mode — they are constitutional constraints.

--- a/claude-plugins/manifest-dev/skills/verify/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify
-description: 'Manifest verification runner. Spawns parallel verifiers for Global Invariants and Acceptance Criteria. Called by /do, not directly by users.'
+description: 'Manifest verification runner. Spawns parallel verifiers for Global Invariants and Acceptance Criteria. Optional --mode efficient|balanced|thorough controls parallelism and model routing (default: thorough). Called by /do, not directly by users.'
 user-invocable: false
 ---
 
@@ -10,9 +10,11 @@ Orchestrate verification of all criteria from a Manifest by spawning parallel ve
 
 **User request**: $ARGUMENTS
 
-Format: `<manifest-file-path> <execution-log-path>`
+Format: `<manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough]`
 
-If paths missing: Return error "Usage: /verify <manifest-path> <log-path>"
+If paths missing: Return error "Usage: /verify <manifest-path> <log-path> [--mode efficient|balanced|thorough]"
+
+Mode defaults to `thorough` if not provided.
 
 ## Principles
 
@@ -20,7 +22,7 @@ If paths missing: Return error "Usage: /verify <manifest-path> <log-path>"
 |-----------|------|
 | **Orchestrate, don't verify** | Spawn agents to verify. You coordinate results, never run checks yourself. |
 | **ALL criteria, no exceptions** | Every INV-G* and AC-*.* criterion MUST be verified. Skipping any criterion is a critical failure. |
-| **Maximize parallelism** | Launch all verifiers in a SINGLE message with multiple Task tool calls. Never launch one at a time. |
+| **Maximize parallelism** | Launch all verifiers in a SINGLE message with multiple Task tool calls. Never launch one at a time. **Overridden by mode** — see Mode-Aware Verification below. |
 | **Globals are critical** | Global Invariant failures mean task failure. Highlight prominently. |
 | **Actionable feedback** | Pass through file:line, expected vs actual, fix hints. |
 
@@ -50,10 +52,22 @@ Note: PG-* items guide HOW to work. Followed during /do, not checked by /verify.
 
 If a verification agent crashes, times out, or returns unusable output, treat the criterion as FAIL with a note that verification itself failed (not the criterion). Include the error in the failure details so /do can distinguish "criterion didn't pass" from "couldn't check."
 
+## Mode-Aware Verification
+
+When `--mode` is not `thorough`, these rules override default behavior:
+
+| Mode | Parallelism | Criteria-checker model | Quality gate reviewers |
+|------|-------------|----------------------|----------------------|
+| efficient | Sequential (one at a time) | haiku | SKIPPED for deliverable-level ACs |
+| balanced | Batched (max 4 concurrent) | inherit | inherit |
+| thorough | All at once (default) | inherit | inherit |
+
+**Efficient mode skipping**: Skip reviewer subagent verification (code-bugs-reviewer, type-safety-reviewer, etc.) for deliverable-level ACs. Still run: all bash/codebase checks, all INV-G* verification (regardless of method), and any AC with an explicit `model:` in its verify block.
+
 ## Never Do
 
-- Skip criteria (even "obvious" ones)
-- Launch verifiers sequentially across multiple messages
+- Skip criteria (even "obvious" ones) — unless mode explicitly allows (efficient mode skips deliverable-level reviewer subagents)
+- Launch verifiers sequentially across multiple messages — unless mode requires it (efficient = sequential, balanced = batched)
 - Verify criteria yourself instead of spawning agents
 
 ## Outcome Handling

--- a/dist/codex/README.md
+++ b/dist/codex/README.md
@@ -131,6 +131,20 @@ rm -rf "$TMP_DIR"
 | Project context | CLAUDE.md | AGENTS.md + CLAUDE.md fallback | project_doc_fallback_filenames config |
 | Notify (fire-and-forget) | N/A | agent-turn-complete event | Observability only, no blocking |
 
+## Execution Modes
+
+Control verification intensity with `--mode`:
+
+| Mode | Verification | Parallelism | Best For |
+|------|-------------|-------------|----------|
+| **thorough** (default) | Full reviewer agents, unlimited fix loops | All at once | Production-quality work |
+| **balanced** | Full model capability, capped loops | Batched (max 4) | Standard development |
+| **efficient** | Skips reviewer subagents, lighter checks | Sequential | Quick iterations, low-risk changes |
+
+Usage: `/do <manifest> [log] --mode balanced`
+
+Mode can also be set in the manifest's `mode:` field during `/define`. The `--mode` flag on `/do` takes precedence.
+
 ## Known Limitations
 
 1. **Skills are the only fully compatible component** -- agents are TOML stubs with approximated instructions, hooks are impossible without a hook system.
@@ -155,6 +169,8 @@ dist/codex/
 │   ├── do/
 │   │   ├── SKILL.md
 │   │   └── references/
+│   │       ├── BUDGET_MODES.md
+│   │       └── COLLABORATION_MODE.md
 │   ├── verify/
 │   │   └── SKILL.md
 │   ├── done/

--- a/dist/codex/skills/define/SKILL.md
+++ b/dist/codex/skills/define/SKILL.md
@@ -339,6 +339,7 @@ Three categories, each covering **output** or **process**:
 ## 1. Intent & Context
 - **Goal:** [High-level purpose]
 - **Mental Model:** [Key concepts to understand]
+- **Mode:** efficient | balanced | thorough *(optional, default: thorough — controls verification intensity during /do)*
 
 ## 2. Approach (Complex Tasks Only)
 *Initial direction, not rigid plan. Provides enough to start confidently; expect adjustment when reality diverges.*
@@ -417,7 +418,13 @@ Manifests support amendments during execution:
 
 ## Verification Loop
 
-After writing the manifest, invoke the manifest-verifier agent. Pass only the file paths — no summary, framing, or commentary:
+After writing the manifest, check the manifest's `mode:` field and the `/define manifest-verifier` row in `skills/do/references/BUDGET_MODES.md`:
+
+- **efficient**: Skip the manifest-verifier. Proceed directly to Summary for Approval.
+- **balanced**: Run the manifest-verifier **once**. If it returns CONTINUE, present its questions, update the manifest, then proceed to Summary for Approval (no repeat loop).
+- **thorough** (default, or unspecified): Run the manifest-verifier with the full repeat loop until COMPLETE.
+
+When running the verifier, pass only the file paths — no summary, framing, or commentary:
 
 ```
 Invoke the manifest-dev:manifest-verifier agent with: "Manifest: /tmp/manifest-{timestamp}.md | Log: /tmp/define-discovery-{timestamp}.md"

--- a/dist/codex/skills/do/SKILL.md
+++ b/dist/codex/skills/do/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: do
-description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Use when executing a manifest, running a plan, implementing a defined task.'
+description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Optional --mode efficient|balanced|thorough controls verification intensity (default: thorough). Only pass --mode when the user explicitly requests a different mode. Use when executing a manifest, running a plan, implementing a defined task.'
 ---
 
 # /do - Manifest Executor
@@ -13,9 +13,17 @@ Execute a Manifest: satisfy all Deliverables' Acceptance Criteria while followin
 
 ## Input
 
-`$ARGUMENTS` = manifest file path (REQUIRED), optionally with execution log path
+`$ARGUMENTS` = manifest file path (REQUIRED), optionally with execution log path and `--mode <level>`
 
-If no arguments: Output error "Usage: /do <manifest-file-path> [log-file-path]"
+If no arguments: Output error "Usage: /do <manifest-file-path> [log-file-path] [--mode efficient|balanced|thorough]"
+
+## Execution Mode
+
+Resolve mode from (highest precedence first): `--mode` argument → manifest `mode:` field → default `thorough`.
+
+Invalid mode value → error and halt: "Invalid mode '<value>'. Valid modes: efficient | balanced | thorough"
+
+If mode is not `thorough`: read `references/BUDGET_MODES.md` for routing rules, escalation logic, and parallelism overrides. Follow those rules for the remainder of this /do run.
 
 ## Existing Execution Log
 
@@ -35,9 +43,11 @@ If input includes a log file path (iteration on previous work): **treat it as so
 
 **Log after every action** - Write to execution log immediately after each AC attempt. No exceptions. This is disaster recovery—if context is lost, the log is the only record of what happened.
 
-**Must invoke the `verify` skill** - Can't declare done without verification. Invoke the `verify` skill with the manifest and log paths.
+**Must invoke the `verify` skill** - Can't declare done without verification. Invoke the `verify` skill with the manifest, log paths, and the resolved mode: `/verify <manifest> <log> --mode <level>`.
 
-**Escalation boundary** - Escalate when: (1) ACs can't be met as written (contract broken), (2) user requests a pause mid-workflow, or (3) you discover an AC or invariant should be amended (use "Proposed Amendment" escalation type). If ACs remain achievable as written and no user interrupt, continue autonomously. Approach pivots don't require escalation — log adjustments with rationale and continue.
+**Escalation boundary** - Escalate when: (1) ACs can't be met as written (contract broken), (2) user requests a pause mid-workflow, (3) you discover an AC or invariant should be amended (use "Proposed Amendment" escalation type), or (4) mode-specific fix-verify loop limit is reached (see `references/BUDGET_MODES.md`). If ACs remain achievable as written and no user interrupt, continue autonomously. Approach pivots don't require escalation — log adjustments with rationale and continue.
+
+**Mode-aware loop tracking** - Track fix-verify iteration count and escalation count in the execution log. When mode limits are reached, follow the escalation rules in `references/BUDGET_MODES.md`. In efficient mode, also track total escalations and suggest mode switch after 3.
 
 **Stop requires escalation** - During `do`, you cannot stop without either invoking `verify` and reaching `done`, or invoking the `escalate` skill. If you need to pause (user requested, waiting on external action), use the `escalate` skill with "User-Requested Pause" format. Short outputs like "Done." or "Waiting." will be blocked.
 

--- a/dist/codex/skills/do/references/BUDGET_MODES.md
+++ b/dist/codex/skills/do/references/BUDGET_MODES.md
@@ -1,0 +1,42 @@
+# Execution Modes
+
+Execution modes control verification intensity across the manifest-dev workflow (/define, /do, /verify). The mode affects subagent model selection, quality gate inclusion, parallelism, fix-verify loop limits, and manifest validation depth. It does NOT affect what gets built — only how thoroughly the output is verified.
+
+## Mode Routing Table
+
+| Dimension | efficient | balanced | thorough (default) |
+|-----------|-----------|----------|--------------------|
+| Criteria-checker model | inherit | inherit | inherit |
+| Quality gate reviewers | SKIPPED | inherit | inherit |
+| Verification parallelism | Sequential (one at a time) | Batched (max 4 concurrent) | All at once (single message) |
+| Fix-verify loops | Max 1 | Max 2 | Unlimited |
+| /define manifest-verifier | SKIPPED | Runs once (no repeat loop) | Runs (with repeat loop) |
+| Escalation | Auto-escalate after 2 failures per criterion; cap 3 total | Escalate after loop limit hit | None |
+
+**Why these levels exist**: thorough preserves the current quality bar (default). balanced saves quota by limiting parallelism and verification cycles while keeping full model capability. efficient maximizes savings by using a lighter verification pass and skipping reviewer agents — accept this only when iteration speed matters more than verification depth.
+
+## Escalation Rules
+
+**Efficient mode**: When a criterion fails twice, auto-escalate that criterion's verifier to use more thorough checking. Track total escalations — after 3 in a single /do run, suggest to the user: "Efficient mode is escalating frequently. Consider switching to balanced." This prevents runaway costs from repeated escalation.
+
+**Balanced mode**: When the fix-verify loop limit (2) is hit, escalate via the `escalate` skill. The fix isn't converging — human judgment needed.
+
+**Thorough mode**: No escalation mechanism. Unlimited loops, full model capability.
+
+## Verification Parallelism
+
+These override the `verify` skill's default "launch all verifiers in a single message" rule:
+
+- **efficient**: Launch verifiers one at a time. Minimizes concurrent quota usage.
+- **balanced**: Launch in batches of max 4 concurrent verifiers. When any batch completes, launch the next batch.
+- **thorough**: Launch all verifiers in a single message (current default behavior).
+
+## Override Precedence
+
+Three rules govern how mode interacts with other settings:
+
+1. **Criterion-level model wins**: When a manifest criterion specifies `model:` in its verify block, that overrides the mode's model routing. Mode sets defaults; criterion-level `model:` is explicit intent.
+
+2. **Explicit model overrides skip**: In efficient mode, quality gate reviewers are skipped. But if a criterion explicitly sets `model:` (e.g., `model: specific-model`), it runs even when efficient mode would otherwise skip it. The explicit model signals the user deliberately wants this verification.
+
+3. **Global Invariants always run**: "Reviewers SKIPPED" in efficient mode applies only to deliverable-level quality gate reviewer agents (code-bugs-reviewer, type-safety-reviewer, etc.). Global Invariant (INV-G*) verification agents always run regardless of mode — they are constitutional constraints.

--- a/dist/codex/skills/verify/SKILL.md
+++ b/dist/codex/skills/verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify
-description: 'Manifest verification runner. Spawns parallel verifiers for Global Invariants and Acceptance Criteria. Called by /do, not directly by users.'
+description: 'Manifest verification runner. Spawns parallel verifiers for Global Invariants and Acceptance Criteria. Optional --mode efficient|balanced|thorough controls parallelism and model routing (default: thorough). Called by /do, not directly by users.'
 user-invocable: false
 ---
 
@@ -10,9 +10,11 @@ Orchestrate verification of all criteria from a Manifest by spawning parallel ve
 
 **User request**: $ARGUMENTS
 
-Format: `<manifest-file-path> <execution-log-path>`
+Format: `<manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough]`
 
-If paths missing: Return error "Usage: /verify <manifest-path> <log-path>"
+If paths missing: Return error "Usage: /verify <manifest-path> <log-path> [--mode efficient|balanced|thorough]"
+
+Mode defaults to `thorough` if not provided.
 
 ## Principles
 
@@ -20,7 +22,7 @@ If paths missing: Return error "Usage: /verify <manifest-path> <log-path>"
 |-----------|------|
 | **Orchestrate, don't verify** | Spawn agents to verify. You coordinate results, never run checks yourself. |
 | **ALL criteria, no exceptions** | Every INV-G* and AC-*.* criterion MUST be verified. Skipping any criterion is a critical failure. |
-| **Maximize parallelism** | Launch all verifiers in a SINGLE message with multiple Task tool calls. Never launch one at a time. |
+| **Maximize parallelism** | Launch all verifiers in a SINGLE message with multiple Task tool calls. Never launch one at a time. **Overridden by mode** — see Mode-Aware Verification below. |
 | **Globals are critical** | Global Invariant failures mean task failure. Highlight prominently. |
 | **Actionable feedback** | Pass through file:line, expected vs actual, fix hints. |
 
@@ -50,10 +52,22 @@ Note: PG-* items guide HOW to work. Followed during execution by the `do` skill,
 
 If a verification agent crashes, times out, or returns unusable output, treat the criterion as FAIL with a note that verification itself failed (not the criterion). Include the error in the failure details so /do can distinguish "criterion didn't pass" from "couldn't check."
 
+## Mode-Aware Verification
+
+When `--mode` is not `thorough`, these rules override default behavior:
+
+| Mode | Parallelism | Criteria-checker model | Quality gate reviewers |
+|------|-------------|----------------------|----------------------|
+| efficient | Sequential (one at a time) | inherit | SKIPPED for deliverable-level ACs |
+| balanced | Batched (max 4 concurrent) | inherit | inherit |
+| thorough | All at once (default) | inherit | inherit |
+
+**Efficient mode skipping**: Skip reviewer subagent verification (code-bugs-reviewer, type-safety-reviewer, etc.) for deliverable-level ACs. Still run: all bash/codebase checks, all INV-G* verification (regardless of method), and any AC with an explicit `model:` in its verify block.
+
 ## Never Do
 
-- Skip criteria (even "obvious" ones)
-- Launch verifiers sequentially across multiple messages
+- Skip criteria (even "obvious" ones) — unless mode explicitly allows (efficient mode skips deliverable-level reviewer subagents)
+- Launch verifiers sequentially across multiple messages — unless mode requires it (efficient = sequential, balanced = batched)
 - Verify criteria yourself instead of spawning agents
 
 ## Outcome Handling

--- a/dist/gemini/README.md
+++ b/dist/gemini/README.md
@@ -143,6 +143,20 @@ Tools converted from Claude Code names to Gemini CLI equivalents:
 | Skill | `activate_skill` | Agent-only |
 | TaskCreate/Update/Get/List | `write_todos` | Single tool for all todo ops |
 
+## Execution Modes
+
+Control verification intensity with `--mode`:
+
+| Mode | Verification | Parallelism | Best For |
+|------|-------------|-------------|----------|
+| **thorough** (default) | Full reviewer agents, unlimited fix loops | All at once | Production-quality work |
+| **balanced** | Full model capability, capped loops | Batched (max 4) | Standard development |
+| **efficient** | Skips reviewer subagents, lighter checks | Sequential | Quick iterations, low-risk changes |
+
+Usage: `/do <manifest> [log] --mode balanced`
+
+Mode can also be set in the manifest's `mode:` field during `/define`. The `--mode` flag on `/do` takes precedence.
+
 ## Workflow
 
 ```

--- a/dist/gemini/skills/define/SKILL.md
+++ b/dist/gemini/skills/define/SKILL.md
@@ -339,6 +339,7 @@ Three categories, each covering **output** or **process**:
 ## 1. Intent & Context
 - **Goal:** [High-level purpose]
 - **Mental Model:** [Key concepts to understand]
+- **Mode:** efficient | balanced | thorough *(optional, default: thorough — controls verification intensity during /do)*
 
 ## 2. Approach (Complex Tasks Only)
 *Initial direction, not rigid plan. Provides enough to start confidently; expect adjustment when reality diverges.*
@@ -417,7 +418,13 @@ Manifests support amendments during execution:
 
 ## Verification Loop
 
-After writing the manifest, invoke the manifest-verifier agent. Pass only the file paths — no summary, framing, or commentary:
+After writing the manifest, check the manifest's `mode:` field and the `/define manifest-verifier` row in `skills/do/references/BUDGET_MODES.md`:
+
+- **efficient**: Skip the manifest-verifier. Proceed directly to Summary for Approval.
+- **balanced**: Run the manifest-verifier **once**. If it returns CONTINUE, present its questions, update the manifest, then proceed to Summary for Approval (no repeat loop).
+- **thorough** (default, or unspecified): Run the manifest-verifier with the full repeat loop until COMPLETE.
+
+When running the verifier, pass only the file paths — no summary, framing, or commentary:
 
 ```
 Invoke the manifest-dev:manifest-verifier agent with: "Manifest: /tmp/manifest-{timestamp}.md | Log: /tmp/define-discovery-{timestamp}.md"

--- a/dist/gemini/skills/do/SKILL.md
+++ b/dist/gemini/skills/do/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: do
-description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Use when executing a manifest, running a plan, implementing a defined task.'
+description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Optional --mode efficient|balanced|thorough controls verification intensity (default: thorough). Only pass --mode when the user explicitly requests a different mode. Use when executing a manifest, running a plan, implementing a defined task.'
 ---
 
 # /do - Manifest Executor
@@ -13,9 +13,17 @@ Execute a Manifest: satisfy all Deliverables' Acceptance Criteria while followin
 
 ## Input
 
-`$ARGUMENTS` = manifest file path (REQUIRED), optionally with execution log path
+`$ARGUMENTS` = manifest file path (REQUIRED), optionally with execution log path and `--mode <level>`
 
-If no arguments: Output error "Usage: /do <manifest-file-path> [log-file-path]"
+If no arguments: Output error "Usage: /do <manifest-file-path> [log-file-path] [--mode efficient|balanced|thorough]"
+
+## Execution Mode
+
+Resolve mode from (highest precedence first): `--mode` argument → manifest `mode:` field → default `thorough`.
+
+Invalid mode value → error and halt: "Invalid mode '<value>'. Valid modes: efficient | balanced | thorough"
+
+If mode is not `thorough`: read `references/BUDGET_MODES.md` for routing rules, escalation logic, and parallelism overrides. Follow those rules for the remainder of this /do run.
 
 ## Existing Execution Log
 
@@ -35,9 +43,11 @@ If input includes a log file path (iteration on previous work): **treat it as so
 
 **Log after every action** - Write to execution log immediately after each AC attempt. No exceptions. This is disaster recovery—if context is lost, the log is the only record of what happened.
 
-**Must invoke the `verify` skill** - Can't declare done without verification. Invoke the `verify` skill with the manifest and log paths.
+**Must invoke the `verify` skill** - Can't declare done without verification. Invoke the `verify` skill with the manifest, log paths, and the resolved mode: `/verify <manifest> <log> --mode <level>`.
 
-**Escalation boundary** - Escalate when: (1) ACs can't be met as written (contract broken), (2) user requests a pause mid-workflow, or (3) you discover an AC or invariant should be amended (use "Proposed Amendment" escalation type). If ACs remain achievable as written and no user interrupt, continue autonomously. Approach pivots don't require escalation — log adjustments with rationale and continue.
+**Escalation boundary** - Escalate when: (1) ACs can't be met as written (contract broken), (2) user requests a pause mid-workflow, (3) you discover an AC or invariant should be amended (use "Proposed Amendment" escalation type), or (4) mode-specific fix-verify loop limit is reached (see `references/BUDGET_MODES.md`). If ACs remain achievable as written and no user interrupt, continue autonomously. Approach pivots don't require escalation — log adjustments with rationale and continue.
+
+**Mode-aware loop tracking** - Track fix-verify iteration count and escalation count in the execution log. When mode limits are reached, follow the escalation rules in `references/BUDGET_MODES.md`. In efficient mode, also track total escalations and suggest mode switch after 3.
 
 **Stop requires escalation** - During `do`, you cannot stop without either invoking `verify` and reaching `done`, or invoking the `escalate` skill. If you need to pause (user requested, waiting on external action), use the `escalate` skill with "User-Requested Pause" format. Short outputs like "Done." or "Waiting." will be blocked.
 

--- a/dist/gemini/skills/do/references/BUDGET_MODES.md
+++ b/dist/gemini/skills/do/references/BUDGET_MODES.md
@@ -1,0 +1,42 @@
+# Execution Modes
+
+Execution modes control verification intensity across the manifest-dev workflow (/define, /do, /verify). The mode affects subagent model selection, quality gate inclusion, parallelism, fix-verify loop limits, and manifest validation depth. It does NOT affect what gets built — only how thoroughly the output is verified.
+
+## Mode Routing Table
+
+| Dimension | efficient | balanced | thorough (default) |
+|-----------|-----------|----------|--------------------|
+| Criteria-checker model | inherit | inherit | inherit |
+| Quality gate reviewers | SKIPPED | inherit | inherit |
+| Verification parallelism | Sequential (one at a time) | Batched (max 4 concurrent) | All at once (single message) |
+| Fix-verify loops | Max 1 | Max 2 | Unlimited |
+| /define manifest-verifier | SKIPPED | Runs once (no repeat loop) | Runs (with repeat loop) |
+| Escalation | Auto-escalate after 2 failures per criterion; cap 3 total | Escalate after loop limit hit | None |
+
+**Why these levels exist**: thorough preserves the current quality bar (default). balanced saves quota by limiting parallelism and verification cycles while keeping full model capability. efficient maximizes savings by using a lighter verification pass and skipping reviewer agents — accept this only when iteration speed matters more than verification depth.
+
+## Escalation Rules
+
+**Efficient mode**: When a criterion fails twice, auto-escalate that criterion's verifier to use more thorough checking. Track total escalations — after 3 in a single /do run, suggest to the user: "Efficient mode is escalating frequently. Consider switching to balanced." This prevents runaway costs from repeated escalation.
+
+**Balanced mode**: When the fix-verify loop limit (2) is hit, escalate via the `escalate` skill. The fix isn't converging — human judgment needed.
+
+**Thorough mode**: No escalation mechanism. Unlimited loops, full model capability.
+
+## Verification Parallelism
+
+These override the `verify` skill's default "launch all verifiers in a single message" rule:
+
+- **efficient**: Launch verifiers one at a time. Minimizes concurrent quota usage.
+- **balanced**: Launch in batches of max 4 concurrent verifiers. When any batch completes, launch the next batch.
+- **thorough**: Launch all verifiers in a single message (current default behavior).
+
+## Override Precedence
+
+Three rules govern how mode interacts with other settings:
+
+1. **Criterion-level model wins**: When a manifest criterion specifies `model:` in its verify block, that overrides the mode's model routing. Mode sets defaults; criterion-level `model:` is explicit intent.
+
+2. **Explicit model overrides skip**: In efficient mode, quality gate reviewers are skipped. But if a criterion explicitly sets `model:` (e.g., `model: specific-model`), it runs even when efficient mode would otherwise skip it. The explicit model signals the user deliberately wants this verification.
+
+3. **Global Invariants always run**: "Reviewers SKIPPED" in efficient mode applies only to deliverable-level quality gate reviewer agents (code-bugs-reviewer, type-safety-reviewer, etc.). Global Invariant (INV-G*) verification agents always run regardless of mode — they are constitutional constraints.

--- a/dist/gemini/skills/verify/SKILL.md
+++ b/dist/gemini/skills/verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify
-description: 'Manifest verification runner. Spawns parallel verifiers for Global Invariants and Acceptance Criteria. Called by /do, not directly by users.'
+description: 'Manifest verification runner. Spawns parallel verifiers for Global Invariants and Acceptance Criteria. Optional --mode efficient|balanced|thorough controls parallelism and model routing (default: thorough). Called by /do, not directly by users.'
 user-invocable: false
 ---
 
@@ -10,9 +10,11 @@ Orchestrate verification of all criteria from a Manifest by spawning parallel ve
 
 **User request**: $ARGUMENTS
 
-Format: `<manifest-file-path> <execution-log-path>`
+Format: `<manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough]`
 
-If paths missing: Return error "Usage: /verify <manifest-path> <log-path>"
+If paths missing: Return error "Usage: /verify <manifest-path> <log-path> [--mode efficient|balanced|thorough]"
+
+Mode defaults to `thorough` if not provided.
 
 ## Principles
 
@@ -20,7 +22,7 @@ If paths missing: Return error "Usage: /verify <manifest-path> <log-path>"
 |-----------|------|
 | **Orchestrate, don't verify** | Spawn agents to verify. You coordinate results, never run checks yourself. |
 | **ALL criteria, no exceptions** | Every INV-G* and AC-*.* criterion MUST be verified. Skipping any criterion is a critical failure. |
-| **Maximize parallelism** | Launch all verifiers in a SINGLE message with multiple Task tool calls. Never launch one at a time. |
+| **Maximize parallelism** | Launch all verifiers in a SINGLE message with multiple Task tool calls. Never launch one at a time. **Overridden by mode** — see Mode-Aware Verification below. |
 | **Globals are critical** | Global Invariant failures mean task failure. Highlight prominently. |
 | **Actionable feedback** | Pass through file:line, expected vs actual, fix hints. |
 
@@ -50,10 +52,22 @@ Note: PG-* items guide HOW to work. Followed during execution by the `do` skill,
 
 If a verification agent crashes, times out, or returns unusable output, treat the criterion as FAIL with a note that verification itself failed (not the criterion). Include the error in the failure details so /do can distinguish "criterion didn't pass" from "couldn't check."
 
+## Mode-Aware Verification
+
+When `--mode` is not `thorough`, these rules override default behavior:
+
+| Mode | Parallelism | Criteria-checker model | Quality gate reviewers |
+|------|-------------|----------------------|----------------------|
+| efficient | Sequential (one at a time) | inherit | SKIPPED for deliverable-level ACs |
+| balanced | Batched (max 4 concurrent) | inherit | inherit |
+| thorough | All at once (default) | inherit | inherit |
+
+**Efficient mode skipping**: Skip reviewer subagent verification (code-bugs-reviewer, type-safety-reviewer, etc.) for deliverable-level ACs. Still run: all bash/codebase checks, all INV-G* verification (regardless of method), and any AC with an explicit `model:` in its verify block.
+
 ## Never Do
 
-- Skip criteria (even "obvious" ones)
-- Launch verifiers sequentially across multiple messages
+- Skip criteria (even "obvious" ones) — unless mode explicitly allows (efficient mode skips deliverable-level reviewer subagents)
+- Launch verifiers sequentially across multiple messages — unless mode requires it (efficient = sequential, balanced = batched)
 - Verify criteria yourself instead of spawning agents
 
 ## Outcome Handling

--- a/dist/opencode/README.md
+++ b/dist/opencode/README.md
@@ -81,6 +81,20 @@ cp /tmp/manifest-dev/dist/opencode/plugins/HOOK_SPEC.md .opencode/plugins/manife
 | Web research | WebFetch + WebSearch | `webfetch` + `websearch` | WebSearch requires Exa AI key in OpenCode |
 | Session storage | JSONL transcript files | SQLite database | In-memory state tracking replaces transcript parsing |
 
+## Execution Modes
+
+Control verification intensity with `--mode`:
+
+| Mode | Verification | Parallelism | Best For |
+|------|-------------|-------------|----------|
+| **thorough** (default) | Full reviewer agents, unlimited fix loops | All at once | Production-quality work |
+| **balanced** | Full model capability, capped loops | Batched (max 4) | Standard development |
+| **efficient** | Skips reviewer subagents, lighter checks | Sequential | Quick iterations, low-risk changes |
+
+Usage: `/do <manifest> [log] --mode balanced`
+
+Mode can also be set in the manifest's `mode:` field during `/define`. The `--mode` flag on `/do` takes precedence.
+
 ## Known Limitations
 
 1. **Tool blocking uses throw, not abort.** To block a tool call in `tool.execute.before`, **throw new Error("reason")**. The error message becomes the tool result seen by the LLM. The `args.abort` pattern documented elsewhere is incorrect. Confirmed from source code and issue #5894.

--- a/dist/opencode/skills/define/SKILL.md
+++ b/dist/opencode/skills/define/SKILL.md
@@ -339,6 +339,7 @@ Three categories, each covering **output** or **process**:
 ## 1. Intent & Context
 - **Goal:** [High-level purpose]
 - **Mental Model:** [Key concepts to understand]
+- **Mode:** efficient | balanced | thorough *(optional, default: thorough — controls verification intensity during /do)*
 
 ## 2. Approach (Complex Tasks Only)
 *Initial direction, not rigid plan. Provides enough to start confidently; expect adjustment when reality diverges.*
@@ -417,7 +418,13 @@ Manifests support amendments during execution:
 
 ## Verification Loop
 
-After writing the manifest, invoke the manifest-verifier agent. Pass only the file paths — no summary, framing, or commentary:
+After writing the manifest, check the manifest's `mode:` field and the `/define manifest-verifier` row in `skills/do/references/BUDGET_MODES.md`:
+
+- **efficient**: Skip the manifest-verifier. Proceed directly to Summary for Approval.
+- **balanced**: Run the manifest-verifier **once**. If it returns CONTINUE, present its questions, update the manifest, then proceed to Summary for Approval (no repeat loop).
+- **thorough** (default, or unspecified): Run the manifest-verifier with the full repeat loop until COMPLETE.
+
+When running the verifier, pass only the file paths — no summary, framing, or commentary:
 
 ```
 Invoke the manifest-dev:manifest-verifier agent with: "Manifest: /tmp/manifest-{timestamp}.md | Log: /tmp/define-discovery-{timestamp}.md"

--- a/dist/opencode/skills/do/SKILL.md
+++ b/dist/opencode/skills/do/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: do
-description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Use when executing a manifest, running a plan, implementing a defined task.'
+description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Optional --mode efficient|balanced|thorough controls verification intensity (default: thorough). Only pass --mode when the user explicitly requests a different mode. Use when executing a manifest, running a plan, implementing a defined task.'
 ---
 
 # /do - Manifest Executor
@@ -13,9 +13,17 @@ Execute a Manifest: satisfy all Deliverables' Acceptance Criteria while followin
 
 ## Input
 
-`$ARGUMENTS` = manifest file path (REQUIRED), optionally with execution log path
+`$ARGUMENTS` = manifest file path (REQUIRED), optionally with execution log path and `--mode <level>`
 
-If no arguments: Output error "Usage: /do <manifest-file-path> [log-file-path]"
+If no arguments: Output error "Usage: /do <manifest-file-path> [log-file-path] [--mode efficient|balanced|thorough]"
+
+## Execution Mode
+
+Resolve mode from (highest precedence first): `--mode` argument → manifest `mode:` field → default `thorough`.
+
+Invalid mode value → error and halt: "Invalid mode '<value>'. Valid modes: efficient | balanced | thorough"
+
+If mode is not `thorough`: read `references/BUDGET_MODES.md` for routing rules, escalation logic, and parallelism overrides. Follow those rules for the remainder of this /do run.
 
 ## Existing Execution Log
 
@@ -35,9 +43,11 @@ If input includes a log file path (iteration on previous work): **treat it as so
 
 **Log after every action** - Write to execution log immediately after each AC attempt. No exceptions. This is disaster recovery—if context is lost, the log is the only record of what happened.
 
-**Must invoke the `verify` skill** - Can't declare done without verification. Invoke the `verify` skill with the manifest and log paths.
+**Must invoke the `verify` skill** - Can't declare done without verification. Invoke the `verify` skill with the manifest, log paths, and the resolved mode: `/verify <manifest> <log> --mode <level>`.
 
-**Escalation boundary** - Escalate when: (1) ACs can't be met as written (contract broken), (2) user requests a pause mid-workflow, or (3) you discover an AC or invariant should be amended (use "Proposed Amendment" escalation type). If ACs remain achievable as written and no user interrupt, continue autonomously. Approach pivots don't require escalation — log adjustments with rationale and continue.
+**Escalation boundary** - Escalate when: (1) ACs can't be met as written (contract broken), (2) user requests a pause mid-workflow, (3) you discover an AC or invariant should be amended (use "Proposed Amendment" escalation type), or (4) mode-specific fix-verify loop limit is reached (see `references/BUDGET_MODES.md`). If ACs remain achievable as written and no user interrupt, continue autonomously. Approach pivots don't require escalation — log adjustments with rationale and continue.
+
+**Mode-aware loop tracking** - Track fix-verify iteration count and escalation count in the execution log. When mode limits are reached, follow the escalation rules in `references/BUDGET_MODES.md`. In efficient mode, also track total escalations and suggest mode switch after 3.
 
 **Stop requires escalation** - During `do`, you cannot stop without either invoking `verify` and reaching `done`, or invoking the `escalate` skill. If you need to pause (user requested, waiting on external action), use the `escalate` skill with "User-Requested Pause" format. Short outputs like "Done." or "Waiting." will be blocked.
 

--- a/dist/opencode/skills/do/references/BUDGET_MODES.md
+++ b/dist/opencode/skills/do/references/BUDGET_MODES.md
@@ -1,0 +1,42 @@
+# Execution Modes
+
+Execution modes control verification intensity across the manifest-dev workflow (/define, /do, /verify). The mode affects subagent model selection, quality gate inclusion, parallelism, fix-verify loop limits, and manifest validation depth. It does NOT affect what gets built — only how thoroughly the output is verified.
+
+## Mode Routing Table
+
+| Dimension | efficient | balanced | thorough (default) |
+|-----------|-----------|----------|--------------------|
+| Criteria-checker model | inherit | inherit | inherit |
+| Quality gate reviewers | SKIPPED | inherit | inherit |
+| Verification parallelism | Sequential (one at a time) | Batched (max 4 concurrent) | All at once (single message) |
+| Fix-verify loops | Max 1 | Max 2 | Unlimited |
+| /define manifest-verifier | SKIPPED | Runs once (no repeat loop) | Runs (with repeat loop) |
+| Escalation | Auto-escalate after 2 failures per criterion; cap 3 total | Escalate after loop limit hit | None |
+
+**Why these levels exist**: thorough preserves the current quality bar (default). balanced saves quota by limiting parallelism and verification cycles while keeping full model capability. efficient maximizes savings by using a lighter verification pass and skipping reviewer agents — accept this only when iteration speed matters more than verification depth.
+
+## Escalation Rules
+
+**Efficient mode**: When a criterion fails twice, auto-escalate that criterion's verifier to use more thorough checking. Track total escalations — after 3 in a single /do run, suggest to the user: "Efficient mode is escalating frequently. Consider switching to balanced." This prevents runaway costs from repeated escalation.
+
+**Balanced mode**: When the fix-verify loop limit (2) is hit, escalate via the `escalate` skill. The fix isn't converging — human judgment needed.
+
+**Thorough mode**: No escalation mechanism. Unlimited loops, full model capability.
+
+## Verification Parallelism
+
+These override the `verify` skill's default "launch all verifiers in a single message" rule:
+
+- **efficient**: Launch verifiers one at a time. Minimizes concurrent quota usage.
+- **balanced**: Launch in batches of max 4 concurrent verifiers. When any batch completes, launch the next batch.
+- **thorough**: Launch all verifiers in a single message (current default behavior).
+
+## Override Precedence
+
+Three rules govern how mode interacts with other settings:
+
+1. **Criterion-level model wins**: When a manifest criterion specifies `model:` in its verify block, that overrides the mode's model routing. Mode sets defaults; criterion-level `model:` is explicit intent.
+
+2. **Explicit model overrides skip**: In efficient mode, quality gate reviewers are skipped. But if a criterion explicitly sets `model:` (e.g., `model: specific-model`), it runs even when efficient mode would otherwise skip it. The explicit model signals the user deliberately wants this verification.
+
+3. **Global Invariants always run**: "Reviewers SKIPPED" in efficient mode applies only to deliverable-level quality gate reviewer agents (code-bugs-reviewer, type-safety-reviewer, etc.). Global Invariant (INV-G*) verification agents always run regardless of mode — they are constitutional constraints.

--- a/dist/opencode/skills/verify/SKILL.md
+++ b/dist/opencode/skills/verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify
-description: 'Manifest verification runner. Spawns parallel verifiers for Global Invariants and Acceptance Criteria. Called by /do, not directly by users.'
+description: 'Manifest verification runner. Spawns parallel verifiers for Global Invariants and Acceptance Criteria. Optional --mode efficient|balanced|thorough controls parallelism and model routing (default: thorough). Called by /do, not directly by users.'
 user-invocable: false
 ---
 
@@ -10,9 +10,11 @@ Orchestrate verification of all criteria from a Manifest by spawning parallel ve
 
 **User request**: $ARGUMENTS
 
-Format: `<manifest-file-path> <execution-log-path>`
+Format: `<manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough]`
 
-If paths missing: Return error "Usage: /verify <manifest-path> <log-path>"
+If paths missing: Return error "Usage: /verify <manifest-path> <log-path> [--mode efficient|balanced|thorough]"
+
+Mode defaults to `thorough` if not provided.
 
 ## Principles
 
@@ -20,7 +22,7 @@ If paths missing: Return error "Usage: /verify <manifest-path> <log-path>"
 |-----------|------|
 | **Orchestrate, don't verify** | Spawn agents to verify. You coordinate results, never run checks yourself. |
 | **ALL criteria, no exceptions** | Every INV-G* and AC-*.* criterion MUST be verified. Skipping any criterion is a critical failure. |
-| **Maximize parallelism** | Launch all verifiers in a SINGLE message with multiple Task tool calls. Never launch one at a time. |
+| **Maximize parallelism** | Launch all verifiers in a SINGLE message with multiple Task tool calls. Never launch one at a time. **Overridden by mode** — see Mode-Aware Verification below. |
 | **Globals are critical** | Global Invariant failures mean task failure. Highlight prominently. |
 | **Actionable feedback** | Pass through file:line, expected vs actual, fix hints. |
 
@@ -50,10 +52,22 @@ Note: PG-* items guide HOW to work. Followed during execution by the `do` skill,
 
 If a verification agent crashes, times out, or returns unusable output, treat the criterion as FAIL with a note that verification itself failed (not the criterion). Include the error in the failure details so /do can distinguish "criterion didn't pass" from "couldn't check."
 
+## Mode-Aware Verification
+
+When `--mode` is not `thorough`, these rules override default behavior:
+
+| Mode | Parallelism | Criteria-checker model | Quality gate reviewers |
+|------|-------------|----------------------|----------------------|
+| efficient | Sequential (one at a time) | inherit | SKIPPED for deliverable-level ACs |
+| balanced | Batched (max 4 concurrent) | inherit | inherit |
+| thorough | All at once (default) | inherit | inherit |
+
+**Efficient mode skipping**: Skip reviewer subagent verification (code-bugs-reviewer, type-safety-reviewer, etc.) for deliverable-level ACs. Still run: all bash/codebase checks, all INV-G* verification (regardless of method), and any AC with an explicit `model:` in its verify block.
+
 ## Never Do
 
-- Skip criteria (even "obvious" ones)
-- Launch verifiers sequentially across multiple messages
+- Skip criteria (even "obvious" ones) — unless mode explicitly allows (efficient mode skips deliverable-level reviewer subagents)
+- Launch verifiers sequentially across multiple messages — unless mode requires it (efficient = sequential, balanced = batched)
 - Verify criteria yourself instead of spawning agents
 
 ## Outcome Handling


### PR DESCRIPTION
Add budget-aware execution modes to /do, /verify, and /define workflows. Modes control verification intensity — subagent model routing, quality gate inclusion, parallelism limits, and fix-verify loop caps — without affecting what gets built.

- New BUDGET_MODES.md reference file with routing table and escalation rules
- /do parses --mode arg or manifest mode: field (default: thorough)
- /verify adjusts parallelism and model routing per mode
- /define skips manifest-verifier in efficient, runs once in balanced
- sync-tools converts Claude model names to inherit for other CLIs
- dist/ regenerated for Gemini, OpenCode, and Codex CLIs

Closes #38