### PR TITLE
Prevent /define from skipping thinking-disciplines activation

### DIFF
--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.85.0",
+  "version": "0.85.1",
   "description": "Manifest-driven workflows for structured task execution with verification gates.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/skills/define/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/define/SKILL.md
@@ -5,7 +5,9 @@ description: 'Manifest builder. Plan work, scope tasks, spec out requirements, b
 
 # /define - Manifest Builder
 
-Invoke the manifest-dev:thinking-disciplines skill. Apply throughout the entire interview — not just domain understanding, but every question, every assessment, every synthesis.
+## Prerequisites
+
+If thinking disciplines are not already active in this session, invoke the manifest-dev:thinking-disciplines skill. Do not begin the interview until disciplines are active. Apply throughout — every question, assessment, and synthesis.
 
 ## Goal
 


### PR DESCRIPTION
Add Prerequisites section with explicit gate: check if disciplines
are already active before invoking, and block interview start until
confirmed. Fixes observed failure where model jumped straight to
interview work, skipping the first instruction.

https://claude.ai/code/session_01CyU89ToM7w5ngYz3cYmwfJ