### PR TITLE
Reduce Permission Friction for manifest-dev Users

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 claude-plugins/manifest-dev/hooks/stop_do_hook.py"
+            "command": "bash -c 'ROOT=$(git rev-parse --show-toplevel) && python3 \"$ROOT/claude-plugins/manifest-dev/hooks/stop_do_hook.py\"'"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 claude-plugins/manifest-dev/hooks/pretool_verify_hook.py"
+            "command": "bash -c 'ROOT=$(git rev-parse --show-toplevel) && python3 \"$ROOT/claude-plugins/manifest-dev/hooks/pretool_verify_hook.py\"'"
           }
         ]
       },
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 claude-plugins/manifest-dev/hooks/thinking_disciplines_pretool_hook.py"
+            "command": "bash -c 'ROOT=$(git rev-parse --show-toplevel) && python3 \"$ROOT/claude-plugins/manifest-dev/hooks/thinking_disciplines_pretool_hook.py\"'"
           }
         ]
       }
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 claude-plugins/manifest-dev/hooks/prompt_submit_hook.py"
+            "command": "bash -c 'ROOT=$(git rev-parse --show-toplevel) && python3 \"$ROOT/claude-plugins/manifest-dev/hooks/prompt_submit_hook.py\"'"
           }
         ]
       },
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 claude-plugins/manifest-dev/hooks/thinking_disciplines_prompt_hook.py"
+            "command": "bash -c 'ROOT=$(git rev-parse --show-toplevel) && python3 \"$ROOT/claude-plugins/manifest-dev/hooks/thinking_disciplines_prompt_hook.py\"'"
           }
         ]
       }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 claude-plugins/manifest-dev/hooks/posttool_log_hook.py"
+            "command": "bash -c 'ROOT=$(git rev-parse --show-toplevel) && python3 \"$ROOT/claude-plugins/manifest-dev/hooks/posttool_log_hook.py\"'"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 claude-plugins/manifest-dev/hooks/posttool_log_hook.py"
+            "command": "bash -c 'ROOT=$(git rev-parse --show-toplevel) && python3 \"$ROOT/claude-plugins/manifest-dev/hooks/posttool_log_hook.py\"'"
           }
         ]
       },
@@ -75,7 +75,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 claude-plugins/manifest-dev/hooks/posttool_log_hook.py"
+            "command": "bash -c 'ROOT=$(git rev-parse --show-toplevel) && python3 \"$ROOT/claude-plugins/manifest-dev/hooks/posttool_log_hook.py\"'"
           }
         ]
       }
@@ -86,7 +86,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 claude-plugins/manifest-dev/hooks/post_compact_hook.py"
+            "command": "bash -c 'ROOT=$(git rev-parse --show-toplevel) && python3 \"$ROOT/claude-plugins/manifest-dev/hooks/post_compact_hook.py\"'"
           }
         ]
       }

--- a/.claude/skills/setup-manifest-dev
+++ b/.claude/skills/setup-manifest-dev
@@ -1,0 +1,1 @@
+../../claude-plugins/manifest-dev/skills/setup-manifest-dev

--- a/claude-plugins/README.md
+++ b/claude-plugins/README.md
@@ -30,7 +30,7 @@ Manifest-driven workflows separating **what to build** (Deliverables) from **rul
 **Optional skills:**
 - `/figure-out` - Figure things out together on any topic. Truth-convergent thinking partner that investigates before claiming, surfaces gaps, resists premature synthesis. Use before `/define` when the problem space is foggy.
 
-**Other skills:** `/auto` - End-to-end autonomous `/define` → auto-approve → `/do` in a single command (add `--tend-pr` for PR lifecycle) | `/tend-pr` - Tends a PR through review to merge-readiness, manifest-aware or babysit mode | `/learn-define-patterns` - Analyzes past /define sessions and writes preference patterns to CLAUDE.md
+**Other skills:** `/setup-manifest-dev` - One-time setup: auto-detects install scope, pre-grants four permissions needed to run `/define` and `/do` without prompts | `/auto` - End-to-end autonomous `/define` → auto-approve → `/do` in a single command (add `--tend-pr` for PR lifecycle) | `/tend-pr` - Tends a PR through review to merge-readiness, manifest-aware or babysit mode | `/learn-define-patterns` - Analyzes past /define sessions and writes preference patterns to CLAUDE.md
 
 **Internal skills:** `/verify`, `/done`, `/escalate`, `/stop-thinking-disciplines`, `/tend-pr-tick`, `thinking-disciplines`
 

