### PR TITLE
feat(verify): make context-reading expectation explicit in skill

### DIFF
--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.89.0",
+  "version": "0.89.1",
   "description": "Manifest-driven workflows for structured task execution with verification gates.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/skills/verify/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/verify/SKILL.md
@@ -18,6 +18,7 @@ Both paths required — return usage error if missing. Mode defaults to `thoroug
 
 | Principle | Rule |
 |-----------|------|
+| **Context before spawning** | Read manifest and execution log before spawning verifiers — criterion IDs and prompts drive agent composition. |
 | **Orchestrate, don't verify** | Spawn agents to verify. You aggregate results and coordinate, never run checks yourself. |
 | **ALL criteria, no exceptions** | Every INV-G* and AC-*.* criterion MUST be verified. Skipping any criterion is a critical failure. |
 | **Parallelism per mode** | The active execution mode defines how many verifiers to launch concurrently within each phase. Phases always run sequentially — see Phased Execution below. |


### PR DESCRIPTION
## Summary

- Add a Principles row to `/verify` SKILL.md stating that the manifest and execution log are read before spawning verifiers.
- Previously this expectation was carried by the `pretool_verify_hook` re-injection — not portable to harnesses without hook support. The skill text now carries the semantics.
- Hook stays untouched as a safety net for attention decay on current models.
- Plugin version bumped 0.89.0 → 0.89.1 (clarity fix).

## Background

This came out of a `/figure-out` session on whether the manifest-dev process can be adhered to reliably without hooks (for portability to non-Claude-Code harnesses). The audit found 6 of 7 hooks are pure reminders whose semantics already live in the skills, and 1 hook (`stop_do_hook`) does real enforcement that prompts can't replicate.

The one genuine prompt-engineering gap surfaced: `/verify` declares input paths but never states that the orchestrator reads them. This PR closes that single gap. Other reminder-hook content was intentionally not duplicated into skills — under prompt-engineering principles, that would be over-engineering.

## Test plan

- [x] `change-intent-reviewer` — no LOW+ issues (intent achieved cleanly)
- [x] `prompt-reviewer` (scoped to diff) — no MEDIUM+ issues introduced
- [x] WHAT-not-HOW check — phrasing is discipline-level, not tool-prescriptive
- [x] No contradiction with `/do`'s "Refresh before verify" — caller-side vs orchestrator-side, complementary
- [x] Diff scope — only `verify/SKILL.md` (+1 line) and `plugin.json` (version bump)
- [x] `pretool_verify_hook.py` unchanged

## Follow-up

`prompt-reviewer` flagged 5 pre-existing MEDIUM issues in `/verify` SKILL.md during the broader scan (manual routing inconsistency, "no exceptions" vs mode-skip behavior, undocumented framing exceptions, table precedence ambiguity, grouping order ambiguity). Out of scope here; worth a separate PR.

https://claude.ai/code/session_015McNufnMYVKz8rsp2SMuxV

---
_Generated by [Claude Code](https://claude.ai/code/session_015McNufnMYVKz8rsp2SMuxV)_