### PR TITLE
fix(stop_do_hook): escape valve when transcript flush lags behind /do→/done

### DIFF
--- a/claude-plugins/manifest-dev/hooks/hook_utils.py
+++ b/claude-plugins/manifest-dev/hooks/hook_utils.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 import os
 import re
+import sys
+import tempfile
 from dataclasses import dataclass
 from typing import Any
 
@@ -307,7 +309,7 @@ def count_consecutive_short_outputs(transcript_path: str) -> int:
 def record_stop_block(
     session_id: str,
     transcript_path: str,
-    state_dir: str = "/tmp",
+    state_dir: str | None = None,
 ) -> int:
     """
     Track consecutive stop-hook blocks per session, keyed on transcript mtime.
@@ -339,7 +341,12 @@ def record_stop_block(
         The number of consecutive blocks observed without the transcript
         advancing. ``1`` on the first block of a fresh stretch.
     """
-    state_path = os.path.join(state_dir, f"manifest-dev-stop-blocks-{session_id}.json")
+    if state_dir is None:
+        state_dir = tempfile.gettempdir()
+    # Sanitize session_id to prevent path traversal (defense-in-depth;
+    # session_id comes from Claude Code's hook runtime, not user input).
+    safe_id = os.path.basename(session_id) or "default"
+    state_path = os.path.join(state_dir, f"manifest-dev-stop-blocks-{safe_id}.json")
 
     try:
         tx_mtime = os.path.getmtime(transcript_path)