--- a/claude-plugins/manifest-dev/README.md
+++ b/claude-plugins/manifest-dev/README.md
@@ -11,6 +11,33 @@ Tell Claude what "done" looks like. Let it work. Check the result.
 
 That's it. `/define` interviews you and builds a manifest. `/do` executes it. Two commands.
 
+## Setup
+
+manifest-dev needs four permissions to run without prompts: one read of the plugin cache (where skills live) and three `/tmp/` writes (manifest, discovery log, execution log). Run the setup skill once to pre-grant them:
+
+```
+/setup-manifest-dev
+```
+
+That's it. The skill auto-detects your install scope (user, project, or local dev), writes to the right settings file, and confirms which file it updated. Running it again is safe — it deduplicates.
+
+**Manual config** (if you prefer to edit settings directly):
+
+Add these four entries to `permissions.allow` in the appropriate settings file:
+
+```json
+"Read(~/.claude/plugins/cache/manifest-dev/manifest-dev/*/**)",
+"Edit(//tmp/manifest-*.md)",
+"Edit(//tmp/define-discovery-*.md)",
+"Edit(//tmp/do-log-*.md)"
+```
+
+| Install scope | Settings file |
+|---|---|
+| User (global install) | `~/.claude/settings.json` |
+| Project (project install) | `.claude/settings.json` |
+| Local dev (repo clone) | `.claude/settings.local.json` |
+
 ## The Mindset Shift
 
 Stop thinking about *how* to build it. Start thinking about *what you'd accept*.
@@ -103,6 +130,7 @@ Criteria verify blocks support an optional `phase:` field (numeric, default 1). 
 
 | Skill | Description |
 |-------|-------------|
+| `/setup-manifest-dev` | One-time setup: auto-detects install scope (user/project/local), pre-grants the four permissions needed to run `/define` and `/do` without prompts. |
 | `/define` | Interviews you, builds an executable manifest with verification criteria. `--interview minimal\|autonomous\|thorough` controls interview style (default: thorough). |
 | `/do` | Works through the manifest autonomously, verifies everything passes |
 | `/auto` | End-to-end autonomous: `/define --interview autonomous` → auto-approve → `/do` in one command. Supports `--mode` and `--tend-pr` pass-through. |

