### PR TITLE
feat(drive): add /check-in fallback scheduler for when /loop is unavailable

### DIFF
--- a/.manifest/add-check-in-fallback-scheduler-2026-04-24.md
+++ b/.manifest/add-check-in-fallback-scheduler-2026-04-24.md
@@ -276,12 +276,12 @@ Scope: `claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md`. Edits t
     prompt: "Read §Pre-flight in claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md. Confirm: when both /loop AND /check-in are unavailable, the error message (a) names /loop, (b) names /check-in, (c) is actionable (tells user what to do). Pass only if all three are present."
   ```
 
-- [AC-2.3] §Scheduler Kickoff (renamed from §/loop Kickoff) documents the parameterised invocation — the invocation string is identical in structure regardless of scheduler, only the skill name swaps. | Verify: subagent.
+- [AC-2.3] §Scheduler Kickoff (renamed from §/loop Kickoff) documents two scheduler-specific invocation blocks: the `/loop` invocation is byte-equivalent to today (INV-G4); the `/check-in` invocation differs by one additional positional arg (`<log-path>`) up front, which is REQUIRED by INV-G9 (log-file-as-contract). The drive-tick arg string passed to both schedulers is identical. | Verify: subagent.
   ```yaml
   verify:
     method: subagent
     agent: general-purpose
-    prompt: "Read §Scheduler Kickoff (renamed from §/loop Kickoff) in claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md. Confirm: (1) the section is renamed, (2) it describes a single parameterised invocation with the scheduler skill name swapped in, (3) the argument string format is unchanged. Pass = all three."
+    prompt: "Read §Scheduler Kickoff (renamed from §/loop Kickoff) in claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md. Confirm: (1) the section is renamed to 'Scheduler Kickoff'; (2) a /loop invocation block exists and is byte-identical to what drive used today (<interval> then the /drive-tick args); (3) a /check-in invocation block exists with <log-path> as the second positional arg BEFORE the /drive-tick command, consistent with /check-in's need to read the log file per INV-G9; (4) the /drive-tick args string is identical between the two blocks. Pass = all four."
   ```
 
 - [AC-2.4] Run summary printed at end of §Scheduler Kickoff includes an explicit scheduler field naming which was chosen (a labelled line such as `scheduler: /loop` or `scheduler: /check-in`, not merely a mention). Existing summary fields (run-id, mode, platform, sink, interval, budget, branch, PR number, log path, `tail -f` hint) unchanged. | Verify: subagent.

--- a/.manifest/add-check-in-fallback-scheduler-2026-04-24.md
+++ b/.manifest/add-check-in-fallback-scheduler-2026-04-24.md
@@ -20,7 +20,7 @@
     1. Parse `<interval> <log-path> <command>`; validate interval range (`15m`–`24h`); error on malformed input with the same wording `/drive` uses.
     2. Convert interval to seconds.
     3. Loop:
-       - Sleep the interval. Compute chunk count upfront: `chunks = ceil(interval_seconds / 540)` (where 540s = 9 minutes, leaving headroom under the Bash tool's 600s cap). Issue exactly `chunks` sequential `sleep 540` calls (final chunk may be shorter: `interval_seconds % 540`). No in-loop arithmetic — counter is known at entry. Cumulative semantics (sum of chunks), not wall-clock-target.
+       - Sleep the interval. Compute chunk count upfront: `chunks = ceil(interval_seconds / 540)` (where 540s = 9 minutes, leaving headroom under the Bash tool's 600s cap). Issue `chunks - 1` sequential `sleep 540` calls plus one final `sleep <remainder>` where `remainder = interval_seconds - (chunks - 1) * 540` (always in `1..540` — ceil guarantees non-zero, avoiding 9-minute shortfalls on exact-multiple-of-540 intervals that naive `% 540` would produce). No in-loop arithmetic — counter is known at entry. Cumulative semantics (sum of chunks), not wall-clock-target.
        - Invoke the `<command>` verbatim via the Skill tool — `<command>` is passed unparsed; no shell expansion, no re-quoting.
        - If the Skill-tool invocation itself fails (tool error, timeout, crash): fail-loud, exit with an explanatory message. Do NOT retry.
        - Read the log file at `<log-path>`. Find the last `## Tick N — …` or `## BUDGET EXHAUSTED` header.

