### PR TITLE
feat: add --adr flag for Architecture Decision Record export

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,6 +8,7 @@
     "description": "Verification-first manifest workflows for Claude Code"
   },
   "plugins": [
-    { "name": "manifest-dev", "source": "./claude-plugins/manifest-dev" }
+    { "name": "manifest-dev", "source": "./claude-plugins/manifest-dev" },
+    { "name": "manifest-dev-tools", "source": "./claude-plugins/manifest-dev-tools" }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ The Claude Code plugin is the source of truth. Per-CLI distributions under `dist
 | Plugin | Description |
 |--------|-------------|
 | `manifest-dev` | Core manifest workflows: `/define`, `/do`, `/verify`, review agents, workflow hooks. Includes workflow task files for PR review, CI, collaboration, and QA lifecycle support via `--medium`. Mid-execution manifest amendments via `--amend` flag and UserPromptSubmit hook. |
+| `manifest-dev-tools` | Post-processing utilities for manifest workflows. `/adr` synthesizes Architecture Decision Records from session transcripts via multi-agent extraction pipeline. |
 
 ## Plugin Architecture
 

--- a/claude-plugins/README.md
+++ b/claude-plugins/README.md
@@ -15,6 +15,7 @@ Front-load the thinking so AI agents get it right the first time.
 | Plugin | What It Does |
 |--------|--------------|
 | `manifest-dev` | Verification-first manifest workflows with phased verification (fast checks first, e2e/deploy-dependent later) and multi-CLI distribution (Gemini CLI, OpenCode, Codex CLI). Every criterion has explicit verification; execution can't stop without verification passing or escalation. |
+| `manifest-dev-tools` | Post-processing utilities for manifest workflows. `/adr` synthesizes Architecture Decision Records from session transcripts. |
 
 ## Plugin Details
 
@@ -35,6 +36,13 @@ Manifest-driven workflows separating **what to build** (Deliverables) from **rul
 **Hooks** enforce workflow integrity: prevent premature stopping, restore context after compaction, nudge manifest reads before verification, track execution log updates, and detect manifest amendments during `/do`.
 
 **Task guidance** with domain-specific quality gates, risks, and scenarios. Reference material in `tasks/references/research/` provides detailed evidence for `/verify` agents. Collaboration mode instructions in `skills/*/references/COLLABORATION_MODE.md` (progressive disclosure — only loaded when collab is active).
+
+### manifest-dev-tools
+
+Post-processing utilities that operate on the outputs of the manifest workflow.
+
+**Skills:**
+- `/adr` - Synthesize Architecture Decision Records from session transcripts via multi-agent extraction pipeline (architecture, trade-offs, scope/constraints lenses + synthesis gatekeeper). Writes individual MADR files.
 
 ## Contributing
 

--- a/claude-plugins/manifest-dev-tools/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev-tools/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "manifest-dev-tools",
+  "version": "0.1.0",
+  "description": "Post-processing utilities for manifest workflows. ADR synthesis from session transcripts.",
+  "keywords": [
+    "adr",
+    "architecture-decision-records",
+    "post-processing",
+    "manifest"
+  ]
+}

--- a/claude-plugins/manifest-dev-tools/README.md
+++ b/claude-plugins/manifest-dev-tools/README.md
@@ -1,0 +1,19 @@
+# manifest-dev-tools
+
+Post-processing utilities for manifest workflows.
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| `/adr` | Synthesize Architecture Decision Records from session transcripts. Extracts decisions via multi-agent pipeline and writes MADR files. |
+
+## How It Works
+
+These tools operate on the *outputs* of the manifest workflow (`/define` → `/do` → `/done`) — not during it. The session transcript is the richest data source; manifest and logs provide supplementary context.
+
+## Installation
+
+```bash
+/plugin install manifest-dev-tools@manifest-dev-marketplace
+```

--- a/claude-plugins/manifest-dev-tools/skills/adr/SKILL.md
+++ b/claude-plugins/manifest-dev-tools/skills/adr/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: adr
+description: 'Synthesize Architecture Decision Records from session transcripts. Extracts decisions via multi-agent pipeline and writes MADR files to a specified directory. Use after completing a /define or /do session to capture architectural decisions as durable records.'
+user-invocable: true
+---
+
+# /adr - Architecture Decision Record Synthesis
+
+## Goal
+
+Extract ADR-worthy decisions from a completed manifest workflow session and write individual MADR files. Operates as post-processing — runs AFTER the manifest workflow completes, not during it.
+
+## Input
+
+`$ARGUMENTS` = `<manifest-path> <output-dir> --session <transcript-path>`
+
+All three are required:
+- **manifest-path**: Path to the manifest file (primary structured input)
+- **output-dir**: Directory where ADR files will be written (created if needed)
+- **--session \<path\>**: Path to the session transcript JSONL file (primary raw input — `/define` outputs this path at completion)
+
+If any required argument is missing: error and halt with usage:
+```
+Usage: /adr <manifest-path> <output-dir> --session <transcript-path>
+
+Example: /adr /tmp/manifest-1234.md docs/adr/ --session ~/.claude/projects/.../session.jsonl
+```
+
+Optional:
+- Execution log path(s) from `/do` runs — supplementary input for implementation decisions. Pass as additional positional arguments after output-dir.
+
+## Pipeline
+
+### Phase 1: Parallel Extraction
+
+Spawn three extraction agents in parallel, each analyzing the session transcript through a different decision lens:
+
+1. **Architecture Lens** — Identify technology choices, component structure decisions, integration approaches, and pattern selections. Look for: "we should use X", "the architecture is Y", structural decisions with alternatives discussed.
+
+2. **Trade-off Lens** — Identify tensions where competing concerns were weighed. Look for: "A vs B", preference statements with reasoning, rejected approaches with "because", T-* items from the manifest's Approach section that trace back to transcript deliberation.
+
+3. **Scope & Constraints Lens** — Identify deliberate inclusions/exclusions that shape system boundaries, key constraint decisions where alternatives existed. Look for: "out of scope", "we need to include", "the constraint is", INV-G* items from the manifest that arose from deliberation (not just mechanical quality gates).
+
+Each extraction agent receives:
+- The full session transcript (primary source)
+- The manifest file (structured reference)
+- Any execution logs (supplementary)
+
+Each agent outputs a list of candidate decisions with:
+- **Title**: Short decision name
+- **Context**: Why the decision was needed (from transcript)
+- **Decision**: What was chosen
+- **Alternatives**: What else was considered and why not
+- **Consequences**: Positive and negative impacts
+- **Evidence**: Quotes or references from the transcript
+
+### Phase 2: Synthesis & Gatekeeper
+
+A synthesis agent receives all candidates from Phase 1 and:
+
+1. **Deduplicates** — Merge candidates that describe the same decision from different lenses. Prefer the version with richer context and alternatives.
+
+2. **Applies ADR-worthiness criteria** — Read `references/ADR_FORMAT.md` in this skill's directory. Apply the decision test to each candidate: *"Would a new team member joining in 6 months benefit from knowing WHY this was decided this way?"* Remove candidates that fail.
+
+3. **Writes ADR files** — For each surviving candidate, generate a MADR file at `<output-dir>/YYYYMMDD-kebab-title.md` using the template from `references/ADR_FORMAT.md`. Create the output directory if it doesn't exist. Use today's date for the YYYYMMDD prefix.
+
+## Graceful Degradation
+
+If the session transcript at `--session <path>` is unreadable or missing:
+- **Warn the user**: "Session transcript not found at <path>. Proceeding with manifest and logs only — ADRs will be less detailed (no deliberation context)."
+- **Proceed with manifest + logs**: Skip Phase 1 parallel extraction. Instead, extract decisions directly from the manifest's Approach section (Architecture, Trade-offs, Risk Areas) and any execution logs. Apply the same worthiness criteria.
+- **Note in each ADR**: Add to the Source section: "Note: Synthesized from manifest only. Session transcript was unavailable — deliberation context may be incomplete."
+
+If no ADR-worthy decisions are found after synthesis:
+- Output: "No ADR-worthy decisions identified. The session may not have involved architectural decisions, or all decisions were mechanical/obvious."
+
+## Error Handling
+
+- **Missing manifest**: Error and halt — the manifest is required.
+- **Empty/very short transcript** (< 10 messages): Warn "Session transcript is very short — ADR extraction may produce limited results." Proceed normally.
+- **Output directory not writable**: Error and halt with clear message.
+
+## Output
+
+On completion, output:
+```
+ADRs written to: <output-dir>/
+
+| # | Title | File |
+|---|-------|------|
+| 1 | [title] | YYYYMMDD-kebab-title.md |
+| 2 | [title] | YYYYMMDD-kebab-title.md |
+
+Total: N ADR(s) from M candidate decisions.
+```
+
+## Known Limitations
+
+- **Multi-define sessions**: If the session transcript contains multiple `/define` runs, `/adr` processes the full transcript. ADRs may reflect decisions from any run in the session. Review output for relevance to your specific task.
+- **Session transcript format**: Assumes the Claude Code session transcript JSONL format (`~/.claude/projects/<dir>/<id>.jsonl`) is stable. If the format changes, extraction agents may need updating.
+- **Discovery/execution logs are supplementary**: Logs are attention aids for the model, not structured data stores. The skill does not assume or require any particular log structure — it reads them as free-form text for additional context.

--- a/claude-plugins/manifest-dev-tools/skills/adr/references/ADR_FORMAT.md
+++ b/claude-plugins/manifest-dev-tools/skills/adr/references/ADR_FORMAT.md
@@ -1,0 +1,82 @@
+# ADR Format
+
+Architecture Decision Records capture significant decisions with their context, alternatives, and consequences. Based on the MADR (Markdown Any Decision Records) standard.
+
+## ADR Template
+
+```markdown
+# ADR: [Decision Title]
+
+## Status
+Accepted
+
+## Context
+[What situation motivated this decision? What constraints, requirements, or tensions existed?]
+
+## Decision
+[What was decided and why this option was chosen.]
+
+## Alternatives Considered
+- **[Alternative A]**: [Description] — [Why not chosen]
+- **[Alternative B]**: [Description] — [Why not chosen]
+
+## Consequences
+
+### Positive
+- [What becomes easier or better]
+
+### Negative
+- [What becomes harder or is traded away]
+
+## Source
+- Manifest: [manifest file path]
+- Session: [session transcript path]
+```
+
+## File Naming
+
+`YYYYMMDD-kebab-case-title.md` — date prefix using the current date.
+
+Examples: `20260327-decouple-adr-from-workflow.md`, `20260327-use-madr-format.md`
+
+## Decision-Worthiness Criteria
+
+Not every decision during a manifest workflow warrants an ADR. The threshold is **downstream architectural impact** — decisions that shape the system's structure, constrain future options, or would be costly to reverse.
+
+### ADR-Worthy (record these)
+
+| Source | What to capture |
+|--------|----------------|
+| **Architecture choices** | Technology, patterns, component structure, integration approach |
+| **Trade-off resolutions** | When competing concerns were weighed and one was preferred |
+| **Scope decisions with rationale** | Deliberate inclusion/exclusion that shapes the system boundary |
+| **Key constraint decisions** | Invariants established from multiple valid options |
+| **Approach pivots** | When implementation adjusts architecture based on reality |
+
+### NOT ADR-Worthy (skip these)
+
+| Category | Why not |
+|----------|---------|
+| **Quality gate selections** | Verification configuration, not architecture |
+| **Process guidance defaults** | How-to-work, not system structure |
+| **Mechanical choices** | Obvious implementations with no meaningful alternatives |
+| **Known assumptions** | Defaults chosen without deliberation — no alternatives weighed |
+| **Bug fixes** | Corrections, not decisions (unless the fix involves an architectural choice) |
+
+### Decision Test
+
+When uncertain, apply: *"Would a new team member joining in 6 months benefit from knowing WHY this was decided this way?"* If yes → ADR. If they'd just accept it as obvious → skip.
+
+## Synthesis Guidance
+
+When generating ADR entries from session transcripts:
+
+**From session transcripts**: Look for architecture decisions, trade-off resolutions, and scope decisions where alternatives were explicitly discussed. Key signals: user rejecting an option in favor of another, explicit "because" reasoning, deliberation between approaches.
+
+**From manifests**: The Approach section (Architecture, Trade-offs, Risk Areas) contains structured decision summaries. These are the most reliable source for what was decided, though they lack the full deliberation context.
+
+**From execution logs**: Look for approach adjustments with rationale and trade-off applications. The key signal is "changed because" or "preferred X over Y because" — these indicate deliberation.
+
+**Quality over quantity**: A manifest with 10 decisions might produce 2-3 ADRs. The Context and Alternatives sections are what make ADRs valuable — a decision without context is just a fact. If you can't articulate why alternatives were rejected, the decision may not be ADR-worthy.
+
+**Context comes from the transcript, not the manifest**: The most valuable ADR content is the reasoning that happened during the session — user preferences, rejected approaches, constraint trade-offs. The manifest records WHAT was decided; the transcript records WHY.

--- a/claude-plugins/manifest-dev/README.md
+++ b/claude-plugins/manifest-dev/README.md
@@ -105,7 +105,7 @@ Criteria verify blocks support an optional `phase:` field (numeric, default 1). 
 |-------|-------------|
 | `/define` | Interviews you, builds an executable manifest with verification criteria. `--interview minimal\|autonomous\|thorough` controls questioning depth (default: thorough). `--visualize` launches a local web companion showing reasoning transparency and coverage map. |
 | `/do` | Works through the manifest autonomously, verifies everything passes |
-| `/auto` | End-to-end autonomous: `/define --interview autonomous` → auto-approve → `/do` in one command. Supports `--mode` pass-through to `/do`. |
+| `/auto` | End-to-end autonomous: `/define --interview autonomous` → auto-approve → `/do` in one command. Supports `--mode` pass-through. |
 | `/verify` | Runs verifiers phased by iteration speed — fast checks first, e2e/deploy-dependent later. Only advances to the next phase when the current one passes. (You rarely call this directly; `/do` handles it.) |
 | `/done` | Prints what got done and what was verified |
 | `/escalate` | When something's blocked, surfaces the issue for you to decide |

--- a/claude-plugins/manifest-dev/skills/auto/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/auto/SKILL.md
@@ -18,7 +18,7 @@ If `--interview` is present in arguments: error and halt: "--interview is not su
 
 If no arguments provided: error and halt: "Usage: /auto <task description> [--mode efficient|balanced|thorough]"
 
-Parse `--mode` from arguments if present — this will be passed to /do. The remaining text after flag extraction is the task description.
+Parse `--mode` from arguments if present. `--mode` will be passed to /do. The remaining text after flag extraction is the task description.
 
 ## Flow
 

--- a/claude-plugins/manifest-dev/skills/define/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/define/SKILL.md
@@ -512,6 +512,7 @@ When `--medium` is not `local`, read `references/COLLABORATION_MODE.md` for rout
 
 ```text
 Manifest complete: /tmp/manifest-{timestamp}.md
+Session: ~/.claude/projects/<dir>/<session-id>.jsonl
 
 To execute: /do /tmp/manifest-{timestamp}.md [log-file-path if iterating]
 ```


### PR DESCRIPTION
## Summary
- Adds `--adr <path>` flag to `/define`, `/do`, `/done`, and `/auto` that exports manifest decisions as Architecture Decision Records in MADR format
- ADRs build incrementally: `/define` captures interview decisions, `/do` captures implementation decisions, `/done` writes final files to the user-specified directory
- Not every decision becomes an ADR — decision-worthiness criteria filter for downstream architectural impact
- Closes #43

## Example ADRs

See [here](https://github.com/Dev-iL/manifest-dev/tree/2603/adr_examples/docs/adr)

| # | Title |
|---|-------|
| 001 | Integrate ADR generation into existing skills rather than a separate skill |
| 002 | Use memento pattern with a single draft file for ADR state across workflow phases |
| 003 | Define explicit decision-worthiness criteria to filter ADR-worthy decisions |
| 004 | Make --adr accept a directory path instead of being a boolean flag |

## Usage

```bash
/define "add rate limiting to the API" --adr docs/adr/
/auto "add rate limiting" --adr docs/adr/
```

## Files changed

| File | What |
|------|------|
| `skills/define/references/ADR_FORMAT.md` | **NEW** — MADR template, worthiness criteria, draft file format |
| `skills/define/SKILL.md` | `--adr` flag parsing, ADR Generation section, manifest metadata |
| `skills/do/SKILL.md` | ADR Updates section (auto-detected from manifest metadata) |
| `skills/done/SKILL.md` | ADR Finalization section (goals+constraints format) |
| `skills/auto/SKILL.md` | `--adr` passthrough to `/define` |
| `plugin.json` | Version 0.66.0 → 0.67.0, "adr" keyword |
| `README.md` (plugin) | Skills table + ADR Export subsection |
| `README.md` (root) | `--adr` one-liner + `/auto` table entry |
| `docs/adr/*.md` | 4 example ADRs from this feature's own session |

## Test plan

- [ ] Run `/define "test task" --adr docs/adr/` — verify ADR draft file created, manifest contains `**ADR:**` metadata
- [ ] Run `/do` on the resulting manifest — verify ADR draft updated on approach adjustments
- [ ] Verify `/done` writes individual ADR files to `docs/adr/` in MADR format
- [ ] Run `/define "test task"` WITHOUT `--adr` — verify zero behavioral change
- [ ] Run `/auto "test task" --adr docs/adr/` — verify flag passes through
