### PR TITLE
feat: add --interview and --mode flag forwarding to slack-collab skill

### DIFF
--- a/claude-plugins/manifest-dev-collab/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev-collab/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev-collab",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Slack and GitHub collaborative define/do workflow via Agent Teams. Lead orchestrator spawns specialized teammates (slack-coordinator, github-coordinator, define-worker, executor) that coordinate via mailbox messaging for stakeholder Q&A, manifest review, GitHub PR review monitoring, and QA sign-off.",
   "keywords": [
     "slack",

--- a/claude-plugins/manifest-dev-collab/README.md
+++ b/claude-plugins/manifest-dev-collab/README.md
@@ -33,6 +33,16 @@ The lead orchestrates phase transitions, manages state, acts as the subagent bri
 /slack-collab add rate limiting to the API
 ```
 
+**Optional flags** (forwarded to downstream skills):
+- `--interview <level>` — forwarded to `/define` (controls interview depth: `minimal | autonomous | thorough`)
+- `--mode <level>` — forwarded to `/do` (controls verification intensity: `efficient | balanced | thorough`)
+
+```
+/slack-collab --interview minimal --mode efficient add rate limiting to the API
+```
+
+Flags are stored in the state file and persist across `--resume`. Flags provided alongside `--resume` override stored values.
+
 The skill runs through 7 phases:
 
 1. **Preflight** — Lead asks for existing Slack channel ID + stakeholders (names, handles, roles), then creates the team

--- a/claude-plugins/manifest-dev-collab/agents/define-worker.md
+++ b/claude-plugins/manifest-dev-collab/agents/define-worker.md
@@ -15,7 +15,7 @@ You are the **define-worker** — responsible for running `/define` to build a m
 
 When the lead messages you with a task and TEAM_CONTEXT:
 
-1. Invoke the `/define` skill with the full task description and TEAM_CONTEXT block as arguments.
+1. Invoke the `/define` skill with the full task description and TEAM_CONTEXT block as arguments. Include any flags from the lead's message (e.g., `--interview <level>`) — they are forwarded to `/define` as-is.
 2. `/define` will detect the `TEAM_CONTEXT:` block and switch to team collaboration mode — messaging the lead for stakeholder input instead of using AskUserQuestion.
 3. When `/define` needs the manifest-verifier, it will message the lead with a subagent request. You may receive verification results in two ways:
    - **Direct**: A subagent sends you results via SendMessage.

--- a/claude-plugins/manifest-dev-collab/agents/executor.md
+++ b/claude-plugins/manifest-dev-collab/agents/executor.md
@@ -15,7 +15,7 @@ You are the **executor** — responsible for implementing the manifest, creating
 
 When the lead messages you with a manifest path and TEAM_CONTEXT:
 
-1. **You MUST invoke the `/do` skill using the Skill tool** — `Skill("manifest-dev:do", "<manifest-path> TEAM_CONTEXT:...")`. Do NOT implement the manifest directly. Do NOT write files, run verification checks, or make changes yourself. `/do` handles everything: implementation, execution logging, and verification.
+1. **You MUST invoke the `/do` skill** with the manifest path, any flags from the lead's message (e.g., `--mode <level>`), and the TEAM_CONTEXT block. Do NOT implement the manifest directly. Do NOT write files, run verification checks, or make changes yourself. `/do` handles everything: implementation, execution logging, and verification.
    - **Why**: /do creates an execution log (disaster recovery if context is lost), enforces stop_do_hook (prevents premature completion), and runs /verify with proper criteria-checker subagents. Bypassing /do means none of these protections exist.
 2. `/do` will detect the `TEAM_CONTEXT:` block and switch to team collaboration mode — messaging the lead for escalations. Verification delegates to the lead: /verify packages criteria and returns them to /do, which sends a VERIFICATION_REQUEST to the lead. The lead spawns verification teammates. You receive a VERIFICATION_RESULT message with pass/fail results.
 3. Message the lead when complete.

--- a/claude-plugins/manifest-dev-collab/skills/slack-collab/SKILL.md
+++ b/claude-plugins/manifest-dev-collab/skills/slack-collab/SKILL.md
@@ -7,9 +7,14 @@ description: 'Orchestrate team collaboration on define/do workflows through Slac
 
 Orchestrate a full define → do → PR → review → QA → done workflow with your team through Slack. You are the **lead** — spawn teammates and coordinate phases.
 
-`$ARGUMENTS` = task description (what to build/change), or `--resume <state-file-path>` to resume.
+`$ARGUMENTS` = task description (what to build/change), with optional flags:
+- `--resume <state-file-path>` — resume an interrupted workflow
+- `--interview <level>` — forwarded to `/define` (controls interview depth: `minimal | autonomous | thorough`)
+- `--mode <level>` — forwarded to `/do` (controls verification intensity: `efficient | balanced | thorough`)
 
-If `$ARGUMENTS` is empty, ask what they want to build or change.
+`--resume` must appear first when present (existing behavior). `--interview` and `--mode` can appear anywhere in the remaining arguments. Flags persist in state and reach the appropriate teammate (see Phase 1, Phase 3). Flag values are forwarded verbatim — `/define` and `/do` validate them.
+
+If `$ARGUMENTS` is empty (no task description and no `--resume`), ask what they want to build or change.
 
 ## Prerequisites
 
@@ -148,6 +153,10 @@ Re-read the state file before each phase transition to guard against context com
     "ci_status": "unknown",
     "pr_ready": false
   },
+  "flags": {
+    "interview": null,
+    "mode": null
+  },
   "phase_state": {
     "waiting_for": [],
     "active_threads": {},
@@ -170,9 +179,10 @@ Delivery: SendMessage to <worker> | File at <path>
 
 If `$ARGUMENTS` starts with `--resume`:
 1. Read the state file at the provided path.
-2. Re-create the team (slack-coordinator, define-worker, executor) with existing channel/stakeholder context in their spawn prompts.
-3. If resuming from Phase 4 or later and `pr_url` is set, also spawn github-coordinator with the PR URL from the state file.
-4. Continue from the interrupted phase. If `phase_state.waiting_for` is populated, resume polling from where it left off — check for responses that arrived while the process was down.
+2. Restore flags from `state.flags` (default to `{"interview": null, "mode": null}` if the key is missing — older state files may not include it). If `--interview` or `--mode` flags are also provided alongside `--resume`, they override the stored values.
+3. Re-create the team (slack-coordinator, define-worker, executor) with existing channel/stakeholder context in their spawn prompts.
+4. If resuming from Phase 4 or later and `pr_url` is set, also spawn github-coordinator with the PR URL from the state file.
+5. Continue from the interrupted phase. If `phase_state.waiting_for` is populated, resume polling from where it left off — check for responses that arrived while the process was down.
 
 ## Phase Flow
 
@@ -190,11 +200,11 @@ If `$ARGUMENTS` starts with `--resume`:
    - **define-worker**: `subagent_type: "manifest-dev-collab:define-worker"`, `team_name: "<team>"`, `name: "define-worker"`. Omit model (inherits parent). Pass the task description in the prompt.
    - **executor**: `subagent_type: "manifest-dev-collab:executor"`, `team_name: "<team>"`, `name: "executor"`. Omit model (inherits parent). Pass initial context in the prompt.
 4. Message slack-coordinator: "Post a kickoff message to channel [channel_id]: 'Kicking off: [task summary]'. Then post an intro thread tagging all stakeholders. Start your poll loop — report back with thread_ts values and keep polling for stakeholder responses from now on."
-5. When slack-coordinator reports thread info, write state file. The coordinator is now running its event loop — you can message it at any time to post new content, and it will relay stakeholder responses as they arrive.
+5. When slack-coordinator reports thread info, write state file (include parsed `flags`). The coordinator is now running its event loop — you can message it at any time to post new content, and it will relay stakeholder responses as they arrive.
 
 ### Phase 1: Define
 
-1. Message define-worker: "Run /define for: [task description]\n\nTEAM_CONTEXT:\n  lead: <your-name>\n  coordinator: slack-coordinator\n  role: define"
+1. Message define-worker with the task description, TEAM_CONTEXT block, and the `--interview` flag if one was parsed. Example: "Run /define for: [task description] --interview minimal\n\nTEAM_CONTEXT:\n  lead: <your-name>\n  coordinator: slack-coordinator\n  role: define"
 2. When define-worker messages you with Q&A questions, route them to slack-coordinator with expertise context (e.g., "Relevant expertise: backend/security") so the coordinator can create a separate parent message and tag the right stakeholder(s). Relay coordinator's responses back to define-worker.
 3. When define-worker requests a subagent (manifest-verifier), follow the Subagent Bridge Protocol.
 4. When define-worker messages you with the manifest_path, update state file.
@@ -208,7 +218,7 @@ If `$ARGUMENTS` starts with `--resume`:
 
 ### Phase 3: Execute
 
-1. Message executor: "Run /do for manifest at [manifest_path]\n\nTEAM_CONTEXT:\n  lead: <your-name>\n  coordinator: slack-coordinator\n  role: execute"
+1. Message executor with the manifest path, TEAM_CONTEXT block, and the `--mode` flag if one was parsed. Example: "Run /do for manifest at [manifest_path] --mode efficient\n\nTEAM_CONTEXT:\n  lead: <your-name>\n  coordinator: slack-coordinator\n  role: execute"
 2. When executor messages you with escalations, route them to slack-coordinator. Relay responses back.
 3. **Verification relay**: When executor messages you with a VERIFICATION_REQUEST (containing all criteria with IDs, methods, commands/prompts):
    - Spawn one verification teammate per criterion in parallel using the Agent tool. Each teammate verifies its assigned criterion and reports back.


### PR DESCRIPTION
The collab skill now parses --interview and --mode flags from arguments
and forwards them to define-worker (for /define) and executor (for /do).
Flags persist in the state file and can be overridden on --resume.

https://claude.ai/code/session_011RBZKedMrhXyhoKBAuDX1A