--- a/claude-plugins/manifest-dev/skills/setup-manifest-dev/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/setup-manifest-dev/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: setup-manifest-dev
+description: 'One-command setup for manifest-dev: auto-detects the plugin install scope (local dev, project, or user) and pre-grants the four permissions needed to run /define and /do without prompts. Triggers: setup manifest-dev, install manifest-dev, configure permissions, permission prompts, run setup.'
+user-invocable: true
+---
+
+Run the following Bash command to configure manifest-dev permissions:
+
+```bash
+python3 << 'PYEOF'
+import json, os, sys
+
+HOME = os.path.expanduser("~")
+CWD = os.getcwd()
+
+REQUIRED_RULES = [
+    "Read(~/.claude/plugins/cache/manifest-dev/manifest-dev/*/**)",
+    "Edit(//tmp/manifest-*.md)",
+    "Edit(//tmp/define-discovery-*.md)",
+    "Edit(//tmp/do-log-*.md)",
+]
+
+# Scope detection: local → project → user (most-specific first)
+# Local: dev clone — .claude/skills/setup-manifest-dev symlink exists in project
+# Project: plugin installed at project level in .claude/plugins/cache/
+# User: plugin installed at user level in ~/.claude/plugins/cache/
+scope_checks = [
+    (
+        "local",
+        os.path.join(CWD, ".claude", "skills", "setup-manifest-dev"),
+        os.path.join(CWD, ".claude", "settings.local.json"),
+    ),
+    (
+        "project",
+        os.path.join(CWD, ".claude", "plugins", "cache", "manifest-dev"),
+        os.path.join(CWD, ".claude", "settings.json"),
+    ),
+    (
+        "user",
+        os.path.join(HOME, ".claude", "plugins", "cache", "manifest-dev"),
+        os.path.join(HOME, ".claude", "settings.json"),
+    ),
+]
+
+detected_scope = None
+settings_file = None
+for scope, plugin_path, settings_path in scope_checks:
+    if os.path.exists(plugin_path):
+        detected_scope = scope
+        settings_file = settings_path
+        break
+
+if detected_scope is None:
+    checked_paths = [p for _, p, _ in scope_checks]
+    print("Error: manifest-dev plugin not found at any expected location:")
+    for p in checked_paths:
+        print(f"  - {p}")
+    print()
+    print("Manual fix: add the following to your ~/.claude/settings.json (user)")
+    print("or .claude/settings.json (project) under permissions.allow:")
+    for r in REQUIRED_RULES:
+        print(f'  "{r}"')
+    sys.exit(1)
+
+# Read existing settings (or start fresh)
+if not os.path.exists(settings_file):
+    settings = {}
+else:
+    try:
+        with open(settings_file) as f:
+            settings = json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"Error: JSON syntax error in {settings_file}: {e}")
+        print("Fix the syntax error manually, then re-run /setup-manifest-dev.")
+        sys.exit(1)
+    if not isinstance(settings, dict):
+        print(f"Error: {settings_file} contains valid JSON but its root is not an object (got {type(settings).__name__}).")
+        print("Fix the file so its root is a JSON object {}, then re-run /setup-manifest-dev.")
+        sys.exit(1)
+
+# Merge rules (deduplicate by exact string match)
+allow = settings.setdefault("permissions", {}).setdefault("allow", [])
+added = 0
+for r in REQUIRED_RULES:
+    if r not in allow:
+        allow.append(r)
+        added += 1
+
+# Ensure parent directory exists
+os.makedirs(os.path.dirname(settings_file), exist_ok=True)
+
+# Write back with proper JSON formatting
+with open(settings_file, "w") as f:
+    json.dump(settings, f, indent=2)
+    f.write("\n")
+
+status = f"{added} rules added" if added > 0 else "already up to date"
+print(f"✓ Detected {detected_scope} scope. Updated {settings_file} with manifest-dev permissions ({status}).")
+if added > 0:
+    print("  Reload your editor if you have that file open.")
+PYEOF
+```
+
+Run this command exactly as shown, then report the output to the user.


### PR DESCRIPTION
~~~md
# Definition: Reduce Permission Friction for manifest-dev Users

## 1. Intent & Context

- **Goal:** New users running manifest-dev (installed at any scope: user, project, or local-only) encounter 4+ permission prompts (plugin file reads + `/tmp/` writes) before any work begins. Build a one-command setup flow that auto-detects the plugin scope and pre-grants permissions to the corresponding settings file, eliminating friction across all install paths.
- **Mental Model:** Claude Code permission system: reads within CWD are unrestricted; reads of external paths (plugin cache) and all writes require explicit allow rules. Empirical testing showed Read + Write + Write + Write prompts when running `/define`. Solution: auto-populate settings with vetted allow-list.
- **Interview:** thorough

## 2. Approach

**Architecture:** Two-part solution with scope auto-detection.
- **Setup Skill** (`/setup-manifest-dev`): 
  1. Auto-detect manifest-dev plugin scope by checking: `~/.claude/plugins/cache/manifest-dev/` (user), `.claude/plugins/cache/manifest-dev/` (project), `./.claude/plugins/cache/manifest-dev/` (local-only)
  2. Map scope to settings file: user→`~/.claude/settings.json`, project→`./.claude/settings.json`, local-only→`./.claude/settings.local.json`
  3. Read target settings file, merge four permission rules, deduplicate, write back
  4. Confirm completion with scope and file path
