### PR TITLE
feat(define): default to amending prior in-session manifest

### DIFF
--- a/.manifest/in-session-default-amendment-2026-04-26.md
+++ b/.manifest/in-session-default-amendment-2026-04-26.md
@@ -1,0 +1,222 @@
+# Definition: In-Session Default Amendment for /define
+
+## 1. Intent & Context
+- **Goal:** When `/define` is invoked again in the same session and a prior manifest exists, default to amending that manifest. Only fall back to a fresh manifest when the new task is *truly* unrelated (rare). Outcome: one manifest per change set, so follow-up tasks (bug fixes, feature extensions, polish on the same surface) inherit and respect the prior INVs/ACs/PGs — preventing silent regression of earlier constraints.
+- **Mental Model:** The manifest is the change-set's constitution. Today, every `/define` starts from scratch — so a bug-fix or follow-up tweak runs without the original task's invariants in scope, and can quietly undo decisions the user already made. Defaulting to amendment carries the constitution forward. The agent does the relatedness judgment using prior manifest's Goal + Deliverables vs. the new task description, with a strong bias to amend (relatedness is the default; only clear domain mismatch → fresh).
+- **Mode:** thorough
+- **Interview:** thorough
+- **Medium:** local
+
+## 2. Approach
+*Initial direction. SKILL.md-only change; instructions, no hook, no util, no flag.*
+
+- **Architecture:**
+  - Add a new standalone **"Session-Default Amendment"** section to `claude-plugins/manifest-dev/skills/define/SKILL.md`, positioned immediately AFTER the "Input" section and BEFORE the existing "Amendment Mode" section (so the explicit `--amend` flag check still happens first and short-circuits the session check; new section sits between Input and Amendment Mode).
+  - The section instructs the agent to: (a) at the start of every `/define`, scan its own conversation context for prior `/define` completion outputs of the form `Manifest complete: /tmp/manifest-{timestamp}.md`; (b) if found and `--amend` was not explicitly passed, read the most recent prior manifest and compare its Goal + Deliverables against the new task description; (c) bias strongly toward "related" — only fresh when domain/surface is clearly different; (d) when amending, announce one line to the user with an explicit invitation to redirect; (e) when the prior manifest file no longer exists or cannot be read, fall back to fresh with a brief note.
+  - Update `references/AMENDMENT_MODE.md` to add a third trigger context: **"Session-Default"** — same behavior as Standalone, but the trigger is `/define`'s in-session detection rather than an explicit `--amend` flag.
+  - Bump plugin version (minor — new feature) and update root + plugin READMEs with a one-line mention.
+  - `/auto` requires no changes — it invokes `/define` via Skill tool, so the new SKILL.md instructions execute inside the `/auto` flow automatically.
+
+- **Execution Order:**
+  - D1 (SKILL.md instructions) → D2 (AMENDMENT_MODE.md context update) → D3 (version bump + README sync)
+  - Rationale: D1 is the load-bearing change. D2 documents the new trigger so amendment-mode behavior reads coherently. D3 is housekeeping per CLAUDE.md sync checklist.
+
+- **Risk Areas:**
+  - [R-1] Conversation compaction may evict the prior `Manifest complete: ...` line, causing /define to miss the amendment target | Detect: post-compaction /define behavior — agent treats the session as fresh. Acceptable per ASM-2; user can re-amend with explicit `--amend <path>`.
+  - [R-2] Agent misjudges "related" and amends an unrelated manifest | Detect: user redirects after the announcement. Mitigation: announcement always offers the opt-out path.
+  - [R-3] Prior manifest file deleted/moved from /tmp/ between invocations | Detect: amendment read fails. Mitigation: AC-1.6 requires graceful fallback to fresh with note.
+  - [R-4] Agent biases too aggressively toward "fresh" because the new task description doesn't lexically match the prior one — losing the regression-prevention benefit the user wants | Detect: change-intent-reviewer cross-checks the section's wording for "amend by default; fresh only when domain is clearly different". Mitigation: encode the bias explicitly in SKILL.md prose (INV-G7).
+
+- **Trade-offs:**
+  - [T-1] User surprise vs. friction → Prefer brief one-line announcement over silent or confirmation-gated, because users need a redirect lever without per-invocation prompts.
+  - [T-2] Determinism (hook/flag) vs. simplicity (instructions only) → Prefer simplicity per user direction; agent already has its conversation context and can reason about it.
+  - [T-3] Strong amend-bias (regression prevention) vs. precise relatedness judgment → Prefer strong amend-bias; "truly unrelated" is the only reason to start fresh, per user.
+
+## 3. Global Invariants
+
+- [INV-G1] change-intent-reviewer reports no LOW-or-higher findings on the SKILL.md + AMENDMENT_MODE.md changes
+  ```yaml
+  verify:
+    method: subagent
+    agent: change-intent-reviewer
+    model: inherit
+    prompt: "Review the changes to claude-plugins/manifest-dev/skills/define/SKILL.md and claude-plugins/manifest-dev/skills/define/references/AMENDMENT_MODE.md against this stated intent: when /define is invoked in a session that already has a prior manifest, default to amending that manifest (strong bias to amend; only start fresh when the new task is clearly unrelated to the prior manifest's Goal + Deliverables). Explicit --amend flag must continue to work as before. /do --from-do amendment path must remain unaffected. /auto must inherit the new default automatically because it invokes /define via Skill tool. Verify the prompt actually achieves these behaviors. Report LOW/MEDIUM/HIGH findings."
+  ```
+
+- [INV-G2] prompt-reviewer reports no MEDIUM-or-higher findings on the SKILL.md changes
+  ```yaml
+  verify:
+    method: subagent
+    agent: prompt-reviewer
+    model: inherit
+    prompt: "Review the new Session-Default Amendment section in claude-plugins/manifest-dev/skills/define/SKILL.md and any modified text in references/AMENDMENT_MODE.md. Check clarity, structure, anti-patterns (no prescribing HOW the model should scan its context, no arbitrary limits, no weak language), invocation fit (the section runs at the start of /define), composition with existing SKILL.md sections (Input parsing, Amendment Mode, Existing Manifest Feedback). Report MEDIUM/HIGH findings."
+  ```
+
+- [INV-G3] Explicit `--amend <path>` behavior is preserved end-to-end (standalone and `--from-do` paths unaffected)
+  ```yaml
+  verify:
+    method: subagent
+    agent: criteria-checker
+    model: inherit
+    prompt: "In claude-plugins/manifest-dev/skills/define/SKILL.md, verify the Input section still parses --amend (and --from-do) exactly as before, and that the new Session-Default Amendment section explicitly short-circuits when --amend is already present in arguments. PASS if both are true; FAIL otherwise."
+  ```
+
+- [INV-G4] When no prior manifest exists in the session context, /define behavior is unchanged from current
+  ```yaml
+  verify:
+    method: subagent
+    agent: criteria-checker
+    model: inherit
+    prompt: "In claude-plugins/manifest-dev/skills/define/SKILL.md's new Session-Default Amendment section, verify that the section explicitly states the no-prior-manifest case is treated as a fresh /define (current behavior preserved). PASS if explicit; FAIL if ambiguous or missing."
+  ```
+
+- [INV-G5] Hardlink integrity preserved between `claude-plugins/manifest-dev/skills/define/` files and their `.claude/skills/define/` counterparts (covers SKILL.md and references/AMENDMENT_MODE.md — both confirmed hardlinked)
+  ```yaml
+  verify:
+    method: bash
+    command: "for f in skills/define/SKILL.md skills/define/references/AMENDMENT_MODE.md; do a=\"claude-plugins/manifest-dev/$f\"; b=\".claude/$f\"; ai=$(stat -c %i \"$a\"); bi=$(stat -c %i \"$b\"); if [ \"$ai\" != \"$bi\" ]; then echo \"FAIL hardlink: $f\"; exit 1; fi; done; echo OK"
+  ```
+
+- [INV-G6] SKILL.md text expresses a strong bias toward amending (relatedness is the default; only "clearly different domain/surface" triggers fresh)
+  ```yaml
+  verify:
+    method: subagent
+    agent: criteria-checker
+    model: inherit
+    prompt: "In claude-plugins/manifest-dev/skills/define/SKILL.md's new Session-Default Amendment section, verify the relatedness rule is biased toward AMEND: amendment is the default; fresh requires clear evidence the new task targets a different domain or surface from the prior manifest's Goal + Deliverables. The wording must NOT read as a 50/50 judgment call. PASS if biased toward amend; FAIL if neutral or biased toward fresh."
+  ```
+
+## 4. Process Guidance
+
+- [PG-1] High-signal changes only — modify only the sections that implement the new default. Do not refactor surrounding sections of SKILL.md or AMENDMENT_MODE.md.
+- [PG-2] Calibrate emotional tone — the user-facing announcement should be calm and matter-of-fact ("Detected... Defaulting... Tell me if..."). No urgency, no apologetic hedging.
+- [PG-3] When editing SKILL.md or AMENDMENT_MODE.md, edit the `claude-plugins/manifest-dev/skills/define/...` canonical copy. The hardlink propagates to `.claude/skills/define/...`.
+- [PG-4] Discovery log lifecycle is unchanged — every /define invocation (fresh OR session-default amendment) creates its own `/tmp/define-discovery-{timestamp}.md`. Logs are not appended across invocations; the manifest itself is what carries forward.
+
+## 5. Known Assumptions
+
+- [ASM-1] "Most recent manifest" = the last `Manifest complete: /tmp/manifest-...md` line emitted in the transcript (transcript order, not path-timestamp order — handles the case where the user manually amended an older manifest mid-session) | Default: last-emitted-in-transcript | Impact if wrong: user redirects via the announcement opt-out, or invokes `/define --amend <other-path>` explicitly.
+- [ASM-2] Conversation compaction may evict the prior `Manifest complete: ...` line; in that case /define falls back to fresh | Default: accept | Impact if wrong: user invokes `/define --amend <path>` explicitly to recover.
+- [ASM-3] No explicit opt-out flag — verbal redirect after the announcement is the only override path | Default: agreed by user | Impact if wrong: a future change can add `--new` without breaking anything.
+- [ASM-4] Standalone `/define --amend` writes to a new `/tmp/manifest-{timestamp}.md` (or in-place — current behavior unchanged either way). The session-default path inherits whatever standalone amend currently does.
+
+## 6. Deliverables
+
+### Deliverable 1: Session-Default Amendment section in SKILL.md
+File: `claude-plugins/manifest-dev/skills/define/SKILL.md`
+
+**Acceptance Criteria:**
+
+- [AC-1.1] A new standalone section titled "Session-Default Amendment" exists in SKILL.md, positioned after the existing "Input" section and before the existing "Amendment Mode" section. It is a separate section, not merged into Amendment Mode.
+  ```yaml
+  verify:
+    method: bash
+    command: "python3 -c 'import re; t=open(\"claude-plugins/manifest-dev/skills/define/SKILL.md\").read(); pos={m.group(1): m.start() for m in re.finditer(r\"^## (.+)$\", t, re.M)}; assert \"Session-Default Amendment\" in pos, \"missing heading\"; assert \"Input\" in pos and \"Amendment Mode\" in pos, \"missing reference headings\"; assert pos[\"Input\"] < pos[\"Session-Default Amendment\"] < pos[\"Amendment Mode\"], \"wrong order\"; print(\"OK\")'"
+  ```
+
+- [AC-1.2] The new section instructs the agent to scan its own conversation context for prior `/define` completion outputs (lines matching `Manifest complete: /tmp/manifest-...md`) at the start of every invocation, BEFORE entering the interview. When multiple prior outputs exist, the most recent in transcript order wins.
+  ```yaml
+  verify:
+    method: subagent
+    agent: criteria-checker
+    model: inherit
+    prompt: "In the Session-Default Amendment section of claude-plugins/manifest-dev/skills/define/SKILL.md, verify the agent is told to: (1) check conversation context for prior /define manifest paths, (2) do this check at the start of every invocation BEFORE the interview, (3) when multiple priors exist pick the most recent in transcript order. PASS if all three are explicit; FAIL otherwise."
+  ```
+
+- [AC-1.3] The section instructs the agent to read the most recent prior manifest's Goal + Deliverables and compare against the new task description, with a strong bias toward amendment (only "truly unrelated / clearly different domain or surface" → fresh).
+  ```yaml
+  verify:
+    method: subagent
+    agent: criteria-checker
+    model: inherit
+    prompt: "In the Session-Default Amendment section of claude-plugins/manifest-dev/skills/define/SKILL.md, verify the relatedness check uses the prior manifest's Goal AND Deliverables as the comparison basis (not just title), and the wording biases strongly toward amend ('truly unrelated' / 'clearly different domain' style language). PASS if both; FAIL otherwise."
+  ```
+
+- [AC-1.4] When a prior manifest is found and the relatedness check passes, /define proceeds as if invoked with `--amend <prior-path>` (delegates to the existing AMENDMENT_MODE.md flow) and explicitly cross-references the new "Session-Default" trigger context in AMENDMENT_MODE.md.
+  ```yaml
+  verify:
+    method: subagent
+    agent: criteria-checker
+    model: inherit
+    prompt: "In the Session-Default Amendment section of claude-plugins/manifest-dev/skills/define/SKILL.md, verify that (1) on a positive relatedness match the agent reuses the existing --amend flow rather than reimplementing amendment logic, and (2) the section explicitly cross-references references/AMENDMENT_MODE.md (by name or path) for the actual amendment behavior. PASS if both; FAIL otherwise."
+  ```
+
+- [AC-1.5] The agent announces the decision to the user before starting the interview, in the form: "Detected prior manifest in session: <path> (<title>). Defaulting to amendment mode. Tell me if this is unrelated work and I'll start fresh." Or substantively equivalent: includes manifest path, title, the word "amendment", and an explicit redirect invitation. Announcement is emitted regardless of interview mode (autonomous included) — preserves audit trail in transcript.
+  ```yaml
+  verify:
+    method: subagent
+    agent: criteria-checker
+    model: inherit
+    prompt: "In the Session-Default Amendment section of claude-plugins/manifest-dev/skills/define/SKILL.md, verify the announcement instruction includes: (a) the prior manifest path, (b) its title or a brief identifier, (c) explicit mention of amendment mode, (d) an opt-out invitation the user can act on verbally, (e) explicit statement that the announcement is emitted regardless of interview mode (including autonomous). PASS if all five; FAIL otherwise."
+  ```
+
+- [AC-1.6] Explicit `--amend` flag in arguments short-circuits the session check (the explicit flag wins). This preserves /do --from-do path (which always passes --amend).
+  ```yaml
+  verify:
+    method: subagent
+    agent: criteria-checker
+    model: inherit
+    prompt: "In the Session-Default Amendment section of claude-plugins/manifest-dev/skills/define/SKILL.md, verify the section explicitly states that if --amend is already present in arguments, the session check is skipped. PASS if explicit; FAIL otherwise."
+  ```
+
+- [AC-1.7] When the prior manifest file no longer exists or cannot be read, /define falls back to fresh manifest creation with a brief one-line note to the user.
+  ```yaml
+  verify:
+    method: subagent
+    agent: criteria-checker
+    model: inherit
+    prompt: "In the Session-Default Amendment section of claude-plugins/manifest-dev/skills/define/SKILL.md, verify there is an explicit fallback rule for the case where the prior manifest path is no longer readable: fall back to fresh /define with a brief note to the user. PASS if explicit; FAIL otherwise."
+  ```
+
+- [AC-1.8] When the new task is determined to be truly unrelated, /define proceeds fresh and includes a one-line note explaining why (so the user can correct).
+  ```yaml
+  verify:
+    method: subagent
+    agent: criteria-checker
+    model: inherit
+    prompt: "In the Session-Default Amendment section of claude-plugins/manifest-dev/skills/define/SKILL.md, verify that on a 'truly unrelated' determination the agent proceeds fresh AND tells the user why in one line so they can correct. PASS if both; FAIL otherwise."
+  ```
+
+- [AC-1.9] When no prior `Manifest complete: ...` line is present in the conversation context, the section explicitly states /define behavior is unchanged from current (fresh manifest, no announcement).
+  ```yaml
+  verify:
+    method: subagent
+    agent: criteria-checker
+    model: inherit
+    prompt: "In the Session-Default Amendment section of claude-plugins/manifest-dev/skills/define/SKILL.md, verify the no-prior-manifest case is explicitly handled: the section says behavior is unchanged from a normal fresh /define and no announcement is emitted. PASS if explicit; FAIL otherwise."
+  ```
+
+### Deliverable 2: AMENDMENT_MODE.md notes the new trigger context
+File: `claude-plugins/manifest-dev/skills/define/references/AMENDMENT_MODE.md`
+
+**Acceptance Criteria:**
+
+- [AC-2.1] AMENDMENT_MODE.md adds (or revises an existing section to add) a third trigger context: "Session-Default" — explains that /define may auto-promote to amendment mode based on session context (no explicit `--amend` flag), and behaves identically to the Standalone interactive path from that point on. Existing "Standalone" and "From /do (Autonomous Fast Path)" descriptions remain accurate.
+  ```yaml
+  verify:
+    method: subagent
+    agent: criteria-checker
+    model: inherit
+    prompt: "In claude-plugins/manifest-dev/skills/define/references/AMENDMENT_MODE.md, verify there is a third trigger context covering session-default amendment. It must (a) describe the trigger as /define's in-session detection of a prior related manifest, (b) state behavior is identical to the Standalone interactive path, (c) leave the existing Standalone and From /do descriptions intact and accurate. PASS if all three; FAIL otherwise."
+  ```
+
+### Deliverable 3: Plugin version bump + README sync
+Files: `claude-plugins/manifest-dev/.claude-plugin/plugin.json`, `README.md` (root), `claude-plugins/manifest-dev/README.md`
+
+**Acceptance Criteria:**
+
+- [AC-3.1] `claude-plugins/manifest-dev/.claude-plugin/plugin.json` version bumped from 0.89.1 to 0.90.0 (minor — new feature).
+  ```yaml
+  verify:
+    method: bash
+    command: "python3 -c \"import json; v=json.load(open('claude-plugins/manifest-dev/.claude-plugin/plugin.json'))['version']; assert v == '0.90.0', f'expected 0.90.0, got {v}'; print('OK')\""
+  ```
+
+- [AC-3.2] Root `README.md` and `claude-plugins/manifest-dev/README.md` mention the new in-session default amendment behavior in the /define description (one line each, no detailed restatement). If the relevant README does not currently describe /define's per-invocation behavior at this level of detail, this AC is satisfied by adding a brief note where /define is described.
+  ```yaml
+  verify:
+    method: subagent
+    agent: criteria-checker
+    model: inherit
+    prompt: "Check README.md (repo root) and claude-plugins/manifest-dev/README.md. For each, locate the section that describes the /define skill. PASS if at least one of the READMEs mentions the in-session default amendment behavior in one line; FAIL if neither mentions it. If the READMEs don't describe /define's behavior at this granularity at all, PASS (the change doesn't warrant new sections)."
+  ```

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ The Claude Code plugin is the source of truth. Per-CLI distributions under `dist
 
 | Skill | Type | Description |
 |-------|------|-------------|
-| `/define` | User-invoked | Interviews you, classifies task type, probes for latent criteria, outputs manifest with verification methods |
+| `/define` | User-invoked | Interviews you, classifies task type, probes for latent criteria, outputs manifest with verification methods. When invoked again in the same session with a related task, defaults to amending the prior manifest so one change set keeps one constitution. |
 | `/do` | User-invoked | Executes against manifest. Follows execution order, watches for risks, logs progress for disaster recovery |
 | `/auto` | User-invoked | End-to-end autonomous: `/define --interview autonomous` → auto-approve → `/do`. Supports `--mode` and `--tend-pr` pass-through |
 | `/tend-pr` | User-invoked | Sets up PR for review and starts polling loop. Manifest-aware or babysit mode |

--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.89.1",
+  "version": "0.90.0",
   "description": "Manifest-driven workflows for structured task execution with verification gates.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/README.md
+++ b/claude-plugins/manifest-dev/README.md
@@ -103,7 +103,7 @@ Criteria verify blocks support an optional `phase:` field (numeric, default 1). 
 
 | Skill | Description |
 |-------|-------------|
-| `/define` | Interviews you, builds an executable manifest with verification criteria. `--interview minimal\|autonomous\|thorough` controls interview style (default: thorough). |
+| `/define` | Interviews you, builds an executable manifest with verification criteria. `--interview minimal\|autonomous\|thorough` controls interview style (default: thorough). When invoked again in the same session with a related task, defaults to amending the prior manifest so one change set keeps one constitution. |
 | `/do` | Works through the manifest autonomously, verifies everything passes |
 | `/auto` | End-to-end autonomous: `/define --interview autonomous` → auto-approve → `/do` in one command. Supports `--mode` and `--tend-pr` pass-through. |
 | `/tend-pr` | Sets up PR for review and starts a polling loop. Manifest-aware mode with scoped `/do`, or babysit mode without a manifest. |

--- a/claude-plugins/manifest-dev/skills/define/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/define/SKILL.md
@@ -36,6 +36,46 @@ Parse `--amend <manifest-path>` from arguments (can appear anywhere). `--from-do
 
 If no arguments provided, ask: "What would you like to build or change?"
 
+## Session-Default Amendment
+
+After parsing arguments (above) and before any other workflow step (Domain Guidance, interview, etc.), check whether this session already produced a manifest. The goal is **one manifest per related change set** — follow-up bug fixes, feature extensions, and polish on the same surface should accumulate criteria into the existing manifest rather than start over and silently lose prior INVs/ACs/PGs.
+
+**Skip this section entirely when the user has already pointed at a specific manifest.** Explicit signals always win over session-default detection:
+- `--amend <path>` was passed (preserves `/do --from-do`, which always passes `--amend`, and any explicit user `/define --amend <path>` invocation).
+- Input arguments contain a `/tmp/manifest-*.md` path or otherwise plainly point at a specific manifest file — proceed past this section and let the workflow reach **Existing Manifest Feedback** below, which already treats the referenced manifest as source of truth.
+
+**Otherwise**, determine whether a prior `/define` already completed in this session. The signal is `/define`'s own completion output — a line of the form `Manifest complete: /tmp/manifest-{timestamp}.md` (defined in the `## Complete` section below; this is the only cross-invocation signal that survives reliably across `/define` runs). If multiple such lines appear in the conversation context, the **most recent in transcript order wins** (this handles the case where the user manually amended an older manifest mid-session — transcript order, not the path's timestamp, is authoritative). If the conversation has been compacted and the signal is no longer accessible, you'll naturally land in the No Prior Manifest Found branch — proceed fresh; the user can recover with explicit `/define --amend <path>` if needed.
+
+### No Prior Manifest Found
+
+Behavior is unchanged from a normal fresh `/define`. No announcement is emitted. Proceed with the remaining workflow as written.
+
+### Prior Manifest Found
+
+Read the prior manifest at the matched path. Compare its **Goal** and **Deliverables** (titles and acceptance criteria) against the new task description.
+
+**Amendment is the default — not a 50/50 judgment call.** Operational test for "truly unrelated": the new task's intent does **not** extend, fix, or polish anything in the prior manifest's Goal + Deliverables — it targets a clearly different problem space. Truly unrelated work in the same session is rare; anything else — continuation, refinement, follow-up, polish, bug fix on something the prior manifest covered — is related and should amend. **When the test is genuinely ambiguous, default to amendment.** The asymmetry is intentional: the announcement gives the user a one-line escape hatch, while a wrong "fresh" decision silently loses prior INVs/ACs/PGs.
+
+#### When Related (default)
+
+Announce the decision to the user, then proceed as if `--amend <prior-path>` had been passed. Follow `references/AMENDMENT_MODE.md` from that point — the new "Session-Default" trigger context documented there describes this path; behavior follows the Standalone amendment flow, respecting the active interview mode (a `/auto` invocation, for example, still runs autonomously — only the trigger differs from explicit `--amend`).
+
+Announcement format (substantively):
+
+> Detected prior manifest in session: `/tmp/manifest-{ts}.md` (`<title from manifest's H1>`). Defaulting to amendment mode — interrupt me if this is actually unrelated work and I'll start fresh.
+
+Emit the announcement regardless of interview mode (including `--interview autonomous` and `/auto` invocations) — this preserves the audit trail in the transcript. The announcement is one line and non-blocking; the interview proceeds without waiting for confirmation. The "interrupt me" phrasing matches that behavior — the user can redirect mid-interview if needed.
+
+#### When Truly Unrelated
+
+Proceed fresh with a one-line note explaining the decision so the user can correct if needed. Example:
+
+> Found prior manifest `<path>` (`<title>`), but new task targets `<different problem space>`. Starting fresh — interrupt me to amend instead if I read this wrong.
+
+#### When Prior Manifest File Cannot Be Read
+
+If the matched path no longer exists or fails to read, fall back to a fresh manifest with a one-line note: "Prior manifest `<path>` is no longer available; starting fresh."
+
 ## Domain Guidance
 
 Domain-specific guidance available in:

--- a/claude-plugins/manifest-dev/skills/define/references/AMENDMENT_MODE.md
+++ b/claude-plugins/manifest-dev/skills/define/references/AMENDMENT_MODE.md
@@ -16,7 +16,7 @@ The conversation context contains the reason — a user's message, a PR review c
 
 When `--interview` is explicitly provided, use it. Otherwise, inherit the interview style from the manifest's metadata (if recorded) or default to `thorough`. The amendment interview is scoped to the change — not a full re-interview of the entire manifest.
 
-## Two Contexts
+## Three Contexts
 
 ### 1. Standalone
 
@@ -31,6 +31,10 @@ User calls `/define --amend <manifest>` directly. Full interactive mode:
 Triggered by `--from-do` flag (e.g., `/define --amend <manifest> --from-do`). This flag is set by /do after Self-Amendment escalation — it signals deterministically that this is an autonomous amendment, not an interactive session.
 
 In /do context, amendment is autonomous and fast — no user approval gates (verification loop, summary approval). Make targeted changes based on the escalation context. Write updated manifest in-place so /do can resume immediately. Log the amendment in the manifest's `## Amendments` section.
+
+### 3. Session-Default
+
+Triggered implicitly by `/define`'s in-session detection of a prior related manifest (no explicit `--amend` flag). See SKILL.md's `## Session-Default Amendment` section for the detection and relatedness rules. Once the agent decides to amend, behavior **follows the Standalone path** — interview scoped to the change (per the active interview mode), verification loop, summary for approval. The interview mode (`thorough` / `minimal` / `autonomous`) is **not** overridden by the trigger context — `/auto` invocations still run autonomously, just amending the prior manifest instead of starting fresh. The user is told upfront via an announcement and can verbally redirect to a fresh manifest if the relatedness call was wrong.
 
 ## What to Preserve
 


### PR DESCRIPTION
## Summary

- When `/define` is invoked again in the same session and a related prior manifest exists in conversation context, default to amending it instead of starting fresh — so follow-up bug fixes, feature extensions, and polish on the same surface accumulate into one manifest per change set and don't silently regress earlier INVs/ACs/PGs.
- Relatedness check is biased strongly toward amend (operational test: "does the new task extend, fix, or polish anything in the prior Goal + Deliverables?"). Tiebreaker on ambiguity also defaults to amend.
- Explicit `--amend <path>`, prose-referenced manifest paths (handled by existing "Existing Manifest Feedback"), and `/do --from-do` all short-circuit the new default — existing flows unchanged. `/auto` inherits the new default automatically and stays autonomous (interview mode is preserved across the trigger).

## Changes

- `claude-plugins/manifest-dev/skills/define/SKILL.md` — new `## Session-Default Amendment` section between Input and Domain Guidance. Detection signal: the `Manifest complete: /tmp/manifest-{timestamp}.md` line emitted by `/define`'s own Complete section. Includes branches for No Prior, Related (default), Truly Unrelated, and Cannot Be Read; explicit compaction fallback; one-line non-blocking announcement on amend ("interrupt me if this is actually unrelated work").
- `claude-plugins/manifest-dev/skills/define/references/AMENDMENT_MODE.md` — renamed `## Two Contexts` → `## Three Contexts`; added `### 3. Session-Default` subsection that delegates detection to SKILL.md and clarifies behavior follows the Standalone path with the active interview mode preserved.
- `claude-plugins/manifest-dev/.claude-plugin/plugin.json` — version bumped 0.89.1 → 0.90.0 (minor / new feature).
- `README.md` and `claude-plugins/manifest-dev/README.md` — one-line note added to the `/define` description in each.
- `.manifest/in-session-default-amendment-2026-04-26.md` — archived manifest from this `/define` session.

## Verification

All 18 manifest criteria verified PASS via `/verify` (thorough mode):
- INV-G1: change-intent-reviewer → 0 findings
- INV-G2: prompt-reviewer → 0 MEDIUM+, score 9/10
- INV-G3..G6: explicit-amend preservation, no-prior-unchanged, hardlink integrity, strong amend bias
- AC-1.1..1.9: section structure, context scan, comparison basis, delegation, announcement format, short-circuit, fallbacks, no-prior handling
- AC-2.1: third trigger context in AMENDMENT_MODE.md
- AC-3.1, AC-3.2: version bump, README sync

## Test plan

- [ ] In a fresh session, run `/define add foo`, then run `/define also add bar` — confirm second invocation announces amendment of the first manifest.
- [ ] In the same session, run `/define do something completely unrelated` (e.g., a different plugin's surface) — confirm /define proceeds fresh with a one-line note explaining why.
- [ ] Run `/define --amend /tmp/manifest-XYZ.md` in a session with a different prior manifest — confirm explicit `--amend` wins (no announcement about session default).
- [ ] Run `/auto add a feature` twice in the same session — confirm second `/auto` amends the first manifest and remains autonomous (no interview prompts).
- [ ] In a `/do` flow, trigger Self-Amendment via `/escalate` — confirm `/define --amend <path> --from-do` still runs autonomously without the new session-default check interfering.

https://claude.ai/code/session_015JTrhmviCXu9pLskFMKU4a

---
_Generated by [Claude Code](https://claude.ai/code/session_015JTrhmviCXu9pLskFMKU4a)_