### PR TITLE
Add a proper session reference to the /define output

### DIFF
--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.93.0",
+  "version": "0.93.1",
   "description": "Manifest-driven workflows for structured task execution with verification gates. Supports multi-repo changesets via a shared canonical manifest.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/skills/define/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/define/SKILL.md
@@ -527,6 +527,7 @@ The medium is encoded in the manifest's Intent section as `Medium: <value>` so d
 
 ```text
 Manifest complete: /tmp/manifest-{timestamp}.md
+Session: ~/.claude/projects/<dir>/${CLAUDE_SESSION_ID}.jsonl
 
 To execute: /do /tmp/manifest-{timestamp}.md [log-file-path if iterating]
 ```


### PR DESCRIPTION
Re-add the session path removed in 5a9eed6, this time with a token-free approach.

### Tested:

```none
● Manifest complete: /tmp/manifest-example-skeleton.md          
  Session: ~/.claude/projects/-home-USER-repositories-manifest-dev/9de617a0-54bb-4342-b0ed-3c9cdc3
  b4872.jsonl
                                                                                                   
  Discovery log: /tmp/define-discovery-manifest-example.md
                                                                                                   
  To execute: /do /tmp/manifest-example-skeleton.md         

  /define is complete. Your minimal example manifest is ready for testing and validation.  
```