- **Documentation**: Explains permission landscape, the four rules, scope auto-detection behavior, and manual config path for all three scopes.

The skill is the primary friction-reducer; docs support power users and troubleshooting.

**Execution Order:**
- D1 (Setup Skill) → D2 (Documentation)
- Rationale: Skill is self-contained and doesn't depend on docs. Docs can reference the skill once it exists.

**Risk Areas:**
- [R-1] Scope detection fails (plugin not found at any expected path) | Detect: Check for file not found errors, report which paths were checked, suggest manual scope specification
- [R-2] JSON parse/serialize errors in target settings file | Detect: Try-catch, report parse error with file path
- [R-3] Duplicate rules added on multiple skill invocations | Detect: Deduplication logic in merge, verify no duplicates in output
- [R-4] User runs skill, settings get updated, but they have a stale copy open in editor | Detect: Skill outputs "reload your editor" message with file path
- [R-5] Plugin install path changes structure in future versions | Detect: `*/**` glob is future-proof for version bumps, but major restructure would break it. Acceptable risk.

**Trade-offs:**
- [T-1] Scope strategy: auto-detect vs user-specified vs update-all → Prefer auto-detect because: (a) simpler UX (no flags/prompts), (b) deterministic (no ambiguity about which scope to update), (c) matches manifest-dev philosophy of "just follow along and it works"
- [T-2] Auto-merge vs interactive approval → Prefer auto-merge because: (a) rules are conservative (plugin cache only, /tmp only), (b) user explicitly invokes, (c) reduces dialog fatigue, which is the whole point

## 3. Global Invariants

- [INV-G1] Skill must not add duplicate rules. The `permissions.allow` array in settings after skill execution contains the four rules exactly once each. | Verify:
  ```yaml
  verify:
    method: subagent
    agent: code-simplicity-reviewer
    prompt: "Check that the skill's merge logic deduplicates correctly. Test case: allow array already has one rule, skill is run again, result has rule exactly once, not twice."
  ```

- [INV-G2] All four permission rules are present after skill execution (read plugin cache + three /tmp/ writes). | Verify:
  ```yaml
  verify:
    method: bash
    command: "cat ~/.claude/settings.json | python3 -c \"import json,sys; d=json.load(sys.stdin); rules=d.get('permissions',{}).get('allow',[]); required=['Read(~/.claude/plugins/cache/manifest-dev/manifest-dev/*/**)', 'Edit(//tmp/manifest-*.md)', 'Edit(//tmp/define-discovery-*.md)', 'Edit(//tmp/do-log-*.md)']; print('PASS' if all(r in rules for r in required) else 'FAIL: missing rules')\""
  ```

- [INV-G3] The target settings file (inferred from plugin scope) is valid JSON before and after skill execution (no parse errors, no corruption). Applies to all three scopes: user (`~/.claude/settings.json`), project (`./.claude/settings.json`), local (`./.claude/settings.local.json`). | Verify:
  ```yaml
  verify:
    method: bash
    command: "TARGET_FILE=$(python3 -c \"import sys,os; [print(f) for f in ['$HOME/.claude/settings.json', './.claude/settings.json', './.claude/settings.local.json'] if os.path.exists(f)]\" | head -1); python3 -c \"import json; json.load(open('$TARGET_FILE'))\" && echo PASS || echo FAIL"
  ```

- [INV-G4] Scope auto-detection is deterministic: the skill finds exactly one scope (user OR project OR local, not multiple). Detection order: check local first (most specific), then project, then user (most general). | Verify:
  ```yaml
  verify:
    method: subagent
    agent: code-simplicity-reviewer
    prompt: "Check scope detection logic: does it check in the right order (local → project → user)? Does it stop at first match? What if plugin exists at multiple scopes? Ensure deterministic single-scope selection."
  ```

## 4. Process Guidance