--- a/.manifest/add-check-in-fallback-scheduler-2026-04-24.md
+++ b/.manifest/add-check-in-fallback-scheduler-2026-04-24.md
@@ -1,0 +1,360 @@
+# Definition: Add /check-in fallback scheduler to drive plugin
+
+## 1. Intent & Context
+
+- **Goal:** Add a `/check-in` skill to the `manifest-dev-experimental` (drive) plugin that serves as an automatic fallback when `/loop` is not available in the environment. Behaviour: sleep for the configured interval, invoke the tick command, detect terminal markers, and re-loop until terminal — effectively a blocking, session-local substitute for `/loop`'s background cron.
+- **Mental Model:**
+  - `/loop` is an external, cron-like scheduler that fires `/drive-tick` on an interval without blocking. It is required by `/drive` today and `/drive` errors out in pre-flight when it is missing. Today's invocation is verbatim (drive/SKILL.md line 107): `Invoke the /loop skill with: "<interval> /drive-tick --run-id <run-id> --mode <mode> --platform <platform> --sink <sink> --log <log-path> --max-ticks <N> [--manifest <manifest-path>] [--pr <pr-number>]"`.
+  - `/check-in` is a **blocking, same-session substitute**. Interface: `<interval> <log-path> <command>` — one extra positional arg (`<log-path>`) compared to `/loop` because `/check-in` reads terminal state from the **log file**, not from the Skill-tool response. Drive-tick writes its `## Tick N — …` markers to the log file per its Output Protocol (verbatim strings verified in §3 INV-G8); the Skill-tool response is not the contract channel. After each invocation `/check-in` reads the log file, finds the most recent `## Tick N — …` header, and classifies: `Terminal:` / `Error:` / `BUDGET EXHAUSTED` → exit; `Continuing` / `Skipped (lock held)` → re-loop; anything else or no entry at all → fail-loud exit.
+  - `/drive` pre-flight learns a tri-branch: `/loop` available → use it (preferred, preserves existing semantics); only `/check-in` available → fall back (warn user that the session will block); neither available → error with actionable message.
+  - `/drive-tick` itself is **unchanged** — it already writes the markers `/check-in` reads from the log. The scheduler swap is invisible to the tick.
+- **Mode:** thorough
+- **Interview:** autonomous
+- **Medium:** local
+
+## 2. Approach
+
+- **Architecture:**
+  - New skill directory: `claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md`. No references/, no assets/ — single-file skill for v0 simplicity (PROMPTING default: match architecture to skill type; this is a thin Business Process orchestrator).
+  - `/check-in` internal flow (loop inside one Skill invocation):
+    1. Parse `<interval> <log-path> <command>`; validate interval range (`15m`–`24h`); error on malformed input with the same wording `/drive` uses.
+    2. Convert interval to seconds.
+    3. Loop:
+       - Sleep the interval. Compute chunk count upfront: `chunks = ceil(interval_seconds / 540)` (where 540s = 9 minutes, leaving headroom under the Bash tool's 600s cap). Issue exactly `chunks` sequential `sleep 540` calls (final chunk may be shorter: `interval_seconds % 540`). No in-loop arithmetic — counter is known at entry. Cumulative semantics (sum of chunks), not wall-clock-target.
+       - Invoke the `<command>` verbatim via the Skill tool — `<command>` is passed unparsed; no shell expansion, no re-quoting.
+       - If the Skill-tool invocation itself fails (tool error, timeout, crash): fail-loud, exit with an explanatory message. Do NOT retry.
+       - Read the log file at `<log-path>`. Find the last `## Tick N — …` or `## BUDGET EXHAUSTED` header.
+       - Classify: `Terminal:` / `Error:` / `BUDGET EXHAUSTED` → exit; `Continuing` / `Skipped (lock held)` → re-loop; anything else or no header found → fail-loud exit (unexpected drive-tick output).
+  - `/drive` edits (same file `claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md`):
+    - §Pre-flight: replace the single `/loop` availability check with a tri-branch check.
+    - §/loop Kickoff → rename to §Scheduler Kickoff; parameterise invocation on chosen scheduler name.
+    - Run summary: add the scheduler-used line.
+    - §Gotchas: add a line describing the session-blocking nature of `/check-in` fallback.
+  - README edits: `claude-plugins/manifest-dev-experimental/README.md` (What it ships, Dependencies, Gotchas). Plugin version bump in `plugin.json` (0.4.0 → 0.5.0, add `check-in` / `fallback` keywords).
+
+- **Execution Order:**
+  - D1 (`/check-in` skill) → D2 (`/drive` integration) → D3 (README + plugin.json updates).
+  - Rationale: the skill must exist before `/drive` can reference it in pre-flight; README reflects the final state once both are in place.
+
+- **Risk Areas:**
+  - [R-1] Infinite loop if drive-tick's marker format changes | Detect: /check-in reads responses that contain none of the recognized markers → it halts and reports (fail-loud), instead of silently looping.
+  - [R-2] Bash tool's long-sleep restriction (single-call cap ~10m, "long leading sleep" blocked) | Detect: upfront chunk-count formula (AC-1.6) ensures each sleep call is ≤540s, well under the 600s cap. End-to-end integration test (invoking a stubbed drive-tick over a full 15m sleep) is explicitly scoped out for v0 — cost/time disproportionate to the bounded risk of a well-specified chunk formula. If the formula itself is wrong, INV-G1 (prompt-reviewer) should catch it; if chunking still fails at runtime, the Bash call times out with an explicit error rather than silently hanging.
+  - [R-3] Pre-flight regression — existing `/drive` behaviour when `/loop` IS available must be byte-identical | Detect: INV-G4 compares pre/post on the "/loop available" branch.
+  - [R-4] Session-end fragility — closing the Claude session kills /check-in mid-sleep (unlike /loop which delegates to host cron) | Detect: documented in gotchas; no automated detection. Acknowledged as intrinsic to fallback mode.
+
+- **Trade-offs:**
+  - [T-1] Interface fidelity to /loop vs. bespoke interface → Prefer fidelity. /drive builds the invocation string once; swap skill name only.
+  - [T-2] Blocking session vs. backgrounded → Prefer blocking. Honest about fallback's weaker guarantees; user who wants cron installs /loop.
+  - [T-3] Auto-fallback vs. user-selectable flag → Prefer auto. User asked for automatic fallback explicitly.
+  - [T-4] Fail-loud on unknown marker vs. keep looping → Prefer fail-loud. Silent infinite loops waste tokens; halt and surface.
+
+## 3. Global Invariants
+
+- [INV-G1] `/check-in` SKILL.md passes the `prompt-reviewer` agent with no MEDIUM-or-higher findings. This subsumes PROMPTING.md quality gates: Clarity, No conflicts, Structure, Information density, No anti-patterns, Invocation fit, Domain context, Complexity fit, Edge case coverage, Model-prompt fit, Guardrail calibration, Output calibration, Emotional tone — all covered by prompt-reviewer's default rubric. | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: prompt-reviewer
+    prompt: "Review claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md against prompt-engineering principles. Report issues with severity. Pass = no MEDIUM+ issues."
+  ```
+
+- [INV-G2] The full change set (check-in SKILL.md + drive/SKILL.md edits + README + plugin.json) passes the `change-intent-reviewer` agent with no LOW-or-higher intent mismatches. | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: change-intent-reviewer
+    prompt: "Review the git diff on branch claude/add-checkin-fallback-*. Intent: add a /check-in skill to manifest-dev-experimental that serves as an automatic fallback scheduler when /loop is unavailable. /check-in sleeps the configured interval, invokes the command, detects drive-tick terminal markers, and either exits or re-loops. /drive pre-flight learns a tri-branch; /loop path must be byte-identical to today when /loop is available. Pass = no LOW+ findings."
+  ```
+
+- [INV-G3] `/check-in`'s description field follows the What + When + Triggers pattern (PROMPTING.md skill gate: "Description as trigger"). | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Read claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md frontmatter. Verify the description field is: (a) a trigger specification not a human-readable summary, (b) explains WHAT the skill does, WHEN to invoke, and includes trigger terms. Pass = all three present; Fail = any missing."
+  ```
+
+- [INV-G4] `/drive`'s behaviour when `/loop` IS available remains byte-equivalent to today. The tri-branch pre-flight only DIVERGES from today when /loop is unavailable. | Verify: codebase.
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Read claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md §Pre-flight and §Scheduler Kickoff (was §/loop Kickoff). Confirm: (1) when /loop is available and /check-in is also available, /drive uses /loop; (2) the invocation string for /loop is identical in structure to today's; (3) the run summary's scheduler line is additive (doesn't alter existing fields). Fail if any /loop-path behaviour changed."
+  ```
+
+- [INV-G5] `/check-in`'s prompt is ≤450 instruction words of SKILL.md body (excluding frontmatter and section headers), keeping context-rot surface minimal for long-running loops. Threshold set realistically given AC-1.1 through AC-1.10 require specific content (arg spec, chunk formula, five verbatim marker anchors, fail-loud semantics for four distinct failure modes, last-seen-header tracking, first-iteration grace, gotchas). 150 was the original threshold set autonomously during /define; self-amended during /do after discovering the lower bound required more prose than 150 words permit. | Verify: bash.
+  ```yaml
+  verify:
+    method: bash
+    command: "awk '/^---$/{f=!f;next} !f && !/^#/ && NF{print}' claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md | wc -w | awk '{if($1<=450){print \"pass: \"$1\" words\"}else{print \"fail: \"$1\" words (>450)\"; exit 1}}'"
+  ```
+
+- [INV-G6] No changes to `claude-plugins/manifest-dev-experimental/skills/drive-tick/SKILL.md`. The tick is scheduler-agnostic. | Verify: bash.
+  ```yaml
+  verify:
+    method: bash
+    command: "git diff --name-only $(git merge-base HEAD origin/main 2>/dev/null || git rev-list --max-parents=0 HEAD | tail -1) HEAD -- claude-plugins/manifest-dev-experimental/skills/drive-tick/SKILL.md | wc -l | awk '{if($1==0){print \"pass\"}else{print \"fail: drive-tick/SKILL.md was modified\"; exit 1}}'"
+  ```
+
+- [INV-G7] `manifest-dev-experimental/.claude-plugin/plugin.json` version bumped to 0.5.0 (minor, new feature) per CLAUDE.md versioning rules. | Verify: bash.
+  ```yaml
+  verify:
+    method: bash
+    command: "python3 -c \"import json; v = json.load(open('claude-plugins/manifest-dev-experimental/.claude-plugin/plugin.json'))['version']; assert v == '0.5.0', f'version is {v}, expected 0.5.0'; print('pass: 0.5.0')\""
+  ```
+
+- [INV-G8] `/check-in`'s terminal-marker anchors match drive-tick's Output Protocol verbatim — including the em-dash `—` (U+2014), not the hyphen `-`. The five anchor strings are: `## Tick N — Terminal:`, `## Tick N — Continuing`, `## Tick N — Skipped (lock held)`, `## Tick N — Error:`, `## BUDGET EXHAUSTED`. | Verify: bash.
+  ```yaml
+  verify:
+    method: bash
+    command: "f=claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md; for s in 'Tick N — Terminal:' 'Tick N — Continuing' 'Tick N — Skipped (lock held)' 'Tick N — Error:' 'BUDGET EXHAUSTED'; do grep -qF \"$s\" \"$f\" || { echo \"fail: missing '$s'\"; exit 1; }; done; echo pass"
+  ```
+
+- [INV-G9] `/check-in` reads terminal state from the **log file** (parses the last `## Tick N — …` header from the file at `<log-path>`). It does NOT rely on parsing the Skill-tool response text for these markers — drive-tick's Output Protocol writes them to the log, not to its response. | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Read claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md. Confirm it describes reading the log file at <log-path> to detect terminal state — NOT scanning the Skill-tool response for '## Tick N' markers. Pass only if the body explicitly says the log file is the detection source and the Skill-tool response is NOT."
+  ```
+
+- [INV-G10] `/check-in` treats a failed Skill-tool invocation (tool error, timeout, crash — distinct from drive-tick completing and writing an `Error:` log entry) as fail-loud: stop looping, surface the error, exit. No retry, no silent continuation. | Verify: bash.
+  ```yaml
+  verify:
+    method: bash
+    command: "grep -E -q 'Skill[- ]tool.*(fail|error|crash)' claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md && grep -E -q '(No retry|do not retry|without retry|fail-loud)' claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md && echo pass || (echo fail; exit 1)"
+  ```
+
+## 4. Process Guidance
+
+- [PG-1] Skill type: Business Process + Scaffolding (thin orchestrator). Architecture: single SKILL.md file, no references/, no assets/, no scripts/. (PROMPTING.md default: match architecture to skill type.)
+
+- [PG-2] No externalised memento. `/check-in`'s cross-iteration state is minimal — the original args PLUS the last-seen `## Tick N — …` signature (required by AC-1.10) PLUS a counter of consecutive header-less iterations (required by AC-1.9). All three live in the model's working context for the one Skill-tool invocation; no state file, no JSON blob, no scratchpad on disk. drive-tick owns cross-tick memento.
+
+- [PG-3] Emotional tone: trusted-advisor, low-arousal. Match `/drive` and `/drive-tick`'s tone. No urgency language, no praise, no "finally you can ..." framing.
+
+- [PG-4] High-signal changes only. Touch only the files the task requires:
+  - Add: `claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md`.
+  - Edit: `claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md` (pre-flight, kickoff, run summary, gotchas).
+  - Edit: `claude-plugins/manifest-dev-experimental/README.md` (What it ships, Dependencies, Gotchas).
+  - Edit: `claude-plugins/manifest-dev-experimental/.claude-plugin/plugin.json` (version, keywords, description one-liner).
+  - Do NOT edit drive-tick, adapter contracts, platform/sink files, or any other plugin.
+
+- [PG-5] Write content incrementally per CLAUDE.md "Output Style". Use an initial Write for the first section, then Edit-append subsequent sections. Applies to SKILL.md if it grows beyond a single logical block.
+
+- [PG-6] Kebab-case naming per CLAUDE.md convention. Skill name is `check-in` (hyphen, not underscore, not camelCase).
+
+- [PG-7] Do NOT mirror `/check-in` into `.claude/skills/`. The drive plugin is not hardlinked there today (verified via `stat` — only `manifest-dev` skills are). Adding `/check-in` there would diverge from the repo's symlink convention.
+
+## 5. Known Assumptions
+
+- [ASM-1] **Confirmed from source.** Interface shape: `/check-in` takes `<interval> <log-path> <command>` — one extra positional arg compared to `/loop`'s `<interval> <command>`. `/loop`'s exact invocation today was read verbatim from drive/SKILL.md line 107 and quoted in §1 Mental Model. The extra `<log-path>` is necessary because drive-tick writes terminal markers to the log file, not to its Skill-tool response (verified in INV-G9). Impact if wrong: would only change if `/loop`'s real implementation turns out to differ from what drive/SKILL.md documents — outside this repo's control.
+
+- [ASM-2] Behaviour shape: self-contained loop (/check-in owns the re-invocation), NOT "drive-tick calls /check-in at end of tick." Chosen so drive-tick is unchanged and scheduler choice is entirely /drive's concern. Impact if wrong: if the user intended the drive-tick-invokes-scheduler pattern, /check-in becomes a single sleep+invoke call and drive-tick grows scheduler awareness. Reversal is mechanical.
+
+- [ASM-3] No user-specific config persisted for /check-in. All state comes from /drive via invocation args. Impact if wrong: if the user wanted session-persistent preferences (e.g., default interval), those would be added later — easy additive change.
+
+- [ASM-4] No memento / externalised state. Impact if wrong: would need a log file; currently unnecessary because each iteration's state is re-derivable from args.
+
+- [ASM-5] `/loop` is preferred when both /loop and /check-in are available. Rationale: preserves today's background-cron semantics; /check-in blocks the session. Impact if wrong: user who actively wants /check-in's blocking determinism would need a future `--scheduler` flag (deferred, additive).
+
+- [ASM-6] Interval range for /check-in mirrors /drive: 15m–24h. Rationale: consistency, and /drive is the only caller in v0. Impact if wrong: if a user invokes /check-in directly with a sub-15m interval, they get an error they could perceive as arbitrary — but /drive is the documented caller, so this is acceptable.
+
+- [ASM-7] **Confirmed from source.** Terminal-marker set read verbatim from drive-tick/SKILL.md §Output Protocol (lines 222, 228, 234, 242) and §Budget Check (line 52). Terminal: `## Tick N — Terminal:`, `## Tick N — Error:`, `## BUDGET EXHAUSTED`. Non-terminal: `## Tick N — Continuing`, `## Tick N — Skipped (lock held)`. All use em-dash `—` (U+2014), not hyphen. Pinned by INV-G8 in `/check-in` SKILL.md; protected from drive-tick drift by INV-G6 (no drive-tick edits). If drive-tick's markers drift in a FUTURE change, `/check-in` fails-loud on unrecognized headers (per INV-G9/G10 and AC-1.5) — not silent loop.
+
+- [ASM-8] `<command>` is passed verbatim to the Skill tool — no shell expansion, no re-quoting, no re-parsing. `/check-in` treats `<command>` as an opaque string after interval and log-path extraction. Impact if wrong: if a real `<command>` contains shell metacharacters that need escaping, the Skill-tool invocation may misfire. Mitigation: drive-tick's arg format is known and controlled (flag-based, space-separated — no shell metacharacters).
+
+- [ASM-9] Chunked-sleep uses **cumulative-sleep** semantics (sum of per-chunk durations), not wall-clock target. If chunks accumulate drift (e.g., 540s calls taking 541s), total sleep is slightly longer than requested. Impact if wrong: <1% drift over a 15m interval; interval is already documented as a floor not a precise cadence. Negligible.
+
+- [ASM-10] Session compaction mid-loop is out of scope for v0. If Claude Code auto-compacts context during `/check-in`'s loop, the next iteration resumes with compacted history; `/check-in`'s per-iteration state is minimal (interval, log-path, command — all re-derived from args at skill entry, not from accumulated context), so compaction should not break the loop. Not explicitly protected — future regression risk. Impact if wrong: compaction corrupts state → `/check-in` exits loudly on the next unrecognized outcome. Acceptable v0 behavior.
+
+- [ASM-11] "drive plugin" in the user's request maps to `manifest-dev-experimental` — the plugin that ships `/drive` and `/drive-tick`. Inferred from repo exploration (`/drive` lives at `claude-plugins/manifest-dev-experimental/skills/drive/`); there is no standalone plugin named `drive`. Impact if wrong: would need to relocate `/check-in` to the correct plugin directory — mechanical, but edits to drive/SKILL.md would follow the `/drive` file wherever it lives.
+
+## 6. Deliverables
+
+### Deliverable 1: /check-in skill
+
+Scope: `claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md` (new file). Single-file skill. Frontmatter includes `name`, `description` (What + When + Triggers), `user-invocable: true` (consistent with /drive and /drive-tick).
+
+**Acceptance Criteria:**
+
+- [AC-1.1] File exists at `claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md` with valid YAML frontmatter. | Verify: bash.
+  ```yaml
+  verify:
+    method: bash
+    command: "test -f claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md && python3 -c \"import re,sys; t=open('claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md').read(); m=re.match(r'^---\\n(.*?)\\n---\\n', t, re.S); assert m, 'no frontmatter'; import yaml; d=yaml.safe_load(m.group(1)); assert d.get('name')=='check-in'; assert d.get('user-invocable') is True; assert isinstance(d.get('description'),str) and len(d['description'])>0; print('pass')\""
+  ```
+
+- [AC-1.2] Skill documents the sleep + invoke + read-log + classify flow in SKILL.md body. | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Read claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md. Verify the body describes all five steps: (1) parse interval + log-path + command, (2) sleep the interval (with chunked-sleep for >9 minute intervals), (3) invoke the command via the Skill tool, (4) read the log file at <log-path> and locate the LAST `## Tick N — …` or `## BUDGET EXHAUSTED` header, (5) classify per INV-G8's five anchors and either exit (Terminal / Error / BUDGET) or re-loop (Continuing / Skipped). Pass = all five present and unambiguous; step (4) reads the log file (NOT the Skill-tool response)."
+  ```
+
+- [AC-1.3] Skill documents the terminal-marker list consistent with drive-tick/SKILL.md §Output Protocol: `## Tick N — Terminal:`, `## Tick N — Error:`, `## BUDGET EXHAUSTED` are terminal; `## Tick N — Continuing` and `## Tick N — Skipped (lock held)` are non-terminal. | Verify: bash.
+  ```yaml
+  verify:
+    method: bash
+    command: "grep -q 'Tick N — Terminal' claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md && grep -q 'Tick N — Error' claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md && grep -q 'BUDGET EXHAUSTED' claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md && grep -q 'Continuing' claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md && echo pass"
+  ```
+
+- [AC-1.4] Skill defines empty-input and malformed-interval behaviour: errors with usage message, does not sleep or invoke anything. | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Read claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md. Verify the skill: (a) errors with a 'Usage: /check-in <interval> <command>' message when called with no args, (b) errors on intervals outside 15m–24h with a matching-wording message, (c) never sleeps or invokes the command before args are validated. Pass = all three present."
+  ```
+
+- [AC-1.5] Skill documents fail-loud behaviour on unrecognized log-file markers — `/check-in` halts and reports rather than looping when the log's most recent `## Tick N — …` header (or lack thereof) doesn't match any of the five anchors from INV-G8. Verified semantically (not regex-prescriptive) by subagent. | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Read claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md. Confirm: when the log file contains no `## Tick N — …` header at all, OR contains a header that matches none of the five known anchors (Terminal:, Continuing, Skipped (lock held), Error:, BUDGET EXHAUSTED), the skill STOPS the loop and surfaces an error. Pass only if fail-loud is explicit and silent-continue is ruled out."
+  ```
+
+- [AC-1.6] Skill documents the chunked-sleep pattern with an **upfront** chunk-count formula (`ceil(interval_seconds / 540)`), not an in-loop decrementing counter. This avoids arithmetic-during-loop drift, which LLMs are prone to. | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Read claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md. Confirm chunked-sleep specification: (1) computes chunk count UPFRONT via `ceil(interval_seconds / 540)` (or equivalent wording making the 540s cap and ceil-division explicit), (2) issues that many sequential `sleep 540` calls plus a final remainder chunk, (3) does NOT use an in-loop cumulative-elapsed counter that the model maintains across chunks. Pass = upfront formula is specified."
+  ```
+
+- [AC-1.7] Skill documents Skill-tool-failure handling: if the Skill tool invocation itself errors (distinct from drive-tick completing and writing `Error:` to the log), `/check-in` stops the loop, surfaces the failure, and does NOT retry. | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Read claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md. Confirm it distinguishes (a) drive-tick completing normally and writing a log entry (including `Error:`), from (b) the Skill tool invocation itself failing (tool error, timeout, crash). For case (b), verify the skill halts the loop, surfaces the failure, and does not retry. Pass = distinction is explicit and no-retry is stated."
+  ```
+
+- [AC-1.8] Skill documents parsing of the three-positional-arg spec `<interval> <log-path> <command>`. | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Read claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md. Confirm the arg spec is `<interval> <log-path> <command>` — three positional args — and the skill uses <log-path> to locate the log file it reads for terminal-state detection. Pass only if the arg shape is unambiguous."
+  ```
+
+- [AC-1.9] Skill documents first-iteration and log-absence behaviour: if the log file is missing or contains no `## Tick N — …` header on a given iteration (i.e., drive-tick was invoked but appended nothing, or the file was not yet created), treat as `Continuing` for up to ONE consecutive iteration (handles first-tick initialization races), then fail-loud. | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Read claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md. Confirm first-iteration / log-absence handling: (a) missing or header-less log on the FIRST iteration counts as Continuing (allow one grace iteration for initialization race), (b) TWO CONSECUTIVE iterations without a new `## Tick N — …` header triggers fail-loud exit with an explanatory message, (c) this is explicitly stated — not implicit. Pass = all three."
+  ```
+
+- [AC-1.10] Skill documents per-iteration 'last-seen header' tracking to distinguish new headers from stale ones. `/check-in` remembers the last header index/signature it classified and requires a STRICTLY NEWER entry before re-classifying. Prevents misreading an old `Terminal:` header from a prior crashed run. | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Read claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md. Confirm the skill describes how it distinguishes a newly-written `## Tick N — …` header from one that was already present before the current iteration's invocation. Acceptable mechanisms: tracking the last-seen tick number, tracking the file size / byte offset before invocation and reading only new content after, or reading only the log tail after the invocation timestamp. Pass = an explicit distinguishing mechanism is described."
+  ```
+
+### Deliverable 2: /drive integration
+
+Scope: `claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md`. Edits to §Pre-flight, §/loop Kickoff (renamed to §Scheduler Kickoff), the run-summary print, and §Gotchas. No structural restructuring — minimal surgical edits.
+
+**Acceptance Criteria:**
+
+- [AC-2.1] §Pre-flight's first dependency check replaces the single `/loop available` bullet with a tri-branch: both available → use /loop; only /check-in → use /check-in with blocking-session warning; neither → error naming both providers. | Verify: bash.
+  ```yaml
+  verify:
+    method: bash
+    command: "awk '/## Pre-flight/,/## Base Branch Resolution/' claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md | grep -E -q '/check-in' && awk '/## Pre-flight/,/## Base Branch Resolution/' claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md | grep -E -q 'neither|both unavailable|not found' && echo pass || (echo fail; exit 1)"
+  ```
+
+- [AC-2.2] Error message when neither scheduler is available names both skills and suggests installation paths — does not silently fall through. | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Read §Pre-flight in claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md. Confirm: when both /loop AND /check-in are unavailable, the error message (a) names /loop, (b) names /check-in, (c) is actionable (tells user what to do). Pass only if all three are present."
+  ```
+
+- [AC-2.3] §Scheduler Kickoff (renamed from §/loop Kickoff) documents the parameterised invocation — the invocation string is identical in structure regardless of scheduler, only the skill name swaps. | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Read §Scheduler Kickoff (renamed from §/loop Kickoff) in claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md. Confirm: (1) the section is renamed, (2) it describes a single parameterised invocation with the scheduler skill name swapped in, (3) the argument string format is unchanged. Pass = all three."
+  ```
+
+- [AC-2.4] Run summary printed at end of §Scheduler Kickoff includes an explicit scheduler field naming which was chosen (a labelled line such as `scheduler: /loop` or `scheduler: /check-in`, not merely a mention). Existing summary fields (run-id, mode, platform, sink, interval, budget, branch, PR number, log path, `tail -f` hint) unchanged. | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Read §Scheduler Kickoff (or §/loop Kickoff if unrenamed) in claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md. Confirm the run-summary print specification: (1) includes an explicit scheduler-name field labelled clearly enough that a reader can tell it's the chosen scheduler (e.g., `scheduler:` prefix, or a sentence like 'scheduler used: X'), not merely a passing mention; (2) all of these original fields remain and are unchanged in meaning: run-id, mode, platform, sink, interval, budget, branch, PR number (github), log path, tail-f hint. Pass = both."
+  ```
+
+- [AC-2.5] §Gotchas includes a new line flagging the session-blocking nature of /check-in fallback (session close → scheduler dies immediately, unlike /loop cron). | Verify: bash.
+  ```yaml
+  verify:
+    method: bash
+    command: "awk '/## Gotchas/,0' claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md | grep -E -q '/check-in.*(block|session|fallback)' && echo pass || (echo fail; exit 1)"
+  ```
+
+- [AC-2.6] Drive's §Pre-flight explicitly orders /loop preferred, /check-in fallback, neither → error — with /loop named first in prose (not a coin-flip or alphabetical order). | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Read §Pre-flight in claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md. Confirm the scheduler-selection ordering is explicit and stated as: /loop is preferred when available; /check-in is used only when /loop is unavailable; neither → error. The order must not be ambiguous or reversible from the text. Pass = ordering is stated explicitly."
+  ```
+
+### Deliverable 3: README + plugin metadata
+
+Scope: `claude-plugins/manifest-dev-experimental/README.md` and `claude-plugins/manifest-dev-experimental/.claude-plugin/plugin.json`.
+
+**Acceptance Criteria:**
+
+- [AC-3.1] README's "What it ships" section mentions `/check-in` with a one-sentence summary of its fallback role. | Verify: bash.
+  ```yaml
+  verify:
+    method: bash
+    command: "awk '/## What it ships/,/## Mode matrix/' claude-plugins/manifest-dev-experimental/README.md | grep -E -q '/check-in' && echo pass || (echo fail; exit 1)"
+  ```
+
+- [AC-3.2] README's "Dependencies checked before bootstrap" section updated: the `/loop skill` bullet expanded to "`/loop` OR `/check-in`" with a note that `/loop` is preferred. | Verify: bash.
+  ```yaml
+  verify:
+    method: bash
+    command: "awk '/## Dependencies/,/## Recommended/' claude-plugins/manifest-dev-experimental/README.md | grep -E -q '/check-in' && echo pass || (echo fail; exit 1)"
+  ```
+
+- [AC-3.3] README's "Gotchas" section includes a bullet that (a) names `/check-in`, (b) describes blocking-session semantics (session close ends the loop immediately, no background cron), (c) contrasts with `/loop`'s fire-and-forget behaviour. | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Read the Gotchas section of claude-plugins/manifest-dev-experimental/README.md. Confirm a bullet exists that (a) names /check-in, (b) describes session-blocking / session-end-kills-loop semantics, (c) contrasts with /loop's cron/background behaviour. All three must be present. Pass = all three."
+  ```
+
+- [AC-3.4] plugin.json version bumped to `0.5.0`; keywords array includes both `check-in` and `fallback`. | Verify: bash.
+  ```yaml
+  verify:
+    method: bash
+    command: "python3 -c \"import json; d=json.load(open('claude-plugins/manifest-dev-experimental/.claude-plugin/plugin.json')); assert d['version']=='0.5.0', d['version']; kw=d.get('keywords',[]); assert 'check-in' in kw and 'fallback' in kw, kw; print('pass')\""
+  ```
+
+- [AC-3.5] plugin.json description mentions `/check-in` fallback in a single clause (keeps the one-liner under ~240 chars). | Verify: bash.
+  ```yaml
+  verify:
+    method: bash
+    command: "python3 -c \"import json; d=json.load(open('claude-plugins/manifest-dev-experimental/.claude-plugin/plugin.json')); desc=d['description']; assert 'check-in' in desc, 'no check-in in desc'; assert len(desc)<=280, f'desc too long: {len(desc)}'; print('pass:',len(desc),'chars')\""
+  ```
+
+- [AC-3.6] No other README in the repo is stale because of this change. | Verify: subagent.
+  ```yaml
+  verify:
+    method: subagent
+    agent: docs-reviewer
+    prompt: "Audit README.md at repo root and claude-plugins/README.md for mentions of /drive, /loop, or the experimental plugin's dependencies. The change in this PR adds a /check-in fallback to the experimental plugin. Report any stale references that contradict the new state — 'dependencies: /loop only' phrasing, missing /check-in mentions where drive's scheduler list is enumerated, etc. Pass = either no drift or no dependency enumerations exist in those files."
+  ```
+
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,10 @@
 
 manifest-dev marketplace -- verification-first manifest workflows for Claude Code, with agents, skills, and hooks.
 
+## Output Style
+
+Write long outputs (manifests, docs, multi-section files) **incrementally in chunks** rather than one massive Write call. Use an initial Write to create the file with the first section, then Edit to append subsequent sections. Keeps context usage bounded and makes progress visible.
+
 ## Development Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ The Claude Code plugin is the source of truth. Per-CLI distributions under `dist
 |--------|-------------|
 | `manifest-dev` | Core manifest workflows: `/define`, `/do`, `/verify`, `/tend-pr`, review agents, workflow hooks. Mid-execution manifest amendments via `--amend` flag and UserPromptSubmit hook. |
 | `manifest-dev-tools` | Post-processing utilities for manifest workflows. `/adr` synthesizes Architecture Decision Records from session transcripts via multi-agent extraction pipeline. |
-| `manifest-dev-experimental` | **Experimental.** Cron-driven, tick-based manifest runner (`/drive` + `/drive-tick`) with pluggable platform (`none`, `github`) and sink (`local`) adapters. Takes a manifest (or PR in babysit mode) to a terminal state via repeated stateless ticks — cross-tick convergence replaces `/do`'s internal fix-verify-loop hooks. Coexists with `manifest-dev`; nothing deprecated. |
+| `manifest-dev-experimental` | **Experimental.** Tick-based manifest runner (`/drive` + `/drive-tick`) with `/check-in` as a blocking-session fallback scheduler when `/loop` is not installed. Pluggable platform (`none`, `github`) and sink (`local`) adapters. Takes a manifest (or PR in babysit mode) to a terminal state via repeated stateless ticks — cross-tick convergence replaces `/do`'s internal fix-verify-loop hooks. Coexists with `manifest-dev`; nothing deprecated. |
 
 ## Plugin Architecture
 

--- a/claude-plugins/README.md
+++ b/claude-plugins/README.md
@@ -16,7 +16,7 @@ Front-load the thinking so AI agents get it right the first time.
 |--------|--------------|
 | [`manifest-dev`](./manifest-dev) | Verification-first manifest workflows with phased verification (fast checks first, e2e/deploy-dependent later) and multi-CLI distribution (Gemini CLI, OpenCode, Codex CLI). Every criterion has explicit verification; execution can't stop without verification passing or escalation. |
 | [`manifest-dev-tools`](./manifest-dev-tools) | Post-processing utilities for manifest workflows. `/adr` synthesizes Architecture Decision Records from session transcripts. |
-| [`manifest-dev-experimental`](./manifest-dev-experimental) | **Experimental.** Cron-driven, tick-based manifest runner (`/drive` + `/drive-tick`) with pluggable platform (`none`, `github`) and sink (`local`) adapters. Wide stateless ticks, cross-tick convergence, no flow-control hooks. Coexists with `manifest-dev` — nothing deprecated. |
+| [`manifest-dev-experimental`](./manifest-dev-experimental) | **Experimental.** Tick-based manifest runner (`/drive` + `/drive-tick`) with `/check-in` as a blocking-session fallback scheduler when `/loop` is not installed. Pluggable platform (`none`, `github`) and sink (`local`) adapters. Wide stateless ticks, cross-tick convergence, no flow-control hooks. Coexists with `manifest-dev` — nothing deprecated. |
 
 ## Plugin Details
 
@@ -53,8 +53,9 @@ Post-processing utilities that operate on the outputs of the manifest workflow.
 **Experimental** alternative to `/do` + `/tend-pr`. Cron-driven tick loop with pluggable platform and sink adapters.
 
 **Skills:**
-- `/drive` - Wrapper that parses args, resolves base branch, pre-flights `/loop`, bootstraps branch/commit/PR (github mode), then hands control to `/loop` for repeated `/drive-tick` invocations.
+- `/drive` - Wrapper that parses args, resolves base branch, pre-flights the scheduler (`/loop` preferred, `/check-in` fallback) and `manifest-dev` skills, bootstraps branch/commit/PR (github mode), then hands control to the scheduler for repeated `/drive-tick` invocations.
 - `/drive-tick` - The per-iteration brain. Reads full log (memento), loads platform + sink adapters, checks terminal states, handles inbox, implements inline, verifies via `manifest-dev:verify`, fixes, amends if scope shifts, commits, and returns for the next scheduled iteration — or ends on terminal state / budget exhaust.
+- `/check-in` - Blocking, same-session fallback scheduler. Auto-selected by `/drive` when `/loop` is not installed. Sleeps the interval in chunks, invokes `/drive-tick`, reads the log file to detect terminal state, and either exits or re-loops. Trades `/loop`'s background cron for blocking-session determinism.
 
 **Adapters:**
 - Platforms: `none` (local branch only), `github` (PR bootstrap + tend — preserves `tend-pr-tick`'s classification, CI triage, PR sync, thread resolution, and merge-ready semantics adapted to the adapter contract).

--- a/claude-plugins/manifest-dev-experimental/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev-experimental/.claude-plugin/plugin.json
@@ -1,11 +1,13 @@
 {
   "name": "manifest-dev-experimental",
-  "version": "0.4.0",
-  "description": "Experimental tick-based cron-driven manifest runner. Ships /drive + /drive-tick: a stateless, wide-tick driver that takes a manifest (or PR in babysit mode) to a terminal state through pluggable platform and sink adapters. Coexists with manifest-dev — nothing deprecated.",
+  "version": "0.5.0",
+  "description": "Experimental cron-driven manifest runner. Ships /drive + /drive-tick + /check-in fallback (auto-selected when /loop is unavailable). Stateless, wide-tick driver taking a manifest or PR to a terminal state through pluggable platforms and sinks.",
   "keywords": [
     "drive",
     "tick",
     "loop",
+    "check-in",
+    "fallback",
     "autonomous",
     "experimental",
     "manifest",

--- a/claude-plugins/manifest-dev-experimental/README.md
+++ b/claude-plugins/manifest-dev-experimental/README.md
@@ -6,8 +6,9 @@ Cron-driven, tick-based driver that takes a manifest (or PR in babysit mode) all
 
 ## What it ships
 
-- **`/drive`** — user-invocable wrapper. Parses args, validates mode, resolves base branch, pre-flights `/loop`, `manifest-dev`, and stale locks, bootstraps (branch + empty commit + PR for github; branch + empty commit for none), then kicks off `/loop`.
+- **`/drive`** — user-invocable wrapper. Parses args, validates mode, resolves base branch, pre-flights the scheduler (`/loop` preferred, `/check-in` as fallback), `manifest-dev`, and stale locks, bootstraps (branch + empty commit + PR for github; branch + empty commit for none), then kicks off the chosen scheduler.
 - **`/drive-tick`** — the per-iteration brain. Lean orchestration. Each tick: grab lock, read the full execution log (memento), read state via platform adapter, check terminal states, handle inbox (amendments — no inline code edits), invoke `/do` for the full manifest-convergence loop, run CI triage + tend PR via the adapter, and either return for the next scheduled iteration or end on terminal state or budget exhaust.
+- **`/check-in`** — blocking, same-session fallback scheduler. Automatically selected by `/drive` when `/loop` is not installed. Sleeps the interval in upfront-computed chunks (≤9m each to stay under the Bash tool cap), invokes `/drive-tick`, reads the log file to detect terminal state, and either exits or re-loops. Trades `/loop`'s background cron for blocking-session determinism; install `/loop` for fire-and-forget.
 - **Pluggable adapters** — `skills/drive/references/platforms/{none,github}.md` and `skills/drive/references/sinks/local.md` follow a consistent markdown-state-report contract. Adding a new platform or sink is a copy-and-adjust.
 
 ## Mode matrix
@@ -84,7 +85,7 @@ If `/drive` proves out, a later manifest can deprecate the overlapping skills. F
 
 `/drive` performs pre-flight checks before any branch/commit/push/PR side effects. It errors actionably if any of these are missing:
 
-- **`/loop` skill** — the cron scheduler that invokes `/drive-tick` on the configured interval.
+- **Scheduler: `/loop` OR `/check-in`** — `/drive` selects `/loop` when available (background cron, non-blocking); otherwise falls back to `/check-in` (blocking, same-session). Neither installed → `/drive` errors out in pre-flight. `/loop` is preferred because its cron survives session close; `/check-in` is a lighter-weight fallback for environments where `/loop` is not installed.
 - **`manifest-dev:do`, `manifest-dev:verify`, and `manifest-dev:define`** — `/do` runs the full verify-fix loop per tick; `/verify` backs it; `/define --amend --from-do` handles mid-tick manifest amendments.
 - **GitHub MCP tools** (when `--platform github`) — for PR create/read/comment operations.
 - **`/tmp/` persistence across sessions** — the tick reads its log from `/tmp/drive-log-{run-id}.md` on every wake (same assumption `tend-pr-tick` relies on).
@@ -126,6 +127,7 @@ Adjust to your workflow. These are **not enforced by the plugin** — they're Cl
 ## Gotchas
 
 - **`/loop` reliability is outside the plugin's control.** If the cron host sleeps or the Claude Code session ends, ticks stop. No recovery.
+- **`/check-in` fallback is blocking and session-bound.** When `/drive` falls back to `/check-in` (because `/loop` is not installed), the scheduler runs inside the Claude Code session as a blocking Skill invocation — not a background cron. Closing the session ends the loop immediately; there is no resumption mechanism. This is a strictly weaker guarantee than `/loop`'s cron-backed scheduling; install `/loop` for fire-and-forget behaviour.
 - **Stale locks require manual cleanup.** Locks have no TTL — a crashed or interrupted tick leaves its lock behind. The next `/drive` run halts with the lock path + timestamp + manual-removal instructions. Never auto-cleared; the user confirms no live tick exists before removing.
 - **Lock TOCTOU.** Two ticks may race on lock creation and both think they acquired. The tick re-verifies lock ownership immediately after creation (reads back PID/timestamp); mismatch → exit silently. Rare duplicate work is possible.
 - **Crash recovery keeps WIP.** If a prior tick crashed mid-implementation, uncommitted working-tree changes persist. The next tick commits them if the last log entry is consistent with the WIP shape; otherwise it logs a manual-review flag and exits. Never force-resets.

--- a/claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md
+++ b/claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md
@@ -27,7 +27,7 @@ Substitute for `/loop` when it is not installed. Drives `/drive-tick` from a sin
 2. Record `last_seen_header` = the last `## Tick N — …` line already in `<log-path>` at entry (null if none).
 3. Set `empty_count = 0`.
 4. Loop:
-   - Sleep: issue `chunks - 1` sequential `sleep 540` Bash calls, then one `sleep <remainder>` for the final chunk. Cumulative — drift is acceptable.
+   - Sleep: issue `chunks - 1` sequential `sleep 540` Bash calls, then one final `sleep <remainder>` where `remainder = interval_seconds - (chunks - 1) * 540` (always in the range `1..540`, never zero — `ceil` guarantees this). Cumulative — drift is acceptable.
    - Invoke `<command>` via the Skill tool. If the Skill tool itself errors, times out, or crashes (NOT the normal case of drive-tick completing and writing a log entry), exit fail-loud. No retry.
    - Read `<log-path>`. Find the last line matching `^## Tick N — ` or `^## BUDGET EXHAUSTED`.
    - If no match, OR the match is not strictly newer than `last_seen_header`: `empty_count += 1`. If `empty_count >= 2`, exit fail-loud (drive-tick produced no new outcome for two consecutive iterations). Otherwise re-loop — ONE grace iteration for first-tick init races.

--- a/claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md
+++ b/claude-plugins/manifest-dev-experimental/skills/check-in/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: check-in
+description: 'Blocking, same-session fallback scheduler for /drive when /loop is not installed. Takes <interval> <log-path> <command>, sleeps the interval (chunked ≤9m to stay under the Bash tool cap), invokes the command via the Skill tool, reads the log file to find the most recent drive-tick outcome header, and either exits (Terminal / Error / BUDGET EXHAUSTED) or re-loops (Continuing / Skipped). Trades /loop''s background cron for blocking-session determinism. Use when /drive pre-flight selects it because /loop is unavailable. Triggers: check-in, fallback scheduler, sleep and invoke, loop without loop, drive without cron.'
+user-invocable: true
+---
+
+# /check-in — Blocking Fallback Scheduler
+
+Substitute for `/loop` when it is not installed. Drives `/drive-tick` from a single blocking Skill invocation.
+
+## Args
+
+`<interval> <log-path> <command>` — three positional args, required.
+
+- `<interval>`: `15m`–`24h` inclusive.
+- `<log-path>`: absolute path to drive's execution log.
+- `<command>`: invoked verbatim via the Skill tool — no shell expansion, no re-parsing.
+
+### Errors
+
+- Missing/empty args → `Usage: /check-in <interval> <log-path> <command>`.
+- `<interval>` unparseable or out of range → `Interval '<value>' out of range. Must be between 15m and 24h.`
+
+## Flow
+
+1. Parse `<interval>` to seconds. Compute `chunks = ceil(interval_seconds / 540)` upfront.
+2. Record `last_seen_header` = the last `## Tick N — …` line already in `<log-path>` at entry (null if none).
+3. Set `empty_count = 0`.
+4. Loop:
+   - Sleep: issue `chunks - 1` sequential `sleep 540` Bash calls, then one `sleep <remainder>` for the final chunk. Cumulative — drift is acceptable.
+   - Invoke `<command>` via the Skill tool. If the Skill tool itself errors, times out, or crashes (NOT the normal case of drive-tick completing and writing a log entry), exit fail-loud. No retry.
+   - Read `<log-path>`. Find the last line matching `^## Tick N — ` or `^## BUDGET EXHAUSTED`.
+   - If no match, OR the match is not strictly newer than `last_seen_header`: `empty_count += 1`. If `empty_count >= 2`, exit fail-loud (drive-tick produced no new outcome for two consecutive iterations). Otherwise re-loop — ONE grace iteration for first-tick init races.
+   - Otherwise update `last_seen_header`, set `empty_count = 0`, classify:
+     - `## Tick N — Terminal:` / `## Tick N — Error:` / `## BUDGET EXHAUSTED` → exit.
+     - `## Tick N — Continuing` / `## Tick N — Skipped (lock held)` → re-loop.
+     - Any other header (none of the five anchors) → exit fail-loud. Never silently continue.
+
+## Terminal markers (verbatim — em-dash U+2014, not hyphen)
+
+- `## Tick N — Terminal:` (terminal)
+- `## Tick N — Error:` (terminal)
+- `## BUDGET EXHAUSTED` (terminal)
+- `## Tick N — Continuing` (continuing)
+- `## Tick N — Skipped (lock held)` (continuing)
+
+Authored by drive-tick's Output Protocol; `/check-in` must match them byte-for-byte.
+
+## Gotchas
+
+- **Blocking session.** Closing the Claude Code session stops the loop immediately — no background cron. Install `/loop` for fire-and-forget.
+- **Log file is the contract.** drive-tick writes outcomes to `<log-path>`, not to its Skill-tool response. `/check-in` ignores the response text.
+- **Chunked-sleep drift.** Per-chunk tool overhead adds <1% over the minimum interval. Interval is a floor, not a precise cadence.

--- a/claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md
+++ b/claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md
@@ -44,7 +44,7 @@ Coexists with `/do`, `/tend-pr`, `/auto` — does not replace them.
 
 All pre-flight checks run BEFORE any branch creation, commit, push, or PR operation. If any check fails, the wrapper errors actionably and exits without modifying repository state.
 
-- **`/loop` available.** Error: "/loop skill not found — ensure a loop provider is installed."
+- **Scheduler available.** Select in this order: `/loop` preferred when installed (background cron, non-blocking); else `/check-in` as a fallback (blocking, same-session — warn the user during the run summary); else error. The order is deterministic — `/loop` first, `/check-in` only when `/loop` is missing. Error when neither is available: "No scheduler installed — /drive requires either /loop (background cron) or /check-in (blocking fallback). Install one of them."
 - **`manifest-dev:do`, `manifest-dev:verify`, and `manifest-dev:define` available** (drive-tick invokes `manifest-dev:do` directly and `manifest-dev:define --amend` during Amendment; `manifest-dev:verify` is required transitively by `/do`). Error: "manifest-dev skills not found — /drive requires manifest-dev."
 - **Inside a git repo.** Error: "Not inside a git repository."
 - **Manifest mode: manifest file readable and parseable** as a `manifest-dev:define` manifest. Error: "Manifest not found, unreadable, or malformed: <path>"
@@ -99,21 +99,36 @@ Create `/tmp/drive-log-{run-id}.md` if it does not already exist. If it does exi
 
 Seed header includes: manifest path, mode (manifest|babysit), platform, sink, base branch, current branch, PR number (if github), interval, max-ticks, run-id, timestamp.
 
-## /loop Kickoff
+## Scheduler Kickoff
 
-After all pre-flight, bootstrap, and log initialization succeed, invoke `/loop` with the configured interval and `/drive-tick` plus its flag-based arguments:
+After all pre-flight, bootstrap, and log initialization succeed, invoke the chosen scheduler. The invocation string is parameterised on the scheduler resolved during pre-flight.
+
+**When `/loop` is the chosen scheduler** (preferred):
 
 ```
 Invoke the /loop skill with: "<interval> /drive-tick --run-id <run-id> --mode <mode> --platform <platform> --sink <sink> --log <log-path> --max-ticks <N> [--manifest <manifest-path>] [--pr <pr-number>]"
 ```
 
-Include `--manifest` only in manifest mode; include `--pr` only when platform is github. Then exit — `/drive` does not wait for tick completion.
+**When `/check-in` is the chosen scheduler** (fallback, blocking):
 
-Print a run summary to the terminal: run-id, mode, platform, sink, interval, budget, branch, PR number (github mode only), log path, and a `tail -f` hint for observing progress. `/drive` exits after kickoff; ongoing work happens in scheduled `/drive-tick` invocations.
+```
+Invoke the /check-in skill with: "<interval> <log-path> /drive-tick --run-id <run-id> --mode <mode> --platform <platform> --sink <sink> --log <log-path> --max-ticks <N> [--manifest <manifest-path>] [--pr <pr-number>]"
+```
+
+The drive-tick arg string is identical between the two; `/check-in` takes one extra positional arg (`<log-path>`) upfront because it reads terminal state from the log file rather than from drive-tick's response.
+
+Include `--manifest` only in manifest mode; include `--pr` only when platform is github.
+
+With `/loop`: then exit — `/drive` does not wait for tick completion (background cron).
+
+With `/check-in`: `/drive` remains blocked for the duration of the run — the session holds the scheduler. Closing the session ends the run immediately.
+
+Print a run summary to the terminal: `scheduler: /loop` or `scheduler: /check-in` (new), run-id, mode, platform, sink, interval, budget, branch, PR number (github mode only), log path, and a `tail -f` hint for observing progress. When `/check-in` was chosen, also print a one-line warning that the session will block for the duration of the run.
 
 ## Gotchas
 
 - **`/loop` reliability is outside /drive's control.** If cron stops firing (session ends, host sleeps), ticks stop. No automatic recovery — the log will go stale. Re-invoke `/drive` to resume. The tick is designed to pick up from log state.
+- **`/check-in` fallback is blocking and session-bound.** When `/drive` falls back to `/check-in` (because `/loop` is not installed), the scheduler runs inside the Claude Code session as a blocking Skill invocation. Closing the session kills the scheduler immediately — there is no background cron. This is a documented weaker guarantee than `/loop`; install `/loop` for fire-and-forget behaviour.
 - **Base branch auto-detection can fail** on repos with unusual configurations (detached HEAD on remote, no `origin/HEAD`, no `main` branch). The error is explicit — no silent fallback to `master`. Pass `--base <branch>` to override.
 - **Stale lock after crash** — see §Pre-flight.
 - **Run-id collision mitigations.** Github-mode run-ids are qualified by repo owner/name to avoid collision when `/tmp` is shared across multiple repositories with overlapping PR numbers. None-mode run-ids include a 4-char random suffix to avoid collision when two none-mode runs start within the same second.


### PR DESCRIPTION
## Summary

- New `/check-in` skill in `manifest-dev-experimental`: a blocking, same-session fallback scheduler that substitutes for `/loop` when it is not installed. Sleeps the interval in upfront-computed chunks (≤9m each to stay under the Bash tool cap), invokes `/drive-tick`, reads the log file to detect terminal state, and either exits or re-loops.
- `/drive` pre-flight now selects a scheduler in deterministic order: `/loop` preferred, `/check-in` as fallback, error when neither is installed. Existing `/loop` behaviour is byte-equivalent to today when `/loop` is available.
- `/drive-tick` is unchanged — scheduler swap is invisible to the tick. Terminal-state markers are read from the log file (not the Skill-tool response), matching drive-tick's Output Protocol contract.

## Architecture

```
/drive  →  pre-flight  ─┬─→ /loop available?     ── yes ──→ kick off /loop (unchanged)
                        └─→ /check-in available? ── yes ──→ kick off /check-in (fallback)
                        └─→ neither?             ── yes ──→ error (names both, actionable)

/check-in  (blocking, same session)
    loop: sleep(chunked) → Skill /drive-tick → read log file → classify last "## Tick N —" header
                                                               ├─ Terminal/Error/BUDGET → exit
                                                               ├─ Continuing/Skipped    → loop
                                                               └─ unknown/absent×2      → fail-loud
```

## Guardrails

- Terminal-marker strings pinned verbatim — em-dash `—` (U+2014), not hyphen.
- Fail-loud on unrecognized markers, Skill-tool errors, and two-consecutive-iteration log silence. Never silently loops.
- Plugin version bumped 0.4.0 → 0.5.0 (minor, new feature). README sync for experimental README, claude-plugins README, and root README.

## Test plan

- [ ] Install `manifest-dev-experimental` in an environment without `/loop` — confirm `/drive` falls back to `/check-in` and the run summary prints `scheduler: /check-in` with the blocking-session warning.
- [ ] Install both `/loop` and `/check-in` — confirm `/drive` chooses `/loop` (unchanged behaviour).
- [ ] Uninstall both — confirm `/drive` errors with the "No scheduler installed — …" message naming both skills.
- [ ] Run a short manifest through `/check-in` fallback with a 15m interval — confirm chunked sleep, log-file-based terminal detection, and loop exit on drive-tick Terminal.
- [ ] Induce a stale `## Tick N — Terminal:` header left over from a prior crashed run — confirm `/check-in` ignores it (last-seen tracking) and waits for a strictly newer header.

Manifest: `.manifest/add-check-in-fallback-scheduler-2026-04-24.md`

https://claude.ai/code/session_018V6m49ZGLYGzDYfyPGdkLq

---
_Generated by [Claude Code](https://claude.ai/code/session_018V6m49ZGLYGzDYfyPGdkLq)_