@@ -353,10 +360,19 @@ def record_stop_block(
                 loaded = json.load(f)
             if isinstance(loaded, dict):
                 state = loaded
-        except (json.JSONDecodeError, OSError):
-            pass
+        except (json.JSONDecodeError, OSError) as exc:
+            print(
+                f"manifest-dev: corrupt stop-block state, resetting: {exc}",
+                file=sys.stderr,
+            )
 
     prior_mtime = state.get("transcript_mtime", 0.0)
+    # Float equality is stable here: json roundtrips preserve float64, and
+    # APFS/ext4/tmpfs have sub-second mtime resolution.  On coarse-resolution
+    # filesystems (FAT32, some NFS), two writes within the same second would
+    # look identical — the counter wouldn't reset even though the transcript
+    # genuinely advanced.  In practice this is unlikely to cause a false
+    # escape (would need N blocks within one second).
     if isinstance(prior_mtime, (int, float)) and prior_mtime == tx_mtime:
         # Transcript has not advanced since the previous block — keep counting
         prior_count = state.get("count", 0)
@@ -371,8 +387,11 @@ def record_stop_block(
     try:
         with open(state_path, "w", encoding="utf-8") as f:
             json.dump(new_state, f)
-    except OSError:
-        pass
+    except OSError as exc:
+        print(
+            f"manifest-dev: failed to write stop-block state: {exc}",
+            file=sys.stderr,
+        )
 
     return new_count
 

--- a/claude-plugins/manifest-dev/hooks/hook_utils.py
+++ b/claude-plugins/manifest-dev/hooks/hook_utils.py
@@ -8,6 +8,7 @@ Contains transcript parsing for skill invocation detection.
 from __future__ import annotations
 
 import json
+import os
 import re
 from dataclasses import dataclass
 from typing import Any
@@ -301,6 +302,79 @@ def count_consecutive_short_outputs(transcript_path: str) -> int:
             break
 
     return consecutive_short
+
+
+def record_stop_block(
+    session_id: str,
+    transcript_path: str,
+    state_dir: str = "/tmp",
+) -> int:
+    """
+    Track consecutive stop-hook blocks per session, keyed on transcript mtime.
+
+    Each call increments a per-session counter stored at
+    ``{state_dir}/manifest-dev-stop-blocks-{session_id}.json``. The counter
+    resets to 1 when the transcript's on-disk mtime advances between
+    invocations.
+
+    This independence from transcript content matters: the existing
+    ``count_consecutive_short_outputs`` helper relies on the model's
+    short-output pattern being visible in the transcript, but Claude Code
+    flushes assistant output to disk only at user-prompt boundaries. During
+    a long ``/do → /verify → /done`` chain with no intervening user prompt,
+    the model's recent invocations remain buffered in memory and are
+    invisible to the hook. Counting blocks (which the hook itself observes)
+    rather than transcript content makes the loop-escape independent of
+    that flush timing.
+
+    Args:
+        session_id: Stable identifier for the current Claude Code session.
+            Hook input typically provides this as ``hook_input["session_id"]``.
+        transcript_path: Path to the on-disk transcript file. Used only for
+            its mtime — not parsed.
+        state_dir: Directory for the per-session counter file. Defaults to
+            ``/tmp``; tests override.
+
+    Returns:
+        The number of consecutive blocks observed without the transcript
+        advancing. ``1`` on the first block of a fresh stretch.
+    """
+    state_path = os.path.join(state_dir, f"manifest-dev-stop-blocks-{session_id}.json")
+
+    try:
+        tx_mtime = os.path.getmtime(transcript_path)
+    except OSError:
+        tx_mtime = 0.0
+
+    state: dict[str, Any] = {"count": 0, "transcript_mtime": 0.0}
+    if os.path.exists(state_path):
+        try:
+            with open(state_path, encoding="utf-8") as f:
+                loaded = json.load(f)
+            if isinstance(loaded, dict):
+                state = loaded
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    prior_mtime = state.get("transcript_mtime", 0.0)
+    if isinstance(prior_mtime, (int, float)) and prior_mtime == tx_mtime:
+        # Transcript has not advanced since the previous block — keep counting
+        prior_count = state.get("count", 0)
+        if not isinstance(prior_count, int):
+            prior_count = 0
+        new_count = prior_count + 1
+    else:
+        # Transcript advanced (model output reached disk) — fresh stretch
+        new_count = 1
+
+    new_state = {"count": new_count, "transcript_mtime": tx_mtime}
+    try:
+        with open(state_path, "w", encoding="utf-8") as f:
+            json.dump(new_state, f)
+    except OSError:
+        pass
+
+    return new_count
 
 
 def parse_do_flow(transcript_path: str) -> DoFlowState:

--- a/claude-plugins/manifest-dev/hooks/stop_do_hook.py
+++ b/claude-plugins/manifest-dev/hooks/stop_do_hook.py
@@ -18,13 +18,21 @@ Decision matrix:
 from __future__ import annotations
 
 import json
+import os
 import sys
 
 from hook_utils import (
     count_consecutive_short_outputs,
     has_recent_api_error,
     parse_do_flow,
+    record_stop_block,
 )
+
+# Maximum number of consecutive blocks to allow before escaping with a
+# diagnostic warning when the transcript is not advancing. This is the
+# independent-of-transcript-content escape valve. Override with the
+# environment variable below.
+MAX_STALE_BLOCKS_DEFAULT = 5
 
 
 def main() -> None:
@@ -99,6 +107,45 @@ def main() -> None:
                 "WARNING: Stop allowed to break infinite loop. "
                 "The /do workflow was NOT properly completed. "
                 "Next time, call /escalate when blocked instead of minimal outputs."
+            ),
+        }
+        print(json.dumps(output))
+        sys.exit(0)
+
+    # Transcript-stale escape valve. The short-output check above relies on
+    # the model's `.` outputs being visible in the on-disk transcript, but
+    # the transcript only flushes to disk at user-prompt boundaries — so a
+    # long /do → /verify → /done chain with no user prompt between leaves
+    # the model's recent invocations buffered in memory, invisible to this
+    # hook. Counting our own block invocations (independent of transcript
+    # content) catches that case: when we've blocked N times without the
+    # transcript advancing, something needs human inspection regardless of
+    # whether the buffered work succeeded or genuinely got stuck.
+    session_id = hook_input.get("session_id", "default")
+    max_stale_blocks = int(
+        os.environ.get("MANIFEST_DEV_STOP_MAX_STALE_BLOCKS", MAX_STALE_BLOCKS_DEFAULT)
+    )
+    stale_blocks = record_stop_block(session_id, transcript_path)
+    if stale_blocks >= max_stale_blocks:
+        output = {
+            "reason": (
+                f"Allowed after {stale_blocks} blocks with no transcript movement"
+            ),
+            "systemMessage": (
+                f"WARNING: Stop hook allowed after {stale_blocks} consecutive "
+                "blocks without the on-disk transcript advancing. Two likely "
+                "causes:\n"
+                "  (a) The model's /verify or /done invocations completed but "
+                "the transcript hasn't flushed them to disk (Claude Code "
+                "flushes the .jsonl on user-prompt boundaries; long workflows "
+                "with no user input keep the buffer in memory). Work may "
+                "actually be complete — inspect the execution log "
+                "(/tmp/do-log-*.md) for the /verify outcome.\n"
+                "  (b) The model is genuinely stuck and not calling /done or "
+                "/escalate. Treat the run as incomplete and check "
+                "Deliverables.\n"
+                "Override threshold via MANIFEST_DEV_STOP_MAX_STALE_BLOCKS "
+                f"(default {MAX_STALE_BLOCKS_DEFAULT})."
             ),
         }
         print(json.dumps(output))