- [PG-1] Skill should be idempotent: running it multiple times produces the same result (no error, no duplicates, same final state).
- [PG-2] When target settings file doesn't exist (for any of the three scopes), skill creates it with minimal structure `{"permissions": {"allow": [...]}}`, not a full default config.
- [PG-3] Skill output includes a success message naming the file path (`~/.claude/settings.json updated`) so user knows where to find it.
- [PG-4] If parse fails or scope detection fails, error message includes the file path (or paths checked) and suggests manual remediation or scope specification.

## 5. Known Assumptions

- [ASM-1] User has write access to at least one of: `~/.claude/` (user scope), `./.claude/` (project scope), `./.claude/settings.local.json` (local scope). Default: assumed true (standard permissions for where plugin is installed). Impact if wrong: skill fails with file permission error on all three scopes, user must check permissions or run with elevated privileges.
- [ASM-2] Plugin cache location structure remains stable: `.../plugins/cache/manifest-dev/manifest-dev/{version}/`. Default: assumed stable based on current Claude Code version. Impact if wrong: scope detection may fail. Mitigation: `*/**` glob is forward-compatible for version bumps; only major directory restructure breaks it. Fallback error message guides user to manual config.
- [ASM-3] Exactly one plugin scope is active at a time (plugin installed as user, project, or local, not multiple). Default: assumed based on Claude Code install behavior. Impact if wrong: skill picks first match in priority order (local → project → user) and updates that scope only. User can manually configure other scopes if needed.

## 6. Deliverables

### Deliverable 1: Setup Skill (`/setup-manifest-dev`)

**Acceptance Criteria:**

- [AC-1.1] Skill auto-detects plugin scope by checking (in order): `./.claude/skills/setup-manifest-dev` presence (local dev clone), `.claude/plugins/cache/manifest-dev/` (project install), `~/.claude/plugins/cache/manifest-dev/` (user install). Reports detected scope to user. | Verify:
  ```yaml
  verify:
    method: bash
    command: "test in all three scopes: (a) .claude/skills/setup-manifest-dev present, run skill, confirm reports 'local scope', (b) plugin at project cache path, run skill, confirm reports 'project scope', (c) plugin at user cache path, run skill, confirm reports 'user scope'"
  ```

- [AC-1.2] Skill reads the target settings file (inferred from detected scope). If file doesn't exist, treat as empty object. If file exists but is invalid JSON, report error with file path and suggest manual remediation. | Verify:
  ```yaml
  verify:
    method: subagent
    agent: code-bugs-reviewer
    prompt: "Check JSON read/parse error handling for all three paths. Test: nonexistent file (should create), invalid JSON file (should report error with path), valid file (should parse)."
  ```

- [AC-1.3] Skill merges four permission rules into `permissions.allow` array without duplicating. Rules are: `Read(~/.claude/plugins/cache/manifest-dev/manifest-dev/*/**)`; `Edit(//tmp/manifest-*.md)`; `Edit(//tmp/define-discovery-*.md)`; `Edit(//tmp/do-log-*.md)`. | Verify:
  ```yaml
  verify:
    method: subagent
    agent: code-simplicity-reviewer
    prompt: "Audit merge logic. Is deduplication by exact string match? Test: user already has one rule, skill is run again, rule appears exactly once, not twice."
  ```

- [AC-1.4] Skill writes updated settings to the target file (determined by scope) with proper JSON formatting (indentation, no trailing commas). | Verify:
  ```yaml
  verify:
    method: bash
    command: "python3 -c \"import json; json.load(open('$HOME/.claude/settings.json'))\" && echo PASS || echo 'FAIL: malformed JSON written'"
  ```

- [AC-1.5] Skill outputs success message including detected scope and target file path, e.g. "✓ Detected user scope. Updated ~/.claude/settings.json with manifest-dev permissions (4 rules added/updated)." | Verify:
  ```yaml
  verify:
    method: bash
    command: "run skill and capture stdout, verify message contains scope name and file path"
  ```

- [AC-1.6] Skill is idempotent: running twice on the same settings produces identical result (no duplicates, no errors, same final state). | Verify:
  ```yaml
  verify:
    method: bash
    command: "run skill, capture target settings file, run skill again, diff should be empty"
  ```

- [AC-1.7] Skill handles edge cases for all three scopes: missing settings file (creates it), empty allow array (adds rules), missing `permissions` object (creates it), invalid JSON (reports error). In all cases, final result has all four rules present exactly once. | Verify:
  ```yaml
  verify:
    method: subagent
    agent: code-testability-reviewer
    prompt: "Enumerate edge cases for each of the three scopes: missing file, empty/missing objects, invalid JSON, existing rules. Does the skill code handle all?"
  ```

### Deliverable 2: Documentation

**Acceptance Criteria:**

- [AC-2.1] README section in `claude-plugins/manifest-dev/README.md` under "Setup" explains: (a) what permissions manifest-dev needs, (b) why (plugin cache reads + /tmp writes), (c) how to use the setup skill (mentions auto-scope detection), (d) manual config alternative for all three scopes with example allow-lists. | Verify:
  ```yaml
  verify:
    method: subagent
    agent: docs-reviewer
    prompt: "Check that README section is: clear to users at all three scopes, explains why these permissions, describes scope auto-detection, gives setup skill command, shows manual config examples for user/project/local scopes."
  ```

- [AC-2.2] Setup section is under 500 words (concise, not exhaustive). | Verify:
  ```yaml
  verify:
    method: bash
    command: "awk '/^## Setup/{p=1} /^## [^S]/{p=0} p' claude-plugins/manifest-dev/README.md | wc -w | awk '{print ($1 <= 500 ? \"PASS\" : \"FAIL: \" $1 \" words in Setup section\")}'"
  ```

- [AC-2.3] If a user follows the documentation, they can either (a) run the skill (which auto-detects scope) or (b) manually add the rules to their settings file per docs. User is unblocked from permission prompts. Verify for all three scopes. | Verify:
  ```yaml
  verify:
    method: manual
    prompt: "For each scope (user/project/local): follow the documentation as a new user. Run `/setup-manifest-dev` or manually edit appropriate settings file per docs. Then run `/define` on a new project. Report: are there permission prompts?"
  ```

## 7. Amendments

### Amendment 2: Fix Detection Path and Word Count Scope

**Changed:**
- **AC-1.1**: Local scope detection changed from `./.claude/plugins/cache/manifest-dev/` to `./.claude/skills/setup-manifest-dev` presence. Rationale: plugin cache doesn't exist in dev clone environments; the skills symlink is the correct proxy for local dev.
- **AC-2.2**: Verify command now checks only the `## Setup` section word count (≤500), not the entire README. Rationale: the README was 1,575 words before this task — the whole-file check was always impossible to pass.

**Why**: AC-1.1 used a detection path that never exists in the intended "local" scenario (dev clone). AC-2.2 checked the whole file instead of the new section, making it always-fail.

### Amendment 1: Support All Plugin Install Scopes

**Changed:**
- **Goal**: Expanded from user-scope only to support all three scopes (user, project, local-only)
- **Architecture**: Added scope auto-detection logic (local → project → user priority order)
- **Trade-offs**: Replaced T-1 (user vs project choice) with T-1 (auto-detect vs user-specified vs update-all strategy) — chose auto-detect
- **Risk Areas**: Added [R-1] for scope detection failure, renumbered remaining risks
- **INVs**: Updated INV-G3 to cover all scopes, added INV-G4 for deterministic scope detection
- **ACs D1**: Split original AC-1.1 into two ACs: scope detection (new AC-1.1) and settings file read (new AC-1.2); renumbered merge/write/idempotent/edge-case ACs accordingly
- **ACs D2**: Updated AC-2.1 to document all three scopes, AC-2.3 to test all scopes

**Why**: User can install manifest-dev at any scope (user account, specific project, or local-only per Claude Code docs). Setup skill must work correctly regardless of scope by auto-detecting where the plugin lives and writing permissions to the corresponding settings file.
~~~