--- a/claude-plugins/manifest-dev/hooks/stop_do_hook.py
+++ b/claude-plugins/manifest-dev/hooks/stop_do_hook.py
@@ -122,9 +122,14 @@ def main() -> None:
     # transcript advancing, something needs human inspection regardless of
     # whether the buffered work succeeded or genuinely got stuck.
     session_id = hook_input.get("session_id", "default")
-    max_stale_blocks = int(
-        os.environ.get("MANIFEST_DEV_STOP_MAX_STALE_BLOCKS", MAX_STALE_BLOCKS_DEFAULT)
-    )
+    try:
+        max_stale_blocks = int(
+            os.environ.get(
+                "MANIFEST_DEV_STOP_MAX_STALE_BLOCKS", MAX_STALE_BLOCKS_DEFAULT
+            )
+        )
+    except (ValueError, TypeError):
+        max_stale_blocks = MAX_STALE_BLOCKS_DEFAULT
     stale_blocks = record_stop_block(session_id, transcript_path)
     if stale_blocks >= max_stale_blocks:
         output = {

--- a/claude-plugins/manifest-dev/hooks/stop_do_hook.py
+++ b/claude-plugins/manifest-dev/hooks/stop_do_hook.py
@@ -40,8 +40,12 @@ def main() -> None:
     try:
         stdin_data = sys.stdin.read()
         hook_input = json.loads(stdin_data)
-    except (json.JSONDecodeError, OSError):
-        # On any error, allow stop (fail open)
+    except (json.JSONDecodeError, OSError) as exc:
+        # Fail open, but leave a breadcrumb for debugging
+        print(
+            f"manifest-dev: stop hook failed to parse stdin, allowing stop: {exc}",
+            file=sys.stderr,
+        )
         sys.exit(0)
 
     transcript_path = hook_input.get("transcript_path", "")
@@ -145,7 +149,7 @@ def main() -> None:
                 "flushes the .jsonl on user-prompt boundaries; long workflows "
                 "with no user input keep the buffer in memory). Work may "
                 "actually be complete — inspect the execution log "
-                "(/tmp/do-log-*.md) for the /verify outcome.\n"
+                f"(/tmp/do-log-*-{session_id[-8:]}.md) for the /verify outcome.\n"
                 "  (b) The model is genuinely stuck and not calling /done or "
                 "/escalate. Treat the run as incomplete and check "
                 "Deliverables.\n"

--- a/tests/hooks/test_do_stop_hook.py
+++ b/tests/hooks/test_do_stop_hook.py
@@ -1296,7 +1296,7 @@ class TestStopHookStaleTranscriptEscape:
     ) -> dict[str, Any] | None:
         """Invoke the hook n times back-to-back and return the final result."""
         import os
-        import shutil
+        import sys
 
         # Clean any prior counter state for this session so the test starts fresh.
         state_path = f"/tmp/manifest-dev-stop-blocks-{session_id}.json"
@@ -1316,11 +1316,13 @@ class TestStopHookStaleTranscriptEscape:
         result = None
         for _ in range(n):
             run_env = os.environ.copy()
+            # Clear env var so tests assuming the default threshold are deterministic
+            run_env.pop("MANIFEST_DEV_STOP_MAX_STALE_BLOCKS", None)
             if env:
                 run_env.update(env)
 
             r = subprocess.run(
-                [shutil.which("python") or "python3", str(HOOKS_DIR / "stop_do_hook.py")],
+                [sys.executable, str(HOOKS_DIR / "stop_do_hook.py")],
                 input=_json.dumps(hook_input),
                 capture_output=True,
                 text=True,
@@ -1406,7 +1408,6 @@ class TestStopHookStaleTranscriptEscape:
         """When transcript mtime changes between blocks, counter must reset."""
         import json as _json
         import os
-        import time
 
         # Write initial transcript (with a /do invocation)
         transcript_file = tmp_path / "transcript.jsonl"
@@ -1419,12 +1420,11 @@ class TestStopHookStaleTranscriptEscape:
         assert result_pre is not None
         assert result_pre["decision"] == "block"
 
-        # Advance transcript mtime by appending a new line
-        time.sleep(0.01)  # ensure mtime tick
+        # Advance transcript mtime with explicit future timestamp
+        prior_mtime = os.path.getmtime(transcript_file)
         with open(transcript_file, "a", encoding="utf-8") as f:
             f.write(_json.dumps({"type": "user", "message": {"content": "hi"}}) + "\n")
-        os.utime(transcript_file, None)  # bump mtime explicitly
-        time.sleep(0.01)
+        os.utime(transcript_file, (prior_mtime + 1, prior_mtime + 1))
 
         # First block after transcript advance: counter resets to 1 → still BLOCK
         result_after = self._block_n_times(
@@ -1474,7 +1474,6 @@ class TestRecordStopBlock:
         """Counter resets to 1 when the transcript mtime changes."""
         import os
         import sys
-        import time
 
         sys.path.insert(0, str(HOOKS_DIR))
         from hook_utils import record_stop_block
@@ -1486,11 +1485,10 @@ class TestRecordStopBlock:
         c2 = record_stop_block("sess-B", str(transcript), state_dir=str(tmp_path))
         assert (c1, c2) == (1, 2)
 
-        # Advance mtime
-        time.sleep(0.02)
+        # Advance mtime with explicit future timestamp
+        prior_mtime = os.path.getmtime(transcript)
         transcript.write_text("v2\n")
-        os.utime(str(transcript), None)
-        time.sleep(0.02)
+        os.utime(str(transcript), (prior_mtime + 1, prior_mtime + 1))
 
         c3 = record_stop_block("sess-B", str(transcript), state_dir=str(tmp_path))
         assert c3 == 1, f"counter should reset on mtime advance; got {c3}"

--- a/tests/hooks/test_do_stop_hook.py
+++ b/tests/hooks/test_do_stop_hook.py
@@ -1266,3 +1266,288 @@ class TestStopHookInterruptHandling:
 
         # Should ALLOW — no /do in transcript
         assert result is None
+
+
+class TestStopHookStaleTranscriptEscape:
+    """
+    Tests for the transcript-stale escape valve in stop_do_hook.
+
+    The model's `/verify` and `/done` Skill invocations land in the
+    transcript only when Claude Code flushes the .jsonl, and that flush
+    happens at user-prompt boundaries. A self-contained
+    `/do → /verify → /done` chain (no user prompt between) leaves the
+    model's calls buffered in memory — invisible to this hook. The
+    short-output loop detector also fails in that case because the model's
+    `.` retries are equally invisible.
+
+    The escape valve here counts hook invocations themselves (not transcript
+    content). When a stretch of N consecutive blocks all see the same
+    transcript mtime, escape with a diagnostic message that names both
+    plausible causes (stale flush vs. genuinely stuck model).
+    """
+
+    def _block_n_times(
+        self,
+        transcript_path: str,
+        session_id: str,
+        n: int,
+        env: dict[str, str] | None = None,
+    ) -> dict[str, Any] | None:
+        """Invoke the hook n times back-to-back and return the final result."""
+        import os
+        import shutil
+
+        # Clean any prior counter state for this session so the test starts fresh.
+        state_path = f"/tmp/manifest-dev-stop-blocks-{session_id}.json"
+        if os.path.exists(state_path):
+            os.remove(state_path)
+
+        hook_input = {
+            "transcript_path": transcript_path,
+            "session_id": session_id,
+        }
+
+        import json as _json
+        import subprocess
+
+        from hook_test_helpers import HOOKS_DIR
+
+        result = None
+        for _ in range(n):
+            run_env = os.environ.copy()
+            if env:
+                run_env.update(env)
+
+            r = subprocess.run(
+                [shutil.which("python") or "python3", str(HOOKS_DIR / "stop_do_hook.py")],
+                input=_json.dumps(hook_input),
+                capture_output=True,
+                text=True,
+                cwd=str(HOOKS_DIR),
+                env=run_env,
+            )
+            assert r.returncode == 0, f"hook crashed: {r.stderr}"
+            result = _json.loads(r.stdout) if r.stdout.strip() else None
+        return result
+
+    def test_blocks_below_threshold(
+        self,
+        temp_transcript,
+        user_do_command: dict[str, Any],
+    ):
+        """Blocks under threshold still BLOCK with the standard message."""
+        transcript_path = temp_transcript([user_do_command])
+
+        result = self._block_n_times(transcript_path, "sess-below", n=4)
+
+        assert result is not None
+        assert result["decision"] == "block"
+        assert "verify" in result["systemMessage"].lower()
+
+    def test_escapes_at_threshold(
+        self,
+        temp_transcript,
+        user_do_command: dict[str, Any],
+    ):
+        """At the default threshold (5) the hook ALLOWS with diagnostic warning."""
+        transcript_path = temp_transcript([user_do_command])
+
+        result = self._block_n_times(transcript_path, "sess-at", n=5)
+
+        assert result is not None
+        assert "decision" not in result, "should allow (omit decision)"
+        assert "5 blocks" in result["reason"] or "5 consecutive" in result["systemMessage"]
+        assert "transcript" in result["systemMessage"].lower()
+
+    def test_diagnostic_names_both_causes(
+        self,
+        temp_transcript,
+        user_do_command: dict[str, Any],
+    ):
+        """The escape message must explain both buffering and stuck-model paths."""
+        transcript_path = temp_transcript([user_do_command])
+
+        result = self._block_n_times(transcript_path, "sess-msg", n=5)
+
+        assert result is not None
+        msg = result["systemMessage"]
+        # Cause (a): buffering / flush timing
+        assert "flush" in msg.lower() or "buffer" in msg.lower()
+        # Cause (b): genuinely stuck model
+        assert "stuck" in msg.lower() or "genuinely" in msg.lower()
+        # Diagnostic should mention the execution log
+        assert "do-log" in msg.lower() or "execution log" in msg.lower()
+
+    def test_env_var_threshold_override(
+        self,
+        temp_transcript,
+        user_do_command: dict[str, Any],
+    ):
+        """MANIFEST_DEV_STOP_MAX_STALE_BLOCKS env var should override the default."""
+        transcript_path = temp_transcript([user_do_command])
+
+        # With threshold=2, escape on the 2nd block, not the 5th.
+        result = self._block_n_times(
+            transcript_path,
+            "sess-env",
+            n=2,
+            env={"MANIFEST_DEV_STOP_MAX_STALE_BLOCKS": "2"},
+        )
+
+        assert result is not None
+        assert "decision" not in result, "should allow at threshold=2"
+
+    def test_counter_resets_when_transcript_advances(
+        self,
+        tmp_path,
+        user_do_command: dict[str, Any],
+    ):
+        """When transcript mtime changes between blocks, counter must reset."""
+        import json as _json
+        import os
+        import time
+
+        # Write initial transcript (with a /do invocation)
+        transcript_file = tmp_path / "transcript.jsonl"
+        with open(transcript_file, "w", encoding="utf-8") as f:
+            f.write(_json.dumps(user_do_command) + "\n")
+        transcript_path = str(transcript_file)
+
+        # Block 4 times — should not yet escape (threshold 5)
+        result_pre = self._block_n_times(transcript_path, "sess-reset", n=4)
+        assert result_pre is not None
+        assert result_pre["decision"] == "block"
+
+        # Advance transcript mtime by appending a new line
+        time.sleep(0.01)  # ensure mtime tick
+        with open(transcript_file, "a", encoding="utf-8") as f:
+            f.write(_json.dumps({"type": "user", "message": {"content": "hi"}}) + "\n")
+        os.utime(transcript_file, None)  # bump mtime explicitly
+        time.sleep(0.01)
+
+        # First block after transcript advance: counter resets to 1 → still BLOCK
+        result_after = self._block_n_times(
+            transcript_path, "sess-reset", n=1
+        )
+        assert result_after is not None
+        assert result_after["decision"] == "block", (
+            "counter should have reset after transcript advanced; "
+            f"got {result_after}"
+        )
+
+
+class TestRecordStopBlock:
+    """Unit tests for hook_utils.record_stop_block in isolation."""
+
+    def test_first_call_returns_one(self, tmp_path):
+        """First call for a fresh session returns 1."""
+        import sys
+
+        sys.path.insert(0, str(HOOKS_DIR))
+        from hook_utils import record_stop_block
+
+        transcript = tmp_path / "tx.jsonl"
+        transcript.write_text("hello\n")
+
+        count = record_stop_block(
+            "fresh-session", str(transcript), state_dir=str(tmp_path)
+        )
+        assert count == 1
+
+    def test_repeated_calls_increment_when_mtime_static(self, tmp_path):
+        """Repeated calls without transcript mtime change increment the counter."""
+        import sys
+
+        sys.path.insert(0, str(HOOKS_DIR))
+        from hook_utils import record_stop_block
+
+        transcript = tmp_path / "tx.jsonl"
+        transcript.write_text("hello\n")
+
+        c1 = record_stop_block("sess-A", str(transcript), state_dir=str(tmp_path))
+        c2 = record_stop_block("sess-A", str(transcript), state_dir=str(tmp_path))
+        c3 = record_stop_block("sess-A", str(transcript), state_dir=str(tmp_path))
+        assert (c1, c2, c3) == (1, 2, 3)
+
+    def test_counter_resets_when_mtime_advances(self, tmp_path):
+        """Counter resets to 1 when the transcript mtime changes."""
+        import os
+        import sys
+        import time
+
+        sys.path.insert(0, str(HOOKS_DIR))
+        from hook_utils import record_stop_block
+
+        transcript = tmp_path / "tx.jsonl"
+        transcript.write_text("v1\n")
+
+        c1 = record_stop_block("sess-B", str(transcript), state_dir=str(tmp_path))
+        c2 = record_stop_block("sess-B", str(transcript), state_dir=str(tmp_path))
+        assert (c1, c2) == (1, 2)
+
+        # Advance mtime
+        time.sleep(0.02)
+        transcript.write_text("v2\n")
+        os.utime(str(transcript), None)
+        time.sleep(0.02)
+
+        c3 = record_stop_block("sess-B", str(transcript), state_dir=str(tmp_path))
+        assert c3 == 1, f"counter should reset on mtime advance; got {c3}"
+
+    def test_sessions_are_independent(self, tmp_path):
+        """Different session_ids maintain independent counters."""
+        import sys
+
+        sys.path.insert(0, str(HOOKS_DIR))
+        from hook_utils import record_stop_block
+
+        transcript = tmp_path / "tx.jsonl"
+        transcript.write_text("hello\n")
+
+        record_stop_block("session-1", str(transcript), state_dir=str(tmp_path))
+        record_stop_block("session-1", str(transcript), state_dir=str(tmp_path))
+        c2_session1 = record_stop_block(
+            "session-1", str(transcript), state_dir=str(tmp_path)
+        )
+        c1_session2 = record_stop_block(
+            "session-2", str(transcript), state_dir=str(tmp_path)
+        )
+        assert c2_session1 == 3
+        assert c1_session2 == 1, "session-2 counter should be independent"
+
+    def test_missing_transcript_does_not_raise(self, tmp_path):
+        """Missing transcript file is tolerated; counter still advances."""
+        import sys
+
+        sys.path.insert(0, str(HOOKS_DIR))
+        from hook_utils import record_stop_block
+
+        c1 = record_stop_block(
+            "sess-missing", "/nonexistent/transcript.jsonl", state_dir=str(tmp_path)
+        )
+        c2 = record_stop_block(
+            "sess-missing", "/nonexistent/transcript.jsonl", state_dir=str(tmp_path)
+        )
+        # Both calls see mtime=0 (missing), so counter increments
+        assert (c1, c2) == (1, 2)
+
+    def test_corrupt_state_file_starts_fresh(self, tmp_path):
+        """A corrupt counter file is treated as a fresh stretch."""
+        import sys
+
+        sys.path.insert(0, str(HOOKS_DIR))
+        from hook_utils import record_stop_block
+
+        transcript = tmp_path / "tx.jsonl"
+        transcript.write_text("hello\n")
+        state_file = tmp_path / "manifest-dev-stop-blocks-sess-corrupt.json"
+        state_file.write_text("not valid json {{")
+
+        count = record_stop_block(
+            "sess-corrupt", str(transcript), state_dir=str(tmp_path)
+        )
+        assert count == 1
+
+
+# Module-scope import for the unit-test class above.
+from hook_test_helpers import HOOKS_DIR  # noqa: E402

--- a/tests/hooks/test_do_stop_hook.py
+++ b/tests/hooks/test_do_stop_hook.py
@@ -6,6 +6,7 @@ Tests the stop hook that enforces verification-first workflow for /do.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest

--- a/tests/hooks/test_do_stop_hook.py
+++ b/tests/hooks/test_do_stop_hook.py
@@ -6,11 +6,16 @@ Tests the stop hook that enforces verification-first workflow for /do.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import Any
 
 import pytest
-from hook_test_helpers import run_hook
+from hook_test_helpers import HOOKS_DIR, run_hook
+
+# Make hook modules importable for direct unit tests (TestRecordStopBlock)
+sys.path.insert(0, str(HOOKS_DIR))
+from hook_utils import record_stop_block  # noqa: E402
 
 
 class TestStopHookBlocking:
@@ -1293,14 +1298,20 @@ class TestStopHookStaleTranscriptEscape:
         session_id: str,
         n: int,
         env: dict[str, str] | None = None,
+        *,
+        clean: bool = True,
     ) -> dict[str, Any] | None:
         """Invoke the hook n times back-to-back and return the final result."""
         import os
         import sys
+        import tempfile
 
         # Clean any prior counter state for this session so the test starts fresh.
-        state_path = f"/tmp/manifest-dev-stop-blocks-{session_id}.json"
-        if os.path.exists(state_path):
+        state_path = os.path.join(
+            tempfile.gettempdir(),
+            f"manifest-dev-stop-blocks-{session_id}.json",
+        )
+        if clean and os.path.exists(state_path):
             os.remove(state_path)
 
         hook_input = {
@@ -1400,6 +1411,54 @@ class TestStopHookStaleTranscriptEscape:
         assert result is not None
         assert "decision" not in result, "should allow at threshold=2"
 
+    def test_invalid_env_var_falls_back_to_default(
+        self,
+        temp_transcript,
+        user_do_command: dict[str, Any],
+    ):
+        """Non-numeric MANIFEST_DEV_STOP_MAX_STALE_BLOCKS falls back to default 5."""
+        transcript_path = temp_transcript([user_do_command])
+
+        # With "abc", int() would raise ValueError — should fall back to 5.
+        # 4 blocks should still BLOCK (under default threshold).
+        result = self._block_n_times(
+            transcript_path,
+            "sess-invalid-env",
+            n=4,
+            env={"MANIFEST_DEV_STOP_MAX_STALE_BLOCKS": "abc"},
+        )
+
+        assert result is not None
+        assert result["decision"] == "block", (
+            "invalid env var should fall back to default threshold; "
+            f"got {result}"
+        )
+
+    def test_missing_session_id_uses_default(
+        self,
+        temp_transcript,
+        user_do_command: dict[str, Any],
+    ):
+        """Hook input without session_id should use 'default' and still function."""
+        import json as _json
+        import subprocess
+
+        transcript_path = temp_transcript([user_do_command])
+        hook_input = {"transcript_path": transcript_path}  # no session_id
+
+        r = subprocess.run(
+            [sys.executable, str(HOOKS_DIR / "stop_do_hook.py")],
+            input=_json.dumps(hook_input),
+            capture_output=True,
+            text=True,
+            cwd=str(HOOKS_DIR),
+        )
+        assert r.returncode == 0, f"hook crashed: {r.stderr}"
+        result = _json.loads(r.stdout) if r.stdout.strip() else None
+
+        assert result is not None
+        assert result["decision"] == "block"
+
     def test_counter_resets_when_transcript_advances(
         self,
         tmp_path,
@@ -1426,9 +1485,11 @@ class TestStopHookStaleTranscriptEscape:
             f.write(_json.dumps({"type": "user", "message": {"content": "hi"}}) + "\n")
         os.utime(transcript_file, (prior_mtime + 1, prior_mtime + 1))
 
-        # First block after transcript advance: counter resets to 1 → still BLOCK
+        # First block after transcript advance: counter resets to 1 → still BLOCK.
+        # clean=False preserves the counter state from the first 4 blocks so we
+        # actually test that mtime advancement resets the counter.
         result_after = self._block_n_times(
-            transcript_path, "sess-reset", n=1
+            transcript_path, "sess-reset", n=1, clean=False
         )
         assert result_after is not None
         assert result_after["decision"] == "block", (
@@ -1442,11 +1503,6 @@ class TestRecordStopBlock:
 
     def test_first_call_returns_one(self, tmp_path):
         """First call for a fresh session returns 1."""
-        import sys
-
-        sys.path.insert(0, str(HOOKS_DIR))
-        from hook_utils import record_stop_block
-
         transcript = tmp_path / "tx.jsonl"
         transcript.write_text("hello\n")
 
@@ -1457,11 +1513,6 @@ class TestRecordStopBlock:
 
     def test_repeated_calls_increment_when_mtime_static(self, tmp_path):
         """Repeated calls without transcript mtime change increment the counter."""
-        import sys
-
-        sys.path.insert(0, str(HOOKS_DIR))
-        from hook_utils import record_stop_block
-
         transcript = tmp_path / "tx.jsonl"
         transcript.write_text("hello\n")
 
@@ -1473,10 +1524,6 @@ class TestRecordStopBlock:
     def test_counter_resets_when_mtime_advances(self, tmp_path):
         """Counter resets to 1 when the transcript mtime changes."""
         import os
-        import sys
-
-        sys.path.insert(0, str(HOOKS_DIR))
-        from hook_utils import record_stop_block
 
         transcript = tmp_path / "tx.jsonl"
         transcript.write_text("v1\n")
@@ -1495,11 +1542,6 @@ class TestRecordStopBlock:
 
     def test_sessions_are_independent(self, tmp_path):
         """Different session_ids maintain independent counters."""
-        import sys
-
-        sys.path.insert(0, str(HOOKS_DIR))
-        from hook_utils import record_stop_block
-
         transcript = tmp_path / "tx.jsonl"
         transcript.write_text("hello\n")
 
@@ -1516,11 +1558,6 @@ class TestRecordStopBlock:
 
     def test_missing_transcript_does_not_raise(self, tmp_path):
         """Missing transcript file is tolerated; counter still advances."""
-        import sys
-
-        sys.path.insert(0, str(HOOKS_DIR))
-        from hook_utils import record_stop_block
-
         c1 = record_stop_block(
             "sess-missing", "/nonexistent/transcript.jsonl", state_dir=str(tmp_path)
         )
@@ -1532,11 +1569,6 @@ class TestRecordStopBlock:
 
     def test_corrupt_state_file_starts_fresh(self, tmp_path):
         """A corrupt counter file is treated as a fresh stretch."""
-        import sys
-
-        sys.path.insert(0, str(HOOKS_DIR))
-        from hook_utils import record_stop_block
-
         transcript = tmp_path / "tx.jsonl"
         transcript.write_text("hello\n")
         state_file = tmp_path / "manifest-dev-stop-blocks-sess-corrupt.json"
@@ -1546,7 +1578,3 @@ class TestRecordStopBlock:
             "sess-corrupt", str(transcript), state_dir=str(tmp_path)
         )
         assert count == 1
-
-
-# Module-scope import for the unit-test class above.
-from hook_test_helpers import HOOKS_DIR  # noqa: E402


### PR DESCRIPTION
## Problem

`stop_do_hook` blocks indefinitely on a long, self-contained `/do → /verify → /done` chain because Claude Code's transcript `.jsonl` flushes at user-prompt boundaries, not on every assistant turn. With no user prompt between `/do` and `/done`, the model's `Skill(skill: "manifest-dev:done")` invocation stays in memory and never reaches the on-disk file the hook reads.

The existing escape valve (`count_consecutive_short_outputs >= 3`) doesn't help: it relies on the same stale transcript and equally fails to see the model's `.` retries.

I hit this myself running `/manifest-dev:do` against a 4-deliverable manifest with a `--mode thorough` `/verify` that took ~5 minutes. After both `/verify` cycles passed and `/done` ran, the Stop hook fired hundreds of times, each reading a transcript frozen 7 hours in the past from the original `/do` invocation. Both the `/done` Skill call AND every `.` short-output retry I sent were buffered in memory, invisible to `parse_do_flow` and `count_consecutive_short_outputs` alike. Only an external user message could break the loop by triggering a transcript flush.

## Fix

Add a transcript-content-independent escape valve: count hook invocations themselves, keyed on transcript mtime. When N consecutive blocks all see the same mtime, allow with a diagnostic message that names both plausible causes:

  (a) Model's `/verify` or `/done` completed but transcript hasn't flushed
  (b) Model is genuinely stuck and not calling `/done` or `/escalate`

Both are user-actionable; neither is improved by the next block.

- New `record_stop_block(session_id, transcript_path, state_dir)` in `hook_utils.py`. State at `/tmp/manifest-dev-stop-blocks-<session_id>.json`. Counter resets when transcript mtime advances (so legitimate slow verifiers that DO flush eventually aren't false-escaped).
- New branch in `stop_do_hook.py` after the existing short-output check. Default threshold 5, override via `MANIFEST_DEV_STOP_MAX_STALE_BLOCKS`.
- 11 new tests: 5 escape-valve scenarios + 6 `record_stop_block` unit tests. All 53 stop_do_hook tests pass.

## Why count blocks instead of elapsed time?

A 15-minute `change-intent-reviewer` agent run never triggers Stop (we're not trying to stop, we're working). Block count stays 0 throughout. When `/verify` → `/done` → assistant attempts to stop, the buffer may still be 15+ minutes behind, but the hook can count its own invocations independently. Time-threshold approaches false-trip on legitimately slow verifiers; block-counting doesn't.

## Notes

- Drive-by: added `from pathlib import Path` for a pre-existing F821 in the test file's `tmp_path: Path` annotation.
- Ruff clean on all touched files. Mypy not run (local environment issue with `pathspec.patterns.gitignore`).
- Pre-existing `tests/test_dist_skill_references.py` failures are unrelated to this change (confirmed on baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)