### PR TITLE
chore(dist): sync Gemini, OpenCode, Codex distributions with source

### DIFF
--- a/dist/codex/README.md
+++ b/dist/codex/README.md
@@ -6,7 +6,7 @@ Verification-first manifest workflows for Codex CLI. Define specifications, exec
 
 | Type | Count | Notes |
 |------|-------|-------|
-| Skills | 13 | Full compatibility (Agent Skills Open Standard) |
+| Skills | 12 | Full compatibility (Agent Skills Open Standard) |
 | Agents | 14 | TOML config stubs with full prompt bodies |
 | Hooks | 0 | Not supported by Codex CLI (Issue #2109) |
 | Rules | 1 | Starlark execution policy |
@@ -97,7 +97,7 @@ The install script handles namespacing automatically (adds `-manifest-dev` suffi
 
 ```
 dist/codex/
-├── skills/                          # 11 skills (unchanged from source)
+├── skills/                          # 12 skills (unchanged from source)
 │   ├── auto/
 │   ├── define/
 │   │   ├── SKILL.md

--- a/dist/codex/agents/change-intent-reviewer.toml
+++ b/dist/codex/agents/change-intent-reviewer.toml
@@ -1,5 +1,5 @@
 name = "change-intent-reviewer"
-description = "Adversarially analyze whether code, prompt, or config changes achieve their stated intent"
+description = "Adversarially analyze whether code, prompt, or config changes achieve their stated intent. Reconstructs change intent from diff context, then systematically attacks the logic to find behavioral divergences"
 sandbox_mode = "read-only"
 developer_instructions = """
 

--- a/dist/codex/agents/code-bugs-reviewer.toml
+++ b/dist/codex/agents/code-bugs-reviewer.toml
@@ -1,7 +1,8 @@
 name = "code-bugs-reviewer"
-description = "Audit code changes for mechanical defects -- runtime failures, resource issues, and structural code flaws"
+description = "Audit code changes for mechanical defects -- runtime failures, resource issues, and structural code flaws. Focuses on defects detectable from code patterns (race conditions, resource leaks, edge cases, dangerous defaults) rather than intent-behavior analysis"
 sandbox_mode = "read-only"
 developer_instructions = """
+
 You are a read-only bug auditor. Your sole output is a structured bug report identifying mechanical defects in code changes — runtime failures, resource issues, and structural code flaws. You do not modify repository files; write only to `/tmp/` for analysis artifacts. Developers implement fixes from your report.
 
 ## Scope Rules

--- a/dist/codex/agents/code-coverage-reviewer.toml
+++ b/dist/codex/agents/code-coverage-reviewer.toml
@@ -1,5 +1,5 @@
 name = "code-coverage-reviewer"
-description = "Verify that code changes have adequate test coverage by proactively enumerating edge cases"
+description = "Verify that code changes have adequate test coverage by proactively enumerating edge cases from the code's logic. Analyzes the diff, derives specific test scenarios with concrete inputs and expected outputs, and reports coverage gaps"
 sandbox_mode = "read-only"
 developer_instructions = """
 

--- a/dist/codex/agents/code-design-reviewer.toml
+++ b/dist/codex/agents/code-design-reviewer.toml
@@ -1,5 +1,5 @@
 name = "code-design-reviewer"
-description = "Audit code for design fitness issues -- right approach given what already exists"
+description = "Audit code for design fitness issues -- whether code is the right approach given what already exists in the framework, codebase, and configuration systems. Identifies reinvented wheels, misplaced responsibilities, under-engineering, short-sighted interfaces, concept misuse, and incoherent changes"
 sandbox_mode = "read-only"
 developer_instructions = """
 

--- a/dist/codex/agents/code-maintainability-reviewer.toml
+++ b/dist/codex/agents/code-maintainability-reviewer.toml
@@ -1,5 +1,5 @@
 name = "code-maintainability-reviewer"
-description = "Comprehensive maintainability audit: DRY, coupling, cohesion, consistency, dead code, boundaries"
+description = "Use this agent when you need a comprehensive maintainability audit of recently written or modified code. Focuses on code organization: DRY violations, coupling, cohesion, consistency, dead code, and architectural boundaries. This agent should be invoked after implementing a feature, completing a refactor, or before finalizing a pull request"
 sandbox_mode = "read-only"
 developer_instructions = """
 
@@ -301,7 +301,7 @@ Do not fabricate issues to fill the report. A clean review is a valid outcome.
 
 - **Be specific**: Always reference exact file paths, line numbers, and code snippets.
 - **Be actionable**: Every issue must have a concrete, implementable fix suggestion.
-- **Consider context**: Account for project conventions from CLAUDE.md files and existing patterns.
+- **Consider context**: Account for project conventions from AGENTS.md files and existing patterns.
 - **Avoid false positives**: Always read full files before flagging issues. A diff alone lacks context—code that looks duplicated in isolation may serve different purposes when you see the full picture.
 - **Avoid these common false positives**:
   - Test file duplication (test setup repetition is often intentional for isolation)

--- a/dist/codex/agents/code-simplicity-reviewer.toml
+++ b/dist/codex/agents/code-simplicity-reviewer.toml
@@ -1,5 +1,5 @@
 name = "code-simplicity-reviewer"
-description = "Audit code for unnecessary complexity, over-engineering, and cognitive burden"
+description = "Audit code for unnecessary complexity, over-engineering, and cognitive burden. Identifies solutions more complex than the problem requires -- not structural issues like coupling or DRY (handled by maintainability-reviewer), but implementation complexity that makes code harder to understand than necessary"
 sandbox_mode = "read-only"
 developer_instructions = """
 

--- a/dist/codex/agents/code-testability-reviewer.toml
+++ b/dist/codex/agents/code-testability-reviewer.toml
@@ -1,5 +1,5 @@
 name = "code-testability-reviewer"
-description = "Audit code for testability issues -- excessive mocking, logic buried in IO, non-deterministic inputs"
+description = "Audit code for testability issues. Identifies code requiring excessive mocking, business logic buried in IO, non-deterministic inputs, and tight coupling that makes verification hard"
 sandbox_mode = "read-only"
 developer_instructions = """
 

--- a/dist/codex/agents/context-file-adherence-reviewer.toml
+++ b/dist/codex/agents/context-file-adherence-reviewer.toml
@@ -1,5 +1,5 @@
 name = "context-file-adherence-reviewer"
-description = "Verify that code changes comply with context file instructions and project standards"
+description = "Verify that code changes comply with context file instructions (CLAUDE.md, AGENTS.md, GEMINI.md) and project standards. Audits pull requests, new code, and refactors against rules defined in the project's context files"
 sandbox_mode = "read-only"
 developer_instructions = """
 

--- a/dist/codex/agents/contracts-reviewer.toml
+++ b/dist/codex/agents/contracts-reviewer.toml
@@ -1,5 +1,5 @@
 name = "contracts-reviewer"
-description = "Verify API and interface contract correctness with evidence"
+description = "Verify API and interface contract correctness with evidence. Checks both outbound (code calls external/internal APIs correctly per documentation) and inbound (changes don't break consumers of your interfaces). Evidence-based -- cites actual API docs or codebase definitions"
 sandbox_mode = "read-only"
 developer_instructions = """
 

--- a/dist/codex/agents/criteria-checker.toml
+++ b/dist/codex/agents/criteria-checker.toml
@@ -1,5 +1,5 @@
 name = "criteria-checker"
-description = "Read-only verification agent. Validates a single criterion using any automated method"
+description = "'Read-only verification agent. Validates a single criterion using any automated method: commands, codebase analysis, file inspection, reasoning, web research. Returns structured PASS/FAIL results.'"
 sandbox_mode = "read-only"
 developer_instructions = """
 

--- a/dist/codex/agents/define-session-analyzer.toml
+++ b/dist/codex/agents/define-session-analyzer.toml
@@ -1,5 +1,5 @@
 name = "define-session-analyzer"
-description = "Analyze a single /define session transcript to extract user preference patterns"
+description = "'Analyze a single /define session transcript to extract user preference patterns. Spawned by learn-define-patterns skill for parallel per-session analysis.'"
 sandbox_mode = "read-only"
 developer_instructions = """
 
@@ -28,7 +28,7 @@ Preferences about what /define should probe for or how it should probe. Examples
 Consistent trade-off resolutions the user makes. Examples: "Always prefers simplicity over configurability", "Chooses coverage over precision in quality gates".
 
 ### Recurring Invariants
-Rules or constraints the user adds to every manifest regardless of task. Examples: "Always requires CLAUDE.md adherence check", "Always includes lint/format/typecheck gate".
+Rules or constraints the user adds to every manifest regardless of task. Examples: "Always requires AGENTS.md adherence check", "Always includes lint/format/typecheck gate".
 
 ### Process Guidance
 Workflow preferences that aren't verifiable but guide execution. Examples: "User prefers goal-oriented prompts over step-by-step", "User wants load-bearing assumptions documented".

--- a/dist/codex/agents/docs-reviewer.toml
+++ b/dist/codex/agents/docs-reviewer.toml
@@ -1,5 +1,5 @@
 name = "docs-reviewer"
-description = "Audit documentation and code comments for accuracy against recent code changes"
+description = "Audit documentation and code comments for accuracy against recent code changes. Performs read-only analysis comparing docs to code, producing a report of required updates without modifying files"
 sandbox_mode = "read-only"
 developer_instructions = """
 

--- a/dist/codex/agents/manifest-verifier.toml
+++ b/dist/codex/agents/manifest-verifier.toml
@@ -1,5 +1,5 @@
 name = "manifest-verifier"
-description = "Reviews /define manifests for gaps and outputs actionable continuation steps"
+description = "'Reviews /define manifests for gaps and outputs actionable continuation steps. Returns specific questions to ask and areas to probe so interview can continue.'"
 sandbox_mode = "read-only"
 developer_instructions = """
 

--- a/dist/codex/agents/type-safety-reviewer.toml
+++ b/dist/codex/agents/type-safety-reviewer.toml
@@ -1,5 +1,5 @@
 name = "type-safety-reviewer"
-description = "Audit code for type safety issues across typed languages"
+description = "Audit code for type safety issues across typed languages (TypeScript, Python, Java/Kotlin, Go, Rust, C#). Identifies type holes that let bugs through, opportunities to make invalid states unrepresentable, and ways to push runtime checks into compile-time guarantees"
 sandbox_mode = "read-only"
 developer_instructions = """
 

--- a/dist/codex/skills/auto/SKILL.md
+++ b/dist/codex/skills/auto/SKILL.md
@@ -33,7 +33,15 @@ The remaining text after flag extraction is the task description (`$TASK_DESCRIP
 
 4. **Tend PR** (only when `--tend-pr` is present) — After /do completes successfully (calls `/done`, not `/escalate`), invoke the manifest-dev:tend-pr skill with: "<manifest-path> --log <execution-log-path>" (the execution log path is available from the conversation context — /do logged its creation at the start of execution). Append `--platform <platform>`, `--interval <duration>`, and `--reviewers <usernames>` if specified in the original /auto arguments.
 
-   If /do escalates instead of completing: do NOT invoke /tend-pr. Report to user: "/do escalated — skipping /tend-pr. Reason: <escalation reason from /do>. Resolve the blocker and re-invoke /tend-pr manually with the manifest path."
+   If /do escalates with **"Deferred-Auto Pending"**: this is a coordination handoff, not a blocker — the implementation is green; the user just needs to run `/verify --deferred` later when prerequisites are ready. Still invoke /tend-pr for cwd's PR (per §Multi-Repo Behavior). Surface the deferred-auto reminder to the user alongside the PR link: "/auto: implementation green; /tend-pr started for cwd's PR. Deferred-auto criteria pending — run `/verify <manifest-path> <log-path> --deferred` when prerequisites are in place to reach /done."
+
+   If /do escalates with any other type: do NOT invoke /tend-pr. Report to user: "/do escalated — skipping /tend-pr. Reason: <escalation reason from /do>. Resolve the blocker and re-invoke /tend-pr manually with the manifest path."
+
+## Multi-Repo Behavior
+
+If `/define` produces a multi-repo manifest (Intent declares `Repos:`), `/auto`'s `/do` invocation **navigates all repos** declared in `Repos:` — `/do` reads the path map and uses absolute paths natively (no filter logic). A single `/auto` invocation can therefore complete the whole multi-repo implementation phase.
+
+The per-cwd limitation is `/tend-pr`: with `--tend-pr`, only cwd's PR is set up for tending, because `/tend-pr` is PR-bound by construction. To tend other repos' PRs, invoke `/tend-pr` from each other repo's cwd. See `manifest-dev:define/references/MULTI_REPO.md` §i.
 
 ## Failure Handling
 

--- a/dist/codex/skills/define/SKILL.md
+++ b/dist/codex/skills/define/SKILL.md
@@ -147,13 +147,21 @@ When `--amend <manifest-path>` is present: read `references/AMENDMENT_MODE.md` f
 
 ## Multi-Repo Scope
 
-When task spans multiple repositories, capture during intent (starting points):
+When the task spans multiple repositories, the manifest stays a single canonical document covering the entire changeset. Full convention is in `references/MULTI_REPO.md` — this section summarizes only what the manifest captures.
 
-- **Which repos** and their roles
-- **Cross-repo constraints** (dependencies, coordination requirements)
-- **Per-repo differences** (different rules, conventions, verification needs)
+**Conditional schema additions** (omit entirely for single-repo manifests):
 
-Scope deliverables and verification to repo context. Cross-repo invariants get explicit verification checking both sides.
+- Intent declares `Repos: [name: path, ...]` listing every repo in scope.
+- Intent optionally declares `Branch: <name>` (single string — same branch name across repos by convention).
+- Each repo-specific deliverable carries a `repo: <name>` tag matching one of the declared repos.
+
+`Repos:` and `repo:` exist for **documentation** — readers (human and agent) know which deliverable lives where. They are **not** an enforcement mechanism for `/do` or `/verify` — `/do` navigates absolute paths from `Repos:` natively (no filter logic).
+
+Cross-repo gates the user must explicitly trigger (e.g., post-deploy verification across services) get `method: deferred-auto`. Normal `/do→/verify` flow skips them during the pass, **but routes to `/escalate` ("Deferred-Auto Pending") instead of `/done` while they remain uncovered**; the user runs `/verify --deferred` when prerequisites are in place. See `references/MULTI_REPO.md` §e.
+
+**Detection** rides on the existing Domain Understanding coverage goal — when conversation, task description, or branch context indicates multiple repos, treat as multi-repo and populate `Repos:` accordingly. No separate probe step is added.
+
+Single-repo manifests omit `Repos:`, `Branch:`, and `repo:` tags entirely; the schema and downstream behavior are identical to today.
 
 ## Principles
 
@@ -377,6 +385,10 @@ Three categories, each covering **output** or **process**:
 - **Mode:** efficient | balanced | thorough *(optional, default: thorough — controls verification intensity during /do)*
 - **Interview:** minimal | autonomous | thorough *(optional, default: thorough — recorded so --amend can inherit the original interview style)*
 - **Medium:** local *(optional, default: local — currently only local is supported)*
+- **Repos:** *(optional, multi-repo only — see `references/MULTI_REPO.md`; omit for single-repo manifests)*
+    - name1: /absolute/path/to/repo1
+    - name2: /absolute/path/to/repo2
+- **Branch:** *(optional, multi-repo only — single string, same branch name across all repos by convention)*
 
 ## 2. Approach (Complex Tasks Only)
 *Initial direction, not rigid plan. Provides enough to start confidently; expect adjustment when reality diverges.*
@@ -401,13 +413,15 @@ Three categories, each covering **output** or **process**:
 - [INV-G1] Description: ... | Verify: [Method]
   ```yaml
   verify:
-    method: bash | codebase | subagent | research | manual
+    method: bash | codebase | subagent | research | manual | deferred-auto
     phase: "[numeric, optional, default 1 — higher phases run after lower phases pass]"
     command: "[if bash]"
     agent: "[if subagent]"
     model: "[if subagent, default inherit]"
     prompt: "[if subagent or research]"
   ```
+
+*`method: deferred-auto` on INV-G* = cross-repo gate the user explicitly triggers via `/verify --deferred`. Skipped during normal `/do→/verify`; routes to `/escalate` "Deferred-Auto Pending" if uncovered when normal flow would otherwise reach `/done`. INV-G* deferred-auto criteria are deliverable-scope-independent — covered only by a `--deferred` pass with empty `--scope`. See `references/MULTI_REPO.md` §e.*
 
 ## 4. Process Guidance (Non-Verifiable)
 *Constraints on HOW to work. Not gates—guidance for the implementer.*
@@ -423,16 +437,18 @@ Three categories, each covering **output** or **process**:
 *Ordered by execution order from Approach, or by dependency then importance.*
 
 ### Deliverable 1: [Name]
-*[If multi-repo: specify repo scope]*
+**Repo:** `name1` *(optional, multi-repo only — must match a name in Intent's `Repos:` map; omit for single-repo manifests)*
 
 **Acceptance Criteria:**
 - [AC-1.1] Description: ... | Verify: ...
   ```yaml
   verify:
-    method: bash | codebase | subagent | research | manual
+    method: bash | codebase | subagent | research | manual | deferred-auto
     phase: "[numeric, optional, default 1]"
     [details]
   ```
+
+*`method: deferred-auto` = automatically verifiable but skipped during normal `/do→/verify`; runs only via `/verify --deferred`. Use for cross-repo gates the user explicitly triggers. See `references/MULTI_REPO.md` §e.*
 
 ### Deliverable 2: [Name]
 ...

--- a/dist/codex/skills/define/references/AMENDMENT_MODE.md
+++ b/dist/codex/skills/define/references/AMENDMENT_MODE.md
@@ -4,11 +4,15 @@
 
 ## Cumulative Manifest Rule
 
-**The manifest is the canonical source of truth for the PR/branch lifetime — not for a single task.** After every amendment, the manifest must describe the FULL PR state: intent, every deliverable, every Global Invariant, every Process Guidance entry, every Known Assumption. The latest increment is layered onto the prior content, never substituted for it.
+**The manifest is the canonical source of truth for the PR/branch lifetime — or, in multi-repo cases, the entire PR set / branch set lifetime — not for a single task.** After every amendment, the manifest must describe the FULL state of every PR it covers: intent, every deliverable (across every repo when multi-repo), every Global Invariant, every Process Guidance entry, every Known Assumption. The latest increment is layered onto the prior content, never substituted for it.
 
 **No silent drops.** When applying an amendment, prior content is preserved by default. Removal is explicit — if a change supersedes an existing AC/INV/PG, the supersession is logged in the `## Amendments` section with rationale. The amendment receiver is responsible for reading the full prior manifest and confirming nothing valuable was lost.
 
-A manifest at any point in time should be readable as "everything currently in scope for this PR/branch," not "the most recent change request." This is what makes the manifest a useful artifact for PR descriptions, reviews, and future amendments.
+A manifest at any point in time should be readable as "everything currently in scope for this PR/branch (or PR set)," not "the most recent change request." This is what makes the manifest a useful working artifact for the agent and the user across the PR lifecycle.
+
+**Multi-repo specifics** — when the manifest declares `Repos:` in Intent, the canonical manifest is shared across all repo PRs (`/tmp/manifest-{ts}.md`); any consumer skill that writes amendments operates on the same file, last-writer-wins (no locking). See `MULTI_REPO.md` §f for the convention.
+
+**Deferred-auto re-verification after amendment** — when an amendment substantively changes a `method: deferred-auto` criterion's verify block (`prompt:`, `command:`, etc.), prior `/verify --deferred` coverage is conceptually invalidated for that criterion. Normal `/verify` always re-runs in-scope criteria so amendments are picked up automatically; deferred-auto bypasses the pass and relies on prior coverage. The user is responsible for re-running `/verify --deferred` for the amended criterion before the gate clears. (Consistent with the user-as-coordinator stance — there is no automatic invalidation mechanism.)
 
 ## Core Behavior
 

--- a/dist/codex/skills/define/references/MULTI_REPO.md
+++ b/dist/codex/skills/define/references/MULTI_REPO.md
@@ -1,0 +1,163 @@
+# Multi-Repo Manifest Workflow
+
+Canonical reference for tasks whose changeset spans multiple repositories. Read this when a manifest declares `Repos:` in its Intent. Core skills (`/define`, `/do`, `/verify`, `/done`, `/auto`, `AMENDMENT_MODE`) summarize the rules below and link here for the full specification. Optional consumer skills (`/tend-pr`, `/tend-pr-tick`, `/drive`, `/drive-tick`) describe how they ride the shared-manifest pattern in their own files — they are add-ons, not part of the core multi-repo workflow.
+
+Single-repo manifests (no `Repos:` field) are unaffected by everything below.
+
+## a. Principle
+
+The shared canonical manifest is the **default and recommended** approach for multi-repo changesets: one manifest captures the whole thing — shared intent, all deliverables (each tagged with its repo), shared invariants, shared trade-offs. The reason it's the default: splitting per PR forces the user to hold cross-PR coherence in their head, which is the work the manifest exists to externalize.
+
+Splitting per repo (one manifest per repo's PR) is a **legitimate user choice** when the work is loosely coupled and the user prefers independent scopes — they accept carrying the cross-PR coherence themselves. Everything below describes the shared-manifest case (when `Repos:` is declared in Intent); the split case is just N independent single-repo manifests and needs no special rules.
+
+The manifest is **internal**. It is a working document for the user and the agent. PR descriptions remain summary-only — no manifest embed, no PR-side surfacing.
+
+## b. Persistence
+
+The canonical manifest lives at `/tmp/manifest-{timestamp}.md`. No archival. No copying to `.manifest/` for multi-repo. No primary repo "owns" it.
+
+If the file is lost (reboot, `/tmp` cleared, session death), re-run `/define` against the same task. The recreated manifest restarts the working state; in-flight PRs continue under the new manifest path.
+
+This is an explicit trade-off: durability infrastructure is more cost than re-running `/define` is occasional pain.
+
+## c. Repo Registration
+
+The manifest's `## 1. Intent & Context` section declares its multi-repo scope:
+
+```markdown
+- **Repos:**                                  # optional, multi-repo only
+    - backend: /home/user/projects/api
+    - frontend: /home/user/projects/web
+- **Branch:** claude/sso-integration          # optional, single string (see §j)
+```
+
+Each deliverable that belongs to a specific repo carries a `repo:` tag matching one of the names above:
+
+```markdown
+### Deliverable 3: SSO endpoint
+**Repo:** `backend`
+```
+
+`Repos:` and `repo:` exist for **documentation** — readers (human and agent) know which deliverable lives where. They are **not** an enforcement mechanism for `/do` or `/verify` (see §d). Optional consumer skills may use the tags for their own scope inference (e.g., a PR-tending tool routing feedback on backend's PR to backend-tagged deliverables), but core skills do not depend on this.
+
+Single-repo manifests omit both `Repos:` and `repo:` entirely.
+
+## d. /do Navigation
+
+`/do` reads `Repos:` from the manifest and uses absolute paths in tool calls (Read/Edit/Write/Bash) when a deliverable lives outside cwd. The LLM handles navigation natively — there is no filter logic, no cwd-to-repo matching, no per-repo configuration in `/do`.
+
+The user can invoke `/do` once globally (the agent navigates between repos as deliverables require), or per-repo with `--scope` (each `/do` handles its repo's slice). Either works.
+
+`/do`'s execution log remains a single file per invocation: `/tmp/do-log-{timestamp}.md`. No per-repo log naming.
+
+Worked example — manifest declares:
+
+```markdown
+- **Repos:**
+    - backend: /home/user/projects/api
+    - frontend: /home/user/projects/web
+
+### Deliverable 1: SSO endpoint
+**Repo:** `backend`
+**Acceptance Criteria:**
+- [AC-1.1] POST /auth/sso accepts SAML assertion
+  ```yaml
+  verify:
+    method: bash
+    command: "curl -X POST http://localhost:8080/auth/sso -d @/tmp/saml-test.xml"
+  ```
+```
+
+`/do` invoked from any cwd reads `Repos:`, navigates to `/home/user/projects/api` for D1's edits via absolute paths, runs the verify command. No filter required.
+
+## e. method: deferred-auto + /verify --deferred
+
+Cross-repo gates often cannot run during normal `/do→/verify` flow because they depend on prerequisites the user controls (e.g., "all PRs deployed to staging"). They are still **automatically verifiable** — just user-triggered.
+
+`method: deferred-auto` marks such criteria. Worked example:
+
+```yaml
+- [INV-G7] Frontend SSO login round-trips through deployed backend
+  verify:
+    method: deferred-auto
+    agent: general-purpose
+    prompt: "Hit https://staging.example.com/login with a test SAML assertion. Confirm successful redirect to /dashboard with a valid session cookie."
+```
+
+Normal `/verify` invocations skip `deferred-auto` criteria during the pass itself. **However, `/verify` will not call `/done` while deferred-auto criteria remain unverified** — instead it routes to `/escalate` with type "Deferred-Auto Pending," signaling the user to run `/verify --deferred` when prerequisites are ready. Only after the deferred-auto criteria pass via `/verify --deferred` does a subsequent normal `/verify` pass reach `/done`. The pass log's `deferred: true|false` field tracks which prior runs covered the deferred-auto set.
+
+When the user signals readiness ("all PRs deployed"), they invoke:
+
+```
+/verify <manifest> <log> --deferred
+```
+
+This runs **only** `deferred-auto` criteria. Flag interactions:
+
+- `--deferred` + `--scope` is supported. `--scope` narrows the deferred set to in-scope deliverables.
+- `--deferred` does not interact with `--final`. It never enters the final-gate machinery.
+- `--deferred` inherits `--mode`. Same parallelism and model routing as the parent invocation.
+
+### Cross-repo path delivery to verifiers
+
+When the manifest declares `Repos: [name: path, ...]`, every `/verify` invocation (selective, full, and `--deferred`) prepends a verbatim string to each verifier's prompt before the criterion's own prompt:
+
+```
+Available repos: backend=/home/user/projects/api, frontend=/home/user/projects/web
+
+[criterion's own prompt follows]
+```
+
+This applies on every pass — not just `--deferred` — so cross-repo verifiers can run during normal `/do→/verify` flow. That's what allows `/done` to fire once per multi-repo manifest (§g) without forcing per-repo /done independence.
+
+Single-repo manifests (no `Repos:` field) get no prefix injection. Manifests with no `deferred-auto` criteria see `/verify --deferred` as a no-op with a clean message.
+
+## f. Shared Manifest Amendment Across PRs
+
+The canonical `/tmp` manifest is shared across all PRs in a multi-repo changeset. Any tool that writes amendments — whether the user editing the file directly, or any optional consumer skill — operates on this single shared file.
+
+There is **no concurrency engineering**. Two writers amending the same manifest at the same instant — last-writer-wins. The later write may overwrite the earlier write's amendment block. Recovery: the writer who lost their amendment notices the missing change in the next iteration and re-triggers it (e.g., re-add the comment that prompted it, or re-invoke whatever workflow generated it).
+
+**Do not add file locking.** The collision rate is low (writes are brief), and the recovery cost is small compared to the complexity of locking, deadlock handling, and stale-lock cleanup.
+
+This pattern is the contract for any optional PR-tending consumer skill (e.g., `/tend-pr`, `/drive`); those skills describe their per-PR usage in their own files.
+
+## g. /done — One Per Manifest, Gated on Deferred-Auto
+
+`/done` fires **once per manifest**, including for multi-repo manifests. There is no per-repo `/done` independence. /verify's "every AC across every deliverable" rule is preserved unchanged; for multi-repo, that means every AC in every repo's deliverables must pass before `/done` is called.
+
+This is achievable because `/verify`'s cross-repo prompt-prefix injection (§e) fires on every pass when `Repos:` is declared — verifiers in normal `/do→/verify` flow have access to all repos' paths and can verify cross-repo behavior without `--deferred`.
+
+**`/done` is gated on no deferred-auto criteria pending.** When the manifest contains `method: deferred-auto` criteria that have not been verified green via a prior `/verify --deferred`, `/verify` routes to `/escalate` ("Deferred-Auto Pending") instead of `/done` — making the user-as-coordinator handoff explicit rather than silently completing. After the user runs `/verify --deferred` and the deferred-auto criteria pass, a subsequent normal `/verify` pass reaches `/done`.
+
+For multi-repo manifests, the `/done` summary lists which repos' deliverables were verified — providing a clear inventory of what landed across the changeset.
+
+## h. User as Coordinator
+
+There is no coordinator process, no primary repo, no orchestrator skill. The user coordinates by:
+
+1. Invoking `/do` or `/auto` (once globally to navigate all repos, or per-repo with `--scope` for parallel execution).
+2. Opening / managing each repo's PR with whatever PR-management workflow they prefer (manual, or via an optional consumer skill).
+3. Triggering `/verify --deferred` once cross-repo prerequisites are in place (e.g., "all PRs merged and deployed").
+
+The system supports this workflow but does not automate it. Coordination is a human concern that the manifest captures the *state* of, not a state machine the system drives.
+
+## i. /auto Behavior
+
+`/auto` chains `/define` → `/do` → optionally `/tend-pr`. The `/do` step **navigates all repos** declared in `Repos:` (per §d — no filter logic, LLM uses absolute paths from the map). A single `/auto` invocation can therefore complete the whole multi-repo implementation phase.
+
+The per-cwd limitation is `/tend-pr`: when `--tend-pr` is set, `/auto` invokes `/tend-pr` from cwd, which sets up tending for cwd's PR only — `/tend-pr` is PR-bound by construction (see §f). To tend the other repos' PRs, invoke `/tend-pr` from each other repo's cwd.
+
+This is the only multi-repo footgun in `/auto`: users may assume `--tend-pr` covers all PRs, when it covers only cwd's. The implementation phase itself runs to completion across all repos in one go.
+
+## j. Branch-Name Convention
+
+By default, all repos in a multi-repo changeset use the **same branch name**. This matches the existing harness pattern (per-repo branch declarations in the system prompt that share a branch identifier).
+
+The manifest's Intent records the branch name as a single string:
+
+```markdown
+- **Branch:** claude/sso-integration
+```
+
+Divergent branch names per repo are not supported by this version. A future extension could replace `Branch: <string>` with `Branches: [name -> branch]` if real cases demand it.

--- a/dist/codex/skills/define/tasks/CODING.md
+++ b/dist/codex/skills/define/tasks/CODING.md
@@ -4,7 +4,7 @@ Base guidance for all code-change tasks (features, bugs, refactors).
 
 ## Quality Gates
 
-CLAUDE.md may specify project-specific preferences.
+AGENTS.md may specify project-specific preferences.
 
 ### Base Gates (always applicable)
 
@@ -20,7 +20,7 @@ Defect-finding agents: every finding at Low severity or above fails the gate (`n
 | Testability | code-testability-reviewer | no MEDIUM+ |
 | Documentation | docs-reviewer | no MEDIUM+ |
 | Design fitness | code-design-reviewer | no MEDIUM+ |
-| CLAUDE.md adherence | context-file-adherence-reviewer | no MEDIUM+ |
+| AGENTS.md adherence | context-file-adherence-reviewer | no MEDIUM+ |
 
 ### Conditional Gates (when applicable)
 
@@ -31,7 +31,7 @@ Defect-finding agents: every finding at Low severity or above fails the gate (`n
 
 ## Project Gates
 
-CLAUDE.md specifies project gates (typecheck, lint, test, format). These become Global Invariants.
+AGENTS.md specifies project gates (typecheck, lint, test, format). These become Global Invariants.
 
 ## E2E Verification
 
@@ -74,7 +74,7 @@ CLAUDE.md specifies project gates (typecheck, lint, test, format). These become 
 *Domain best practices for this task type.*
 
 - **Run existing tests before modifying test files** — Verify current test state before changing tests; prevents masking pre-existing failures
-- **Read project gates from CLAUDE.md** — Discover project-specific commands (typecheck, lint, test, format) before implementation
+- **Read project gates from AGENTS.md** — Discover project-specific commands (typecheck, lint, test, format) before implementation
 
 ## Multi-Repo
 

--- a/dist/codex/skills/do/SKILL.md
+++ b/dist/codex/skills/do/SKILL.md
@@ -71,9 +71,11 @@ When `--scope` is NOT provided, ignore this section entirely — no reference fi
 
 The mandatory full final gate (auto-triggered by /verify after selective green) is the safety net for cross-deliverable regressions. Don't try to skip or short-circuit it.
 
-**Execution log /verify contract** - /verify appends a structured block (`## /verify pass {N}` + fenced YAML with `mode`, `scope`, `result`, `failures`, `auto_triggered_final`) per invocation. Read the most recent block before deciding the next pass's scope. Format defined in `verify/SKILL.md` "Pass Logging Contract."
+**Execution log /verify contract** - /verify appends a structured block (`## /verify pass {N}` + fenced YAML with `mode`, `scope`, `result`, `failures`, `auto_triggered_final`, `deferred`) per invocation. Read the most recent block before deciding the next pass's scope. Format defined in `verify/SKILL.md` "/verify Pass Logging Contract." When scanning for the most recent /verify pass to drive scope decisions, **skip blocks with `deferred: true`** — those reflect user-direct `--deferred` invocations (now possible since /verify is user-invocable), not /do-driven normal-flow passes.
 
 **Escalation boundary** - Escalate when: (1) ACs can't be met as written (contract broken), (2) user requests a pause mid-workflow, (3) you discover an AC or invariant should be amended (use "Proposed Amendment" escalation type), or (4) the active execution mode's fix-verify loop limit is reached. If ACs remain achievable as written and no user interrupt, continue autonomously.
+
+**`/verify`-routed escalation passthrough.** When `/verify` itself routes to `/escalate` (e.g., "Deferred-Auto Pending", "Manual Criteria Review") instead of `/done`, treat as a clean terminal handoff: surface the escalation output verbatim to the caller, do NOT enter the fix-loop, do NOT increment loop counters. The implementation is green; further action belongs to the user (e.g., running `/verify --deferred` for deferred-auto pending). This is distinct from `/verify` returning failures (which enters the standard fix-loop).
 
 **Mode-aware loop tracking** - Track fix-verify iteration count and escalation count in the execution log. When the active execution mode's limits are reached, follow its escalation rules.
 
@@ -93,9 +95,19 @@ Externalize progress to survive context loss.
 
 **Refresh between deliverables** - Before starting a new deliverable, re-read the manifest's deliverable section and relevant log entries. Context degrades across long sessions.
 
+## Multi-Repo Navigation
+
+When the manifest declares `Repos: [name: path, ...]` in Intent, deliverables may live in repos other than cwd. Read the path map and use **absolute paths** in tool calls (Read/Edit/Write/Bash) when working on a deliverable tagged with a different repo. There is **no filter logic, no cwd matching, no per-repo configuration** — the LLM navigates as deliverables require.
+
+A single `/do` invocation can cover the whole multi-repo task by navigating between repos; alternatively the user invokes `/do` per repo with `--scope` for parallel execution. Either works. The execution log remains a single file per `/do` invocation.
+
+When the manifest has no `Repos:` field (single-repo manifest), this section does not apply — behavior is unchanged.
+
+Full convention: `references/MULTI_REPO.md` (lives in `define/references/`).
+
 ## Mid-Execution Amendment
 
-**Default to amend.** Any user message arriving during /do or /verify defaults to triggering Self-Amendment. The manifest is the canonical source of truth for the PR/branch (per `references/AMENDMENT_MODE.md`); feedback flows through it, not around it. The asymmetric framing is deliberate: silent scope drift (feedback acted on inline, manifest left out of date) is a worse failure than an occasional unnecessary amendment cycle.
+**Default to amend.** Any user message arriving during /do or /verify defaults to triggering Self-Amendment. The manifest is the canonical source of truth for the PR/branch — or, in multi-repo cases, the **PR set / branch set** (see `references/AMENDMENT_MODE.md`). Feedback flows through it, not around it. The asymmetric framing is deliberate: silent scope drift (feedback acted on inline, manifest left out of date) is a worse failure than an occasional unnecessary amendment cycle.
 
 **Carve-out: pure questions.** Messages that ask about the manifest or process without requesting a state change are answered inline — no amendment.
 - *Amend:* "Also handle X." / "Change Y to Z." / "That's wrong, it should be …" / "Add a check for …"
@@ -103,7 +115,7 @@ Externalize progress to survive context loss.
 
 **When ambiguous, amend.** A message that could be either ("hmm, what about the auth case?") goes to amendment. Re-running an amendment cycle is cheap; silently dropping a constraint that turns out to matter is expensive.
 
-**/verify-time feedback.** /verify is non-user-invocable orchestrator — semantically, user feedback received while /verify is running is feedback to /do (the caller), not to /verify. The same default-to-amend rule applies. /verify itself never handles user feedback inline; the message is interpreted in /do's context and routed through Self-Amendment.
+**/verify-time feedback.** While /verify is running under /do, user feedback received mid-pass is semantically feedback to /do (the caller), not to /verify. The same default-to-amend rule applies. /verify itself never handles user feedback inline; the message is interpreted in /do's context and routed through Self-Amendment. (When /verify is invoked directly by the user — e.g., `/verify --deferred` — there is no /do caller; mid-pass user messages are handled per the user's own session reflex, not via /do's amendment route.)
 
 **Amendment flow** — Amend the manifest autonomously via Self-Amendment escalation and `/define --amend <manifest-path> --from-do`, then resume with the updated manifest and existing log. Log the trigger before amending. No human wait — the entire cycle is autonomous.
 

--- a/dist/codex/skills/done/SKILL.md
+++ b/dist/codex/skills/done/SKILL.md
@@ -24,6 +24,14 @@ Read the execution log and manifest. Output a summary that shows:
 4. **Key changes** - Files modified, commits made
 5. **Tradeoffs applied** - How preferences were used
 
+When the manifest declares `Repos:` (multi-repo), `/done` still fires **once per manifest** — not once per repo. /verify's "every AC across every deliverable" rule is preserved unchanged; for multi-repo, that means every AC in every repo's deliverables must pass before `/done` is called. This is achievable because `/verify` injects the cross-repo path prefix (`Available repos: ...`) on every pass when `Repos:` is declared, so verifiers can reach all repos during normal flow.
+
+The multi-repo summary additionally lists which **repos' deliverables were verified in this run** — providing a clear inventory of what landed across the changeset.
+
+**`/done` is gated on no deferred-auto criteria pending.** When the manifest contains `method: deferred-auto` criteria that have not yet been verified green via `/verify --deferred`, `/verify` does NOT call `/done` — it routes to `/escalate` with type "Deferred-Auto Pending" instead, telling the user to run `/verify --deferred` when prerequisites are in place. Only after deferred-auto criteria pass via `--deferred` does a subsequent normal `/verify` pass reach `/done`. See `define/references/MULTI_REPO.md` §e/§g and `verify/SKILL.md` "Deferred-Pending Escalation".
+
+Single-repo manifests (no `Repos:` field) get the standard summary unchanged — no repo list, no deferred-auto note. The deferred-auto-pending escalation rule applies regardless of multi-repo (any manifest with deferred-auto criteria, single- or multi-repo, gates /done the same way).
+
 ## Output Format
 
 ```markdown
@@ -72,11 +80,11 @@ The trailing italic line is **mandatory** in /done's output — it surfaces the 
 1. **Mirror manifest structure** - Hierarchy should match: Intent → Global Invariants → Deliverables
 2. **Show evidence** - Link changes to deliverables, describe behavioral changes (not just file lists)
 3. **Adapt detail to complexity** - Simple task = condensed output. Complex task = full hierarchy.
-4. **Called by /verify only, after a full-suite green pass** - /done is the final step after /verify confirms a **full pass** is green — every AC across every deliverable plus every Global Invariant. Selective-mode green alone is not sufficient (per /verify's hard final gate); /verify auto-triggers a full pass after selective green and only then calls /done.
+4. **Called by /verify only, after a full-suite green pass** - /done is the final step after /verify confirms a **full pass** is green — every AC across every deliverable plus every Global Invariant — **AND no `deferred-auto` criteria are pending** (when pending deferred-auto criteria exist, /verify routes to /escalate "Deferred-Auto Pending" instead of calling /done; see narrative above and `verify/SKILL.md` Deferred-Pending Escalation). Selective-mode green alone is not sufficient (per /verify's hard final gate); /verify auto-triggers a full pass after selective green and only then calls /done.
 
 ## Post-Completion Feedback
 
-After /done has been called, the manifest is still the canonical source of truth for the PR/branch — the work isn't necessarily merged, and feedback can still arrive (user comments, PR reviews, second thoughts). The default reflex for any feedback that changes scope or contradicts something settled is the same as during /do (per `do/SKILL.md` Mid-Execution Amendment): **default to amend.**
+After /done has been called, the manifest is still the canonical source of truth for the PR/branch — or the **PR set / branch set** in the multi-repo case — because the work isn't necessarily merged, and feedback can still arrive (user comments, PR reviews, second thoughts). The default reflex for any feedback that changes scope or contradicts something settled is the same as during /do (per `do/SKILL.md` Mid-Execution Amendment): **default to amend.**
 
 **Re-entry flow:** when feedback is determined to be amendment-worthy (not a pure question), invoke `/define --amend <manifest-path>` with the feedback as input, then `/do <manifest-path> <log-path> --scope <new-or-affected-deliverables>` to implement the change. /do's selective-mode + mandatory full final gate apply to the re-entry pass — /done won't be reachable again until the full suite is green on the amended manifest.
 

--- a/dist/codex/skills/escalate/SKILL.md
+++ b/dist/codex/skills/escalate/SKILL.md
@@ -197,6 +197,31 @@ User explicitly asked to stop mid-workflow (e.g., "commit so I can deploy", "sto
 
 **When to use**: User interrupts workflow for legitimate reasons (deploy, review, break). Not a blocker—just a handoff.
 
+### Deferred-Auto Pending
+
+Normal-flow `/verify` completed green, but the manifest contains `method: deferred-auto` criteria that have not yet been verified green via a prior `/verify --deferred` run. This is a coordination handoff, not a blocker — `/done` is unreachable until the user signals readiness and runs `/verify --deferred`. **No 3-attempt evidence required.** Fired by `/verify`, not by `/do`.
+
+```markdown
+## Escalation: Deferred-Auto Pending
+
+**Reason:** Normal-flow verification green; deferred-auto criteria require user signal before they can run.
+
+### Pending Deferred-Auto Criteria
+- [INV-G{N} or AC-{D}.{N}]: [description from manifest]
+- ...
+
+### To Resolve
+When prerequisites are in place (e.g., "all PRs deployed"), invoke:
+
+`/verify <manifest-path> <execution-log-path> --deferred`
+
+After `--deferred` completes green, re-invoke a normal `/verify <manifest-path> <execution-log-path>` (no flags) to reach `/done`.
+```
+
+**When to use**: `/verify` finishes a normal-flow pass green and detects pending deferred-auto criteria — see `verify/SKILL.md` Deferred-Pending Escalation. **Not** a blocker — implementation is done; the user controls when cross-repo / staging / deploy-dependent verification happens.
+
+**Combined with Manual Criteria Review.** When BOTH manual criteria and pending deferred-auto criteria exist after a normal full-mode green pass, compose a single combined escalation: header `## Escalation: Manual Review + Deferred-Auto Pending`, then both sections inline (Manual Criteria block + Pending Deferred-Auto Criteria block + To Resolve combining manual review steps and the `/verify --deferred` instruction). `/done` remains unreachable until both are resolved.
+
 ## Medium Routing
 
 When medium is non-local, /do routes escalations through the medium directly — /escalate is not invoked. The escalation templates above still define the expected content structure; /do uses them when composing messages to the channel.

--- a/dist/codex/skills/learn-define-patterns/SKILL.md
+++ b/dist/codex/skills/learn-define-patterns/SKILL.md
@@ -22,7 +22,7 @@ Every `/define` session, users make the same corrections, add the same invariant
 | **Merge, never overwrite** | If a `## /define Preferences` section already exists, merge new patterns with existing ones. Never blindly overwrite. |
 | **Semantic deduplication** | When merging, identify patterns that say the same thing in different words and consolidate them. Don't just check for exact text matches. |
 | **Standard markdown only** | Output uses `##` headers, `###` subheaders, `- ` bullets, and `<!-- date -->` HTML comments. No custom syntax, no YAML, no special parsing. |
-| **Ask write target** | Ask the user which AGENTS.md to write to: project AGENTS.md, user `~/.codex/AGENTS.md`, or both. Never assume. |
+| **Ask write target** | Ask the user which AGENTS.md to write to: project AGENTS.md, user `~/.claude/CLAUDE.md`, or both. Never assume. |
 | **Diff preview before write** | Show the user exactly what will be added or changed in AGENTS.md before writing. |
 | **Clean up temp files** | Delete per-session analysis files from `/tmp/` after aggregation is complete. |
 
@@ -51,7 +51,7 @@ The final output is a unified set of user preferences derived from all analyzed 
 **What the user sees before approving:**
 - Pattern statement, session frequency, project-specific vs generalizable flag, any contradictions
 - Batch selection (not per-pattern approval)
-- Choice of write target: project AGENTS.md, user `~/.codex/AGENTS.md`, or both
+- Choice of write target: project AGENTS.md, user `~/.claude/CLAUDE.md`, or both
 - Diff/preview of exact changes before writing
 
 # AGENTS.md Output Format

--- a/dist/codex/skills/tend-pr-tick/SKILL.md
+++ b/dist/codex/skills/tend-pr-tick/SKILL.md
@@ -68,9 +68,9 @@ Label source first (bot vs human — read `../tend-pr/references/known-bots.md`)
 *Runs when there are CI failures to handle or when new comments were classified.*
 
 **Manifest mode:** This is the same default-to-amend reflex documented canonically in `do/SKILL.md` Mid-Execution Amendment — PR comments and CI failures are external feedback that contradicts or extends the manifest, so they route through Self-Amendment. The only difference is the trigger source (PR thread vs. user message in a session).
-1. Identify which deliverable(s) the comment or CI failure targets (include all potentially affected when ambiguous).
-2. Amend manifest via `/define --amend <manifest-path> --from-do`.
-3. Invoke `/do <manifest-path> <log-path> --scope <affected-deliverable-ids>`. If `/do` escalates, log the blocker, report the escalation to the user, and end the loop.
+1. Identify which deliverable(s) the comment or CI failure targets (include all potentially affected when ambiguous). When the manifest declares `Repos:` (multi-repo) and deliverables carry `repo:` tags, look up this PR's repo via the platform adapter (e.g., GitHub MCP returns `owner/repo` for the PR number); for each absolute path in the manifest's `Repos:` map, run `git -C <path> remote get-url origin` and parse the URL to its `owner/repo` form; the entry whose remote matches the PR's `owner/repo` is the corresponding repo. Use that entry's `name:` as the deliverable filter — prefer deliverables tagged with the matching repo name.
+2. Amend manifest via `/define --amend <manifest-path> --from-do`. **Multi-repo:** the manifest is a shared canonical `/tmp` file used by every repo's `/tend-pr-tick` — concurrent amendments are last-writer-wins (no locking; see `tend-pr/SKILL.md` §Multi-Repo PR Sets and `define/references/MULTI_REPO.md` §f). If you notice a missed amendment, re-trigger the lost tick.
+3. Invoke `/do <manifest-path> <log-path> --scope <affected-deliverable-ids>`. If `/do` escalates with **"Deferred-Auto Pending"**: implementation is green — proceed to steps 4 and 5 normally (push the fix; reply to the originating thread). Append the deferred-auto reminder to this tick's Status Report so the user sees it: "Implementation green; run `/verify <manifest> <log> --deferred` when prerequisites are in place to reach /done." Do **NOT** terminate the tick — subsequent ticks continue normally toward merge-readiness. If `/do` escalates with any other type: log the blocker, report the escalation to the user, and end the loop.
 4. Push changes.
 5. If the actionable item originated from a comment, reply on that thread.
 
@@ -87,6 +87,8 @@ Label source first (bot vs human — read `../tend-pr/references/known-bots.md`)
 *Runs when this tick produced changes (routing fixes, conflict resolution). Skip when no changes were made.*
 
 After changes, rewrite "what changed" sections to reflect the current diff. Preserve manual context (issue references, motivation, deployment notes). Update title if scope changed significantly.
+
+The PR description stays summary-only — never embed the manifest. Manifests are internal working documents (also true in multi-repo, where the same canonical manifest is shared across all PRs without surfacing to reviewers).
 
 ## Status Report
 

--- a/dist/codex/skills/tend-pr/SKILL.md
+++ b/dist/codex/skills/tend-pr/SKILL.md
@@ -35,6 +35,16 @@ Two modes:
 - No argument, no manifest inferrable, and no open PR for current branch: "Error: No manifest or open PR found. Provide a manifest path or PR URL. Usage: /tend-pr <manifest-path-or-pr-url> [--platform github] [--interval 10m] [--reviewers user1,user2]"
 - `--platform` value not supported: "Error: Platform '<value>' not yet supported. Currently supported: github"
 
+## Multi-Repo PR Sets
+
+When the manifest declares `Repos:` in Intent (multi-repo changeset), each repo's PR is tended by its own `/tend-pr` invocation pointing at the **same canonical `/tmp` manifest**. PR descriptions stay summary-only — manifests are internal and never embedded in PRs.
+
+All `/tend-pr-tick` instances amend the same shared manifest. There is **no locking and no concurrency engineering**. Concurrent amendments are last-writer-wins; the later write may overwrite the earlier write's amendment block. Recovery: the user notices the missing amendment in the next iteration and re-triggers the lost tick (e.g., re-add the comment, re-run `/tend-pr-tick`). **Do not add file locking** — collisions are rare and the recovery cost is small.
+
+Single-repo manifests (no `Repos:` field) are unaffected — one `/tend-pr`, one PR, no shared-manifest considerations.
+
+Full convention: `references/MULTI_REPO.md` (in `define/references/`) §f.
+
 ## Setup
 
 **Manifest-aware mode:** Ensure a non-draft PR exists for the current branch — create one if none exists. Use the manifest's Intent section for PR title/description. If `--reviewers` was provided, request review from those users. Resolve the execution log path (from `--log`, most recent `/tmp/do-log-*.md`, or conversation context).

--- a/dist/codex/skills/verify/SKILL.md
+++ b/dist/codex/skills/verify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: verify
-description: 'Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest.'
-user-invocable: false
+description: 'Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest. Primary user-facing entry point is /verify --deferred (run user-triggered deferred-auto criteria); other invocations normally come from /do.'
+user-invocable: true
 ---
 
 # /verify - Manifest Verification Runner
@@ -10,9 +10,9 @@ Orchestrate verification of all criteria from a Manifest by spawning parallel ve
 
 **Input**: $ARGUMENTS
 
-Format: `<manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough] [--scope D1,D2,...] [--final]`
+Format: `<manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough] [--scope D1,D2,...] [--final] [--deferred]`
 
-Both paths required — return usage error if missing. Mode defaults to `thorough` if not provided. `--scope` and `--final` are mutually exclusive (final is full by definition); when both appear, treat as final.
+Both paths required — return usage error if missing. Mode defaults to `thorough` if not provided. `--scope` and `--final` are mutually exclusive (final is full by definition); when both appear, treat as final. `--deferred` runs only `method: deferred-auto` criteria — see "Deferred-Auto Criteria" below.
 
 ## Selective vs Full Verification
 
@@ -34,11 +34,11 @@ Both paths required — return usage error if missing. Mode defaults to `thoroug
 | **All in-scope criteria, no exceptions** | Every criterion in the current pass's scope (selective: in-scope deliverables' ACs + all INV-G*; full: every AC + every INV-G*) MUST be verified. Skipping any in-scope criterion is a critical failure. |
 | **Parallelism per mode** | The active execution mode defines how many verifiers to launch concurrently within each phase. Phases always run sequentially — see Phased Execution below. |
 | **Actionable feedback** | Pass through file:line, expected vs actual, fix hints. |
-| **Don't handle user feedback** | /verify is non-user-invocable. Any user message arriving while /verify is running is semantically feedback to /do (the caller). /verify never amends, never re-prompts, never deviates from its current pass — it returns results; /do interprets new user input per its own default-to-amend rule (`do/SKILL.md` Mid-Execution Amendment). |
+| **Don't handle user feedback during a pass** | While /verify is running, any user message arriving mid-pass is semantically feedback to the caller (/do, or the user who invoked /verify --deferred directly) — /verify never amends, never re-prompts, never deviates from its current pass. It returns results; the caller interprets new user input per its own rules (e.g., /do's Mid-Execution Amendment). User-direct invocations of /verify --deferred run to completion the same way. |
 
 ## Verification Routing
 
-Route `manual` criteria to /escalate. Route `subagent` criteria to the named agent specified in the criterion. All other types (`bash`, `codebase`, `research`) spawn criteria-checker agents. If a criterion has no verification type, default to criteria-checker.
+Route `manual` criteria to /escalate. Route `subagent` criteria to the named agent specified in the criterion. Route `deferred-auto` criteria per the "Deferred-Auto Criteria" section below — they are **skipped during normal /verify flow** and only run when `--deferred` is passed; under `--deferred`, they are routed by the inner shape of their verify block (if `agent:` is set, route to that named subagent; if `command:` is set, route to criteria-checker as bash; otherwise default to criteria-checker). All other types (`bash`, `codebase`, `research`) spawn criteria-checker agents. If a criterion has no verification type, default to criteria-checker.
 
 ## Agent Prompt Composition
 
@@ -62,6 +62,8 @@ Only include paths that exist. This is informational, not directive — agents d
 - Interpretations of manifest intent ("the goal is to...", "this change is about...")
 
 The verify block's `prompt:` field is manifest-authored — pass it verbatim. These rules target language you add beyond what the manifest specifies. The optional context file paths are raw references, not framing — they provide access to source material without steering the agent's analysis.
+
+**Exception — manifest-driven `Repos:` prefix.** When the manifest declares `Repos:`, the cross-repo path prefix (`Available repos: name=/path, ...`) is prepended to every verifier's prompt per "Cross-repo path delivery to verifiers" below. This is the one prescribed exception to "Do not add your own framing" — the prefix is manifest-driven (derived from `Repos:`), not orchestrator opinion.
 
 ## Criterion Types
 
@@ -112,20 +114,53 @@ Group results by phase, then Global Invariants first, then by Deliverable.
 | Any Global Invariant failed | Return all failures, globals highlighted |
 | Any AC failed | Return failures grouped by deliverable |
 | All in-scope pass, **selective mode that actually narrowed** (`--scope` was set) | **Auto-trigger a full pass** (re-invoke /verify internally with `--final`). Do NOT call /done. Manual criteria in scope are NOT escalated yet — they're deferred to the auto-triggered full pass per the rule below. |
-| All pass, **full mode**, manual criteria exist | List manual criteria with how-to-verify, suggest /escalate |
-| All pass, **full mode** | Call /done |
+| All pass, **full mode**, manual criteria exist (no pending deferred-auto) | List manual criteria with how-to-verify, suggest /escalate |
+| All pass, **full mode**, **deferred-auto criteria exist and not all verified green via prior `--deferred` pass** (no manual criteria) | /escalate with "Deferred-Auto Pending" — see "Deferred-Pending Escalation" below. Do NOT call /done. |
+| All pass, **full mode**, **manual criteria AND pending deferred-auto criteria** | Combined /escalate (Manual Review + Deferred-Auto Pending) per "When BOTH" in Deferred-Pending Escalation below. Do NOT call /done. |
+| All pass, **full mode**, no pending deferred-auto criteria, no manual criteria | Call /done |
 
-**Selective that degenerated to full = full mode for outcome handling.** When `--scope` is absent and `--final` is absent, the pass covered every criterion already. Treat as a full pass: if manual criteria exist → escalate (do not skip the manual row); otherwise → call /done. There is no "auto-trigger another full pass" for degenerated-to-full — that's redundant since the pass already covered everything.
+**Selective that degenerated to full = full mode for outcome handling.** When `--scope` is absent and `--final` is absent, the pass covered every criterion already. Treat as a full pass: if manual criteria exist OR pending deferred-auto criteria exist → escalate (combine both per "Deferred-Pending Escalation §When BOTH"); otherwise → call /done. There is no "auto-trigger another full pass" for degenerated-to-full — that's redundant since the pass already covered everything.
 
 **Manual criteria in selective mode.** When a selective pass encounters manual criteria within its in-scope deliverables and all automated checks pass, manual escalation is **deferred** to the auto-triggered full pass. Rationale: the full pass surfaces every manual criterion across every deliverable, so escalating partial manual criteria from a selective pass would fragment the user-facing escalation. Manual escalation fires exactly once per /verify chain — at the end of the full pass — never from a selective pass.
 
-**Hard final gate.** /done is unreachable from selective-mode green alone. Per project directive ("Done means nothing more to do"), only a full-mode green pass — every AC across every deliverable + every Global Invariant — calls /done. The auto-triggered full pass is unconditional: no mode override, no opt-out. If the auto-triggered full pass fails, /verify returns the failures to /do, which enters the standard fix-loop. Failure during a final pass behaves identically to failure during any other pass — fix, then a fresh selective pass scoped to the failing deliverable, then auto-trigger full again.
+**Hard final gate.** /done is unreachable from selective-mode green alone. Per project directive ("Done means nothing more to do"), only a full-mode green pass — every AC across every deliverable + every Global Invariant — **with no pending deferred-auto criteria** calls /done. When deferred-auto criteria are pending (no prior `--deferred` pass covered them), /verify routes to /escalate ("Deferred-Auto Pending") instead — see Deferred-Pending Escalation. The auto-triggered full pass is unconditional: no mode override, no opt-out. If the auto-triggered full pass fails, /verify returns the failures to /do, which enters the standard fix-loop. Failure during a final pass behaves identically to failure during any other pass — fix, then a fresh selective pass scoped to the failing deliverable, then auto-trigger full again.
 
 **`--final` is internal-only.** /verify uses `--final` to re-invoke itself after a selective green; /do does NOT pass `--final`. /do invokes /verify either with no scope flags (degenerates to full on first pass) or with `--scope D2,D3` (selective). The internal-only constraint preserves the gate: /do can never bypass the selective→full chain by manually requesting a final-only pass.
 
 **Mode is preserved across the recursion.** When /verify auto-triggers itself with `--final`, it carries forward the active `--mode <X>` from the current invocation (efficient | balanced | thorough). The auto-triggered final pass runs at the same intensity (parallelism + model routing + skip rules) as the selective pass that triggered it — never forced to thorough. The "full suite" guarantee is unconditional; the *intensity per criterion* follows the active mode (preserves the orthogonality between selective/full and mode established earlier in this skill).
 
 **On phase failure**: Show the failed phase, then for each failed criterion: ID, description, verification method, failure details (location, expected vs actual, fix hint). Note later phases not run and their pending criteria count.
+
+## Deferred-Auto Criteria
+
+`method: deferred-auto` marks a criterion as **automatically verifiable but user-triggered** — typically a cross-repo gate the user signals readiness for (e.g., "all PRs deployed"). The verifier itself runs automatically (bash command, subagent prompt, etc.); only the *triggering* is user-controlled.
+
+**Normal flow skips them.** Selective and full passes (with or without `--scope`/`--final`) ignore `deferred-auto` criteria entirely during the pass — they never appear in the failure list of a normal pass. **However, their absence-of-coverage gates `/done` routing per "Deferred-Pending Escalation" below**: a normal-flow green pass with pending deferred-auto criteria routes to `/escalate` ("Deferred-Auto Pending"), not `/done`.
+
+**`--deferred` runs them.** When `/verify ... --deferred` is invoked, /verify runs **only** `deferred-auto` criteria (everything else is skipped, including INV-Gs and ACs of other methods).
+
+**Flag interactions:**
+- `--deferred` + `--scope` is supported. `--scope` narrows the deferred-auto set to in-scope deliverables.
+- `--deferred` does not interact with `--final` — never enters the final-gate machinery, never auto-triggers a follow-up pass, never calls /done.
+- `--deferred` inherits `--mode` — same parallelism / model routing as the parent invocation.
+- `--deferred` invoked without `--scope` covers all `deferred-auto` criteria across the manifest.
+- A manifest with no `deferred-auto` criteria sees `--deferred` as a clean no-op ("no deferred-auto criteria in manifest").
+
+**Deferred-Pending Escalation.** When a normal-flow `/verify` pass (selective or full) completes green but the manifest contains `deferred-auto` criteria that have not been verified green via a prior `/verify --deferred` run, `/verify` must NOT call `/done`. Instead, it routes to `/escalate` with type "Deferred-Auto Pending" and a message telling the user which deferred-auto criteria remain and instructing them to invoke `/verify --deferred` once prerequisites are in place. Once those criteria pass via `--deferred`, a subsequent normal `/verify` pass can call `/done`.
+
+**Coverage determination.** A deferred-auto criterion is considered "covered" when there exists a preceding pass-log block with `deferred: true`, `result: pass`, and either (a) `scope:` is empty (full deferred coverage), or (b) `scope:` contains the deliverable that owns the criterion. /verify aggregates coverage across all prior `--deferred` blocks in the log: a criterion is pending iff no prior deferred-pass block satisfies (a) or (b) for it. INV-G* deferred-auto criteria are deliverable-scope-independent — they are covered only by a `deferred: true scope: []` block.
+
+**When BOTH manual criteria and pending deferred-auto criteria exist** after a normal full-mode green pass, surface BOTH in a single combined escalation block: list the manual criteria + their how-to-verify, AND list the pending deferred-auto criteria + the `/verify --deferred` instruction. /done remains unreachable until both are resolved.
+
+**After `/verify --deferred` completes green** (all deferred-auto criteria pass), close the user-as-coordinator loop with an explicit next-step instruction: emit a message like *"Deferred-auto criteria green. Re-invoke `/verify <manifest> <log>` (no flags) to reach /done."* Do NOT call /done from the `--deferred` pass itself — `--deferred` only verifies the deferred-auto subset; the final `/done` decision belongs to a normal-flow pass that confirms the full criterion universe is still green AND the deferred coverage now satisfies the gate.
+
+**Cross-repo path delivery to verifiers.** When the manifest declares `Repos: [name: path, ...]`, **every `/verify` pass** (selective, full, and `--deferred`) prepends a verbatim string to each verifier's prompt before the criterion's own prompt:
+
+```
+Available repos: name1=/path/1, name2=/path/2, ...
+```
+
+This is the one mechanism — verifiers do not parse the manifest themselves. The injection fires on every pass, not just `--deferred`, so cross-repo verifiers can run during normal `/do→/verify` flow — that's what makes `/done` reachable for multi-repo manifests without per-repo /done independence. Single-repo manifests (no `Repos:` field) get no prefix injection. Full convention: `references/MULTI_REPO.md` (lives in `define/references/`) §e.
 
 ## /verify Pass Logging Contract
 
@@ -135,14 +170,17 @@ Every /verify invocation appends a structured block to the execution log so /do 
 ## /verify pass {N}
 
 ```yaml
-mode: selective|full
+mode: selective|full             # for --deferred passes: selective if --scope was set, else full
 scope: [<deliverable-id>, ...]   # empty list when mode is full
 result: pass|fail
 failures: [<criterion-id>, ...]  # empty when pass; criterion IDs only, no narrative
-auto_triggered_final: true|false # true when this pass was auto-triggered after selective green
+auto_triggered_final: true|false # true when this pass was auto-triggered after selective green; always false for --deferred passes
+deferred: true|false             # true when this pass ran via --deferred (only deferred-auto criteria checked); false for normal selective/full passes
 ```
 
 [narrative — failed criterion details, fix hints, etc., per Outcome Handling]
 ````
+
+When `deferred: true`, consumers should treat the pass as a partial verification (only `deferred-auto` criteria) — never as evidence that normal-flow ACs/INVs passed. The `result: pass` of a deferred pass means "the deferred-auto criteria are green," not "the whole manifest is green."
 
 Pure markdown so humans can read; fenced YAML so /do and a future /verify can parse deterministically. Pass numbers are sequential within the execution log. /do uses the most recent block to track progress and decide which pass to invoke next.

--- a/dist/gemini/README.md
+++ b/dist/gemini/README.md
@@ -6,9 +6,9 @@ Verification-first manifest workflows for Gemini CLI. Plan work with structured 
 
 | Type | Count | Description |
 |------|-------|-------------|
-| Skills | 13 | Workflow skills: define, do, verify, auto, figure-out, escalate, done, tend-pr, tend-pr-tick, learn-define-patterns, thinking-disciplines, stop-thinking-disciplines |
+| Skills | 12 | Workflow skills: define, do, verify, auto, figure-out, escalate, done, tend-pr, tend-pr-tick, learn-define-patterns, thinking-disciplines, stop-thinking-disciplines |
 | Agents | 14 | Specialized review agents for code quality verification |
-| Hooks | 8 | Event-driven hooks enforcing workflow discipline |
+| Hooks | 7 | Event-driven hooks enforcing workflow discipline |
 
 ## Installation
 
@@ -51,7 +51,7 @@ The `install.sh` script sets this automatically.
 
 | Feature | Claude Code | Gemini CLI | Notes |
 |---------|-------------|------------|-------|
-| Skills | All 13 | All 13 | Copied unchanged |
+| Skills | All 12 | All 12 | Copied unchanged |
 | Agents | All 14 | All 14 | Frontmatter converted |
 | Hooks | 8 hooks | 8 hooks | Adapted to Gemini event model |
 | Stop enforcement | PreToolUse/Stop | BeforeTool/AfterAgent | Retry counter for loop prevention |

--- a/dist/gemini/agents/code-maintainability-reviewer.md
+++ b/dist/gemini/agents/code-maintainability-reviewer.md
@@ -315,7 +315,7 @@ Do not fabricate issues to fill the report. A clean review is a valid outcome.
 
 - **Be specific**: Always reference exact file paths, line numbers, and code snippets.
 - **Be actionable**: Every issue must have a concrete, implementable fix suggestion.
-- **Consider context**: Account for project conventions from CLAUDE.md files and existing patterns.
+- **Consider context**: Account for project conventions from GEMINI.md files and existing patterns.
 - **Avoid false positives**: Always read full files before flagging issues. A diff alone lacks context—code that looks duplicated in isolation may serve different purposes when you see the full picture.
 - **Avoid these common false positives**:
   - Test file duplication (test setup repetition is often intentional for isolation)

--- a/dist/gemini/agents/criteria-checker.md
+++ b/dist/gemini/agents/criteria-checker.md
@@ -1,6 +1,6 @@
 ---
 name: criteria-checker
-description: 'Read-only verification agent. Validates a single criterion using any automated method: commands, codebase analysis, file inspection, reasoning, web research. Returns structured PASS/FAIL results.'
+description: '''Read-only verification agent. Validates a single criterion using any automated method: commands, codebase analysis, file inspection, reasoning, web research. Returns structured PASS/FAIL results.'''
 kind: local
 tools:
   - run_shell_command

--- a/dist/gemini/agents/define-session-analyzer.md
+++ b/dist/gemini/agents/define-session-analyzer.md
@@ -1,6 +1,6 @@
 ---
 name: define-session-analyzer
-description: 'Analyze a single /define session transcript to extract user preference patterns. Spawned by learn-define-patterns skill for parallel per-session analysis.'
+description: '''Analyze a single /define session transcript to extract user preference patterns. Spawned by learn-define-patterns skill for parallel per-session analysis.'''
 kind: local
 tools:
   - read_file
@@ -39,7 +39,7 @@ Preferences about what /define should probe for or how it should probe. Examples
 Consistent trade-off resolutions the user makes. Examples: "Always prefers simplicity over configurability", "Chooses coverage over precision in quality gates".
 
 ### Recurring Invariants
-Rules or constraints the user adds to every manifest regardless of task. Examples: "Always requires CLAUDE.md adherence check", "Always includes lint/format/typecheck gate".
+Rules or constraints the user adds to every manifest regardless of task. Examples: "Always requires GEMINI.md adherence check", "Always includes lint/format/typecheck gate".
 
 ### Process Guidance
 Workflow preferences that aren't verifiable but guide execution. Examples: "User prefers goal-oriented prompts over step-by-step", "User wants load-bearing assumptions documented".

--- a/dist/gemini/agents/manifest-verifier.md
+++ b/dist/gemini/agents/manifest-verifier.md
@@ -1,6 +1,6 @@
 ---
 name: manifest-verifier
-description: 'Reviews /define manifests for gaps and outputs actionable continuation steps. Returns specific questions to ask and areas to probe so interview can continue.'
+description: '''Reviews /define manifests for gaps and outputs actionable continuation steps. Returns specific questions to ask and areas to probe so interview can continue.'''
 kind: local
 tools:
   - read_file

--- a/dist/gemini/gemini-extension.json
+++ b/dist/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.1.0",
+  "version": "0.92.0",
   "description": "Verification-first manifest workflows for Gemini CLI",
   "mcpServers": {},
   "excludeTools": [],

--- a/dist/gemini/skills/auto/SKILL.md
+++ b/dist/gemini/skills/auto/SKILL.md
@@ -33,7 +33,15 @@ The remaining text after flag extraction is the task description (`$TASK_DESCRIP
 
 4. **Tend PR** (only when `--tend-pr` is present) — After /do completes successfully (calls `/done`, not `/escalate`), invoke the manifest-dev:tend-pr skill with: "<manifest-path> --log <execution-log-path>" (the execution log path is available from the conversation context — /do logged its creation at the start of execution). Append `--platform <platform>`, `--interval <duration>`, and `--reviewers <usernames>` if specified in the original /auto arguments.
 
-   If /do escalates instead of completing: do NOT invoke /tend-pr. Report to user: "/do escalated — skipping /tend-pr. Reason: <escalation reason from /do>. Resolve the blocker and re-invoke /tend-pr manually with the manifest path."
+   If /do escalates with **"Deferred-Auto Pending"**: this is a coordination handoff, not a blocker — the implementation is green; the user just needs to run `/verify --deferred` later when prerequisites are ready. Still invoke /tend-pr for cwd's PR (per §Multi-Repo Behavior). Surface the deferred-auto reminder to the user alongside the PR link: "/auto: implementation green; /tend-pr started for cwd's PR. Deferred-auto criteria pending — run `/verify <manifest-path> <log-path> --deferred` when prerequisites are in place to reach /done."
+
+   If /do escalates with any other type: do NOT invoke /tend-pr. Report to user: "/do escalated — skipping /tend-pr. Reason: <escalation reason from /do>. Resolve the blocker and re-invoke /tend-pr manually with the manifest path."
+
+## Multi-Repo Behavior
+
+If `/define` produces a multi-repo manifest (Intent declares `Repos:`), `/auto`'s `/do` invocation **navigates all repos** declared in `Repos:` — `/do` reads the path map and uses absolute paths natively (no filter logic). A single `/auto` invocation can therefore complete the whole multi-repo implementation phase.
+
+The per-cwd limitation is `/tend-pr`: with `--tend-pr`, only cwd's PR is set up for tending, because `/tend-pr` is PR-bound by construction. To tend other repos' PRs, invoke `/tend-pr` from each other repo's cwd. See `manifest-dev:define/references/MULTI_REPO.md` §i.
 
 ## Failure Handling
 

--- a/dist/gemini/skills/define/SKILL.md
+++ b/dist/gemini/skills/define/SKILL.md
@@ -147,13 +147,21 @@ When `--amend <manifest-path>` is present: read `references/AMENDMENT_MODE.md` f
 
 ## Multi-Repo Scope
 
-When task spans multiple repositories, capture during intent (starting points):
+When the task spans multiple repositories, the manifest stays a single canonical document covering the entire changeset. Full convention is in `references/MULTI_REPO.md` — this section summarizes only what the manifest captures.
 
-- **Which repos** and their roles
-- **Cross-repo constraints** (dependencies, coordination requirements)
-- **Per-repo differences** (different rules, conventions, verification needs)
+**Conditional schema additions** (omit entirely for single-repo manifests):
 
-Scope deliverables and verification to repo context. Cross-repo invariants get explicit verification checking both sides.
+- Intent declares `Repos: [name: path, ...]` listing every repo in scope.
+- Intent optionally declares `Branch: <name>` (single string — same branch name across repos by convention).
+- Each repo-specific deliverable carries a `repo: <name>` tag matching one of the declared repos.
+
+`Repos:` and `repo:` exist for **documentation** — readers (human and agent) know which deliverable lives where. They are **not** an enforcement mechanism for `/do` or `/verify` — `/do` navigates absolute paths from `Repos:` natively (no filter logic).
+
+Cross-repo gates the user must explicitly trigger (e.g., post-deploy verification across services) get `method: deferred-auto`. Normal `/do→/verify` flow skips them during the pass, **but routes to `/escalate` ("Deferred-Auto Pending") instead of `/done` while they remain uncovered**; the user runs `/verify --deferred` when prerequisites are in place. See `references/MULTI_REPO.md` §e.
+
+**Detection** rides on the existing Domain Understanding coverage goal — when conversation, task description, or branch context indicates multiple repos, treat as multi-repo and populate `Repos:` accordingly. No separate probe step is added.
+
+Single-repo manifests omit `Repos:`, `Branch:`, and `repo:` tags entirely; the schema and downstream behavior are identical to today.
 
 ## Principles
 
@@ -377,6 +385,10 @@ Three categories, each covering **output** or **process**:
 - **Mode:** efficient | balanced | thorough *(optional, default: thorough — controls verification intensity during /do)*
 - **Interview:** minimal | autonomous | thorough *(optional, default: thorough — recorded so --amend can inherit the original interview style)*
 - **Medium:** local *(optional, default: local — currently only local is supported)*
+- **Repos:** *(optional, multi-repo only — see `references/MULTI_REPO.md`; omit for single-repo manifests)*
+    - name1: /absolute/path/to/repo1
+    - name2: /absolute/path/to/repo2
+- **Branch:** *(optional, multi-repo only — single string, same branch name across all repos by convention)*
 
 ## 2. Approach (Complex Tasks Only)
 *Initial direction, not rigid plan. Provides enough to start confidently; expect adjustment when reality diverges.*
@@ -401,13 +413,15 @@ Three categories, each covering **output** or **process**:
 - [INV-G1] Description: ... | Verify: [Method]
   ```yaml
   verify:
-    method: bash | codebase | subagent | research | manual
+    method: bash | codebase | subagent | research | manual | deferred-auto
     phase: "[numeric, optional, default 1 — higher phases run after lower phases pass]"
     command: "[if bash]"
     agent: "[if subagent]"
     model: "[if subagent, default inherit]"
     prompt: "[if subagent or research]"
   ```
+
+*`method: deferred-auto` on INV-G* = cross-repo gate the user explicitly triggers via `/verify --deferred`. Skipped during normal `/do→/verify`; routes to `/escalate` "Deferred-Auto Pending" if uncovered when normal flow would otherwise reach `/done`. INV-G* deferred-auto criteria are deliverable-scope-independent — covered only by a `--deferred` pass with empty `--scope`. See `references/MULTI_REPO.md` §e.*
 
 ## 4. Process Guidance (Non-Verifiable)
 *Constraints on HOW to work. Not gates—guidance for the implementer.*
@@ -423,16 +437,18 @@ Three categories, each covering **output** or **process**:
 *Ordered by execution order from Approach, or by dependency then importance.*
 
 ### Deliverable 1: [Name]
-*[If multi-repo: specify repo scope]*
+**Repo:** `name1` *(optional, multi-repo only — must match a name in Intent's `Repos:` map; omit for single-repo manifests)*
 
 **Acceptance Criteria:**
 - [AC-1.1] Description: ... | Verify: ...
   ```yaml
   verify:
-    method: bash | codebase | subagent | research | manual
+    method: bash | codebase | subagent | research | manual | deferred-auto
     phase: "[numeric, optional, default 1]"
     [details]
   ```
+
+*`method: deferred-auto` = automatically verifiable but skipped during normal `/do→/verify`; runs only via `/verify --deferred`. Use for cross-repo gates the user explicitly triggers. See `references/MULTI_REPO.md` §e.*
 
 ### Deliverable 2: [Name]
 ...

--- a/dist/gemini/skills/define/references/AMENDMENT_MODE.md
+++ b/dist/gemini/skills/define/references/AMENDMENT_MODE.md
@@ -4,11 +4,15 @@
 
 ## Cumulative Manifest Rule
 
-**The manifest is the canonical source of truth for the PR/branch lifetime — not for a single task.** After every amendment, the manifest must describe the FULL PR state: intent, every deliverable, every Global Invariant, every Process Guidance entry, every Known Assumption. The latest increment is layered onto the prior content, never substituted for it.
+**The manifest is the canonical source of truth for the PR/branch lifetime — or, in multi-repo cases, the entire PR set / branch set lifetime — not for a single task.** After every amendment, the manifest must describe the FULL state of every PR it covers: intent, every deliverable (across every repo when multi-repo), every Global Invariant, every Process Guidance entry, every Known Assumption. The latest increment is layered onto the prior content, never substituted for it.
 
 **No silent drops.** When applying an amendment, prior content is preserved by default. Removal is explicit — if a change supersedes an existing AC/INV/PG, the supersession is logged in the `## Amendments` section with rationale. The amendment receiver is responsible for reading the full prior manifest and confirming nothing valuable was lost.
 
-A manifest at any point in time should be readable as "everything currently in scope for this PR/branch," not "the most recent change request." This is what makes the manifest a useful artifact for PR descriptions, reviews, and future amendments.
+A manifest at any point in time should be readable as "everything currently in scope for this PR/branch (or PR set)," not "the most recent change request." This is what makes the manifest a useful working artifact for the agent and the user across the PR lifecycle.
+
+**Multi-repo specifics** — when the manifest declares `Repos:` in Intent, the canonical manifest is shared across all repo PRs (`/tmp/manifest-{ts}.md`); any consumer skill that writes amendments operates on the same file, last-writer-wins (no locking). See `MULTI_REPO.md` §f for the convention.
+
+**Deferred-auto re-verification after amendment** — when an amendment substantively changes a `method: deferred-auto` criterion's verify block (`prompt:`, `command:`, etc.), prior `/verify --deferred` coverage is conceptually invalidated for that criterion. Normal `/verify` always re-runs in-scope criteria so amendments are picked up automatically; deferred-auto bypasses the pass and relies on prior coverage. The user is responsible for re-running `/verify --deferred` for the amended criterion before the gate clears. (Consistent with the user-as-coordinator stance — there is no automatic invalidation mechanism.)
 
 ## Core Behavior
 

--- a/dist/gemini/skills/define/references/MULTI_REPO.md
+++ b/dist/gemini/skills/define/references/MULTI_REPO.md
@@ -1,0 +1,163 @@
+# Multi-Repo Manifest Workflow
+
+Canonical reference for tasks whose changeset spans multiple repositories. Read this when a manifest declares `Repos:` in its Intent. Core skills (`/define`, `/do`, `/verify`, `/done`, `/auto`, `AMENDMENT_MODE`) summarize the rules below and link here for the full specification. Optional consumer skills (`/tend-pr`, `/tend-pr-tick`, `/drive`, `/drive-tick`) describe how they ride the shared-manifest pattern in their own files — they are add-ons, not part of the core multi-repo workflow.
+
+Single-repo manifests (no `Repos:` field) are unaffected by everything below.
+
+## a. Principle
+
+The shared canonical manifest is the **default and recommended** approach for multi-repo changesets: one manifest captures the whole thing — shared intent, all deliverables (each tagged with its repo), shared invariants, shared trade-offs. The reason it's the default: splitting per PR forces the user to hold cross-PR coherence in their head, which is the work the manifest exists to externalize.
+
+Splitting per repo (one manifest per repo's PR) is a **legitimate user choice** when the work is loosely coupled and the user prefers independent scopes — they accept carrying the cross-PR coherence themselves. Everything below describes the shared-manifest case (when `Repos:` is declared in Intent); the split case is just N independent single-repo manifests and needs no special rules.
+
+The manifest is **internal**. It is a working document for the user and the agent. PR descriptions remain summary-only — no manifest embed, no PR-side surfacing.
+
+## b. Persistence
+
+The canonical manifest lives at `/tmp/manifest-{timestamp}.md`. No archival. No copying to `.manifest/` for multi-repo. No primary repo "owns" it.
+
+If the file is lost (reboot, `/tmp` cleared, session death), re-run `/define` against the same task. The recreated manifest restarts the working state; in-flight PRs continue under the new manifest path.
+
+This is an explicit trade-off: durability infrastructure is more cost than re-running `/define` is occasional pain.
+
+## c. Repo Registration
+
+The manifest's `## 1. Intent & Context` section declares its multi-repo scope:
+
+```markdown
+- **Repos:**                                  # optional, multi-repo only
+    - backend: /home/user/projects/api
+    - frontend: /home/user/projects/web
+- **Branch:** claude/sso-integration          # optional, single string (see §j)
+```
+
+Each deliverable that belongs to a specific repo carries a `repo:` tag matching one of the names above:
+
+```markdown
+### Deliverable 3: SSO endpoint
+**Repo:** `backend`
+```
+
+`Repos:` and `repo:` exist for **documentation** — readers (human and agent) know which deliverable lives where. They are **not** an enforcement mechanism for `/do` or `/verify` (see §d). Optional consumer skills may use the tags for their own scope inference (e.g., a PR-tending tool routing feedback on backend's PR to backend-tagged deliverables), but core skills do not depend on this.
+
+Single-repo manifests omit both `Repos:` and `repo:` entirely.
+
+## d. /do Navigation
+
+`/do` reads `Repos:` from the manifest and uses absolute paths in tool calls (Read/Edit/Write/Bash) when a deliverable lives outside cwd. The LLM handles navigation natively — there is no filter logic, no cwd-to-repo matching, no per-repo configuration in `/do`.
+
+The user can invoke `/do` once globally (the agent navigates between repos as deliverables require), or per-repo with `--scope` (each `/do` handles its repo's slice). Either works.
+
+`/do`'s execution log remains a single file per invocation: `/tmp/do-log-{timestamp}.md`. No per-repo log naming.
+
+Worked example — manifest declares:
+
+```markdown
+- **Repos:**
+    - backend: /home/user/projects/api
+    - frontend: /home/user/projects/web
+
+### Deliverable 1: SSO endpoint
+**Repo:** `backend`
+**Acceptance Criteria:**
+- [AC-1.1] POST /auth/sso accepts SAML assertion
+  ```yaml
+  verify:
+    method: bash
+    command: "curl -X POST http://localhost:8080/auth/sso -d @/tmp/saml-test.xml"
+  ```
+```
+
+`/do` invoked from any cwd reads `Repos:`, navigates to `/home/user/projects/api` for D1's edits via absolute paths, runs the verify command. No filter required.
+
+## e. method: deferred-auto + /verify --deferred
+
+Cross-repo gates often cannot run during normal `/do→/verify` flow because they depend on prerequisites the user controls (e.g., "all PRs deployed to staging"). They are still **automatically verifiable** — just user-triggered.
+
+`method: deferred-auto` marks such criteria. Worked example:
+
+```yaml
+- [INV-G7] Frontend SSO login round-trips through deployed backend
+  verify:
+    method: deferred-auto
+    agent: general-purpose
+    prompt: "Hit https://staging.example.com/login with a test SAML assertion. Confirm successful redirect to /dashboard with a valid session cookie."
+```
+
+Normal `/verify` invocations skip `deferred-auto` criteria during the pass itself. **However, `/verify` will not call `/done` while deferred-auto criteria remain unverified** — instead it routes to `/escalate` with type "Deferred-Auto Pending," signaling the user to run `/verify --deferred` when prerequisites are ready. Only after the deferred-auto criteria pass via `/verify --deferred` does a subsequent normal `/verify` pass reach `/done`. The pass log's `deferred: true|false` field tracks which prior runs covered the deferred-auto set.
+
+When the user signals readiness ("all PRs deployed"), they invoke:
+
+```
+/verify <manifest> <log> --deferred
+```
+
+This runs **only** `deferred-auto` criteria. Flag interactions:
+
+- `--deferred` + `--scope` is supported. `--scope` narrows the deferred set to in-scope deliverables.
+- `--deferred` does not interact with `--final`. It never enters the final-gate machinery.
+- `--deferred` inherits `--mode`. Same parallelism and model routing as the parent invocation.
+
+### Cross-repo path delivery to verifiers
+
+When the manifest declares `Repos: [name: path, ...]`, every `/verify` invocation (selective, full, and `--deferred`) prepends a verbatim string to each verifier's prompt before the criterion's own prompt:
+
+```
+Available repos: backend=/home/user/projects/api, frontend=/home/user/projects/web
+
+[criterion's own prompt follows]
+```
+
+This applies on every pass — not just `--deferred` — so cross-repo verifiers can run during normal `/do→/verify` flow. That's what allows `/done` to fire once per multi-repo manifest (§g) without forcing per-repo /done independence.
+
+Single-repo manifests (no `Repos:` field) get no prefix injection. Manifests with no `deferred-auto` criteria see `/verify --deferred` as a no-op with a clean message.
+
+## f. Shared Manifest Amendment Across PRs
+
+The canonical `/tmp` manifest is shared across all PRs in a multi-repo changeset. Any tool that writes amendments — whether the user editing the file directly, or any optional consumer skill — operates on this single shared file.
+
+There is **no concurrency engineering**. Two writers amending the same manifest at the same instant — last-writer-wins. The later write may overwrite the earlier write's amendment block. Recovery: the writer who lost their amendment notices the missing change in the next iteration and re-triggers it (e.g., re-add the comment that prompted it, or re-invoke whatever workflow generated it).
+
+**Do not add file locking.** The collision rate is low (writes are brief), and the recovery cost is small compared to the complexity of locking, deadlock handling, and stale-lock cleanup.
+
+This pattern is the contract for any optional PR-tending consumer skill (e.g., `/tend-pr`, `/drive`); those skills describe their per-PR usage in their own files.
+
+## g. /done — One Per Manifest, Gated on Deferred-Auto
+
+`/done` fires **once per manifest**, including for multi-repo manifests. There is no per-repo `/done` independence. /verify's "every AC across every deliverable" rule is preserved unchanged; for multi-repo, that means every AC in every repo's deliverables must pass before `/done` is called.
+
+This is achievable because `/verify`'s cross-repo prompt-prefix injection (§e) fires on every pass when `Repos:` is declared — verifiers in normal `/do→/verify` flow have access to all repos' paths and can verify cross-repo behavior without `--deferred`.
+
+**`/done` is gated on no deferred-auto criteria pending.** When the manifest contains `method: deferred-auto` criteria that have not been verified green via a prior `/verify --deferred`, `/verify` routes to `/escalate` ("Deferred-Auto Pending") instead of `/done` — making the user-as-coordinator handoff explicit rather than silently completing. After the user runs `/verify --deferred` and the deferred-auto criteria pass, a subsequent normal `/verify` pass reaches `/done`.
+
+For multi-repo manifests, the `/done` summary lists which repos' deliverables were verified — providing a clear inventory of what landed across the changeset.
+
+## h. User as Coordinator
+
+There is no coordinator process, no primary repo, no orchestrator skill. The user coordinates by:
+
+1. Invoking `/do` or `/auto` (once globally to navigate all repos, or per-repo with `--scope` for parallel execution).
+2. Opening / managing each repo's PR with whatever PR-management workflow they prefer (manual, or via an optional consumer skill).
+3. Triggering `/verify --deferred` once cross-repo prerequisites are in place (e.g., "all PRs merged and deployed").
+
+The system supports this workflow but does not automate it. Coordination is a human concern that the manifest captures the *state* of, not a state machine the system drives.
+
+## i. /auto Behavior
+
+`/auto` chains `/define` → `/do` → optionally `/tend-pr`. The `/do` step **navigates all repos** declared in `Repos:` (per §d — no filter logic, LLM uses absolute paths from the map). A single `/auto` invocation can therefore complete the whole multi-repo implementation phase.
+
+The per-cwd limitation is `/tend-pr`: when `--tend-pr` is set, `/auto` invokes `/tend-pr` from cwd, which sets up tending for cwd's PR only — `/tend-pr` is PR-bound by construction (see §f). To tend the other repos' PRs, invoke `/tend-pr` from each other repo's cwd.
+
+This is the only multi-repo footgun in `/auto`: users may assume `--tend-pr` covers all PRs, when it covers only cwd's. The implementation phase itself runs to completion across all repos in one go.
+
+## j. Branch-Name Convention
+
+By default, all repos in a multi-repo changeset use the **same branch name**. This matches the existing harness pattern (per-repo branch declarations in the system prompt that share a branch identifier).
+
+The manifest's Intent records the branch name as a single string:
+
+```markdown
+- **Branch:** claude/sso-integration
+```
+
+Divergent branch names per repo are not supported by this version. A future extension could replace `Branch: <string>` with `Branches: [name -> branch]` if real cases demand it.

--- a/dist/gemini/skills/define/tasks/CODING.md
+++ b/dist/gemini/skills/define/tasks/CODING.md
@@ -4,7 +4,7 @@ Base guidance for all code-change tasks (features, bugs, refactors).
 
 ## Quality Gates
 
-CLAUDE.md may specify project-specific preferences.
+GEMINI.md may specify project-specific preferences.
 
 ### Base Gates (always applicable)
 
@@ -20,7 +20,7 @@ Defect-finding agents: every finding at Low severity or above fails the gate (`n
 | Testability | code-testability-reviewer | no MEDIUM+ |
 | Documentation | docs-reviewer | no MEDIUM+ |
 | Design fitness | code-design-reviewer | no MEDIUM+ |
-| CLAUDE.md adherence | context-file-adherence-reviewer | no MEDIUM+ |
+| GEMINI.md adherence | context-file-adherence-reviewer | no MEDIUM+ |
 
 ### Conditional Gates (when applicable)
 
@@ -31,7 +31,7 @@ Defect-finding agents: every finding at Low severity or above fails the gate (`n
 
 ## Project Gates
 
-CLAUDE.md specifies project gates (typecheck, lint, test, format). These become Global Invariants.
+GEMINI.md specifies project gates (typecheck, lint, test, format). These become Global Invariants.
 
 ## E2E Verification
 
@@ -74,7 +74,7 @@ CLAUDE.md specifies project gates (typecheck, lint, test, format). These become 
 *Domain best practices for this task type.*
 
 - **Run existing tests before modifying test files** — Verify current test state before changing tests; prevents masking pre-existing failures
-- **Read project gates from CLAUDE.md** — Discover project-specific commands (typecheck, lint, test, format) before implementation
+- **Read project gates from GEMINI.md** — Discover project-specific commands (typecheck, lint, test, format) before implementation
 
 ## Multi-Repo
 

--- a/dist/gemini/skills/do/SKILL.md
+++ b/dist/gemini/skills/do/SKILL.md
@@ -71,9 +71,11 @@ When `--scope` is NOT provided, ignore this section entirely — no reference fi
 
 The mandatory full final gate (auto-triggered by /verify after selective green) is the safety net for cross-deliverable regressions. Don't try to skip or short-circuit it.
 
-**Execution log /verify contract** - /verify appends a structured block (`## /verify pass {N}` + fenced YAML with `mode`, `scope`, `result`, `failures`, `auto_triggered_final`) per invocation. Read the most recent block before deciding the next pass's scope. Format defined in `verify/SKILL.md` "Pass Logging Contract."
+**Execution log /verify contract** - /verify appends a structured block (`## /verify pass {N}` + fenced YAML with `mode`, `scope`, `result`, `failures`, `auto_triggered_final`, `deferred`) per invocation. Read the most recent block before deciding the next pass's scope. Format defined in `verify/SKILL.md` "/verify Pass Logging Contract." When scanning for the most recent /verify pass to drive scope decisions, **skip blocks with `deferred: true`** — those reflect user-direct `--deferred` invocations (now possible since /verify is user-invocable), not /do-driven normal-flow passes.
 
 **Escalation boundary** - Escalate when: (1) ACs can't be met as written (contract broken), (2) user requests a pause mid-workflow, (3) you discover an AC or invariant should be amended (use "Proposed Amendment" escalation type), or (4) the active execution mode's fix-verify loop limit is reached. If ACs remain achievable as written and no user interrupt, continue autonomously.
+
+**`/verify`-routed escalation passthrough.** When `/verify` itself routes to `/escalate` (e.g., "Deferred-Auto Pending", "Manual Criteria Review") instead of `/done`, treat as a clean terminal handoff: surface the escalation output verbatim to the caller, do NOT enter the fix-loop, do NOT increment loop counters. The implementation is green; further action belongs to the user (e.g., running `/verify --deferred` for deferred-auto pending). This is distinct from `/verify` returning failures (which enters the standard fix-loop).
 
 **Mode-aware loop tracking** - Track fix-verify iteration count and escalation count in the execution log. When the active execution mode's limits are reached, follow its escalation rules.
 
@@ -93,9 +95,19 @@ Externalize progress to survive context loss.
 
 **Refresh between deliverables** - Before starting a new deliverable, re-read the manifest's deliverable section and relevant log entries. Context degrades across long sessions.
 
+## Multi-Repo Navigation
+
+When the manifest declares `Repos: [name: path, ...]` in Intent, deliverables may live in repos other than cwd. Read the path map and use **absolute paths** in tool calls (Read/Edit/Write/Bash) when working on a deliverable tagged with a different repo. There is **no filter logic, no cwd matching, no per-repo configuration** — the LLM navigates as deliverables require.
+
+A single `/do` invocation can cover the whole multi-repo task by navigating between repos; alternatively the user invokes `/do` per repo with `--scope` for parallel execution. Either works. The execution log remains a single file per `/do` invocation.
+
+When the manifest has no `Repos:` field (single-repo manifest), this section does not apply — behavior is unchanged.
+
+Full convention: `references/MULTI_REPO.md` (lives in `define/references/`).
+
 ## Mid-Execution Amendment
 
-**Default to amend.** Any user message arriving during /do or /verify defaults to triggering Self-Amendment. The manifest is the canonical source of truth for the PR/branch (per `references/AMENDMENT_MODE.md`); feedback flows through it, not around it. The asymmetric framing is deliberate: silent scope drift (feedback acted on inline, manifest left out of date) is a worse failure than an occasional unnecessary amendment cycle.
+**Default to amend.** Any user message arriving during /do or /verify defaults to triggering Self-Amendment. The manifest is the canonical source of truth for the PR/branch — or, in multi-repo cases, the **PR set / branch set** (see `references/AMENDMENT_MODE.md`). Feedback flows through it, not around it. The asymmetric framing is deliberate: silent scope drift (feedback acted on inline, manifest left out of date) is a worse failure than an occasional unnecessary amendment cycle.
 
 **Carve-out: pure questions.** Messages that ask about the manifest or process without requesting a state change are answered inline — no amendment.
 - *Amend:* "Also handle X." / "Change Y to Z." / "That's wrong, it should be …" / "Add a check for …"
@@ -103,7 +115,7 @@ Externalize progress to survive context loss.
 
 **When ambiguous, amend.** A message that could be either ("hmm, what about the auth case?") goes to amendment. Re-running an amendment cycle is cheap; silently dropping a constraint that turns out to matter is expensive.
 
-**/verify-time feedback.** /verify is non-user-invocable orchestrator — semantically, user feedback received while /verify is running is feedback to /do (the caller), not to /verify. The same default-to-amend rule applies. /verify itself never handles user feedback inline; the message is interpreted in /do's context and routed through Self-Amendment.
+**/verify-time feedback.** While /verify is running under /do, user feedback received mid-pass is semantically feedback to /do (the caller), not to /verify. The same default-to-amend rule applies. /verify itself never handles user feedback inline; the message is interpreted in /do's context and routed through Self-Amendment. (When /verify is invoked directly by the user — e.g., `/verify --deferred` — there is no /do caller; mid-pass user messages are handled per the user's own session reflex, not via /do's amendment route.)
 
 **Amendment flow** — Amend the manifest autonomously via Self-Amendment escalation and `/define --amend <manifest-path> --from-do`, then resume with the updated manifest and existing log. Log the trigger before amending. No human wait — the entire cycle is autonomous.
 

--- a/dist/gemini/skills/done/SKILL.md
+++ b/dist/gemini/skills/done/SKILL.md
@@ -24,6 +24,14 @@ Read the execution log and manifest. Output a summary that shows:
 4. **Key changes** - Files modified, commits made
 5. **Tradeoffs applied** - How preferences were used
 
+When the manifest declares `Repos:` (multi-repo), `/done` still fires **once per manifest** — not once per repo. /verify's "every AC across every deliverable" rule is preserved unchanged; for multi-repo, that means every AC in every repo's deliverables must pass before `/done` is called. This is achievable because `/verify` injects the cross-repo path prefix (`Available repos: ...`) on every pass when `Repos:` is declared, so verifiers can reach all repos during normal flow.
+
+The multi-repo summary additionally lists which **repos' deliverables were verified in this run** — providing a clear inventory of what landed across the changeset.
+
+**`/done` is gated on no deferred-auto criteria pending.** When the manifest contains `method: deferred-auto` criteria that have not yet been verified green via `/verify --deferred`, `/verify` does NOT call `/done` — it routes to `/escalate` with type "Deferred-Auto Pending" instead, telling the user to run `/verify --deferred` when prerequisites are in place. Only after deferred-auto criteria pass via `--deferred` does a subsequent normal `/verify` pass reach `/done`. See `define/references/MULTI_REPO.md` §e/§g and `verify/SKILL.md` "Deferred-Pending Escalation".
+
+Single-repo manifests (no `Repos:` field) get the standard summary unchanged — no repo list, no deferred-auto note. The deferred-auto-pending escalation rule applies regardless of multi-repo (any manifest with deferred-auto criteria, single- or multi-repo, gates /done the same way).
+
 ## Output Format
 
 ```markdown
@@ -72,11 +80,11 @@ The trailing italic line is **mandatory** in /done's output — it surfaces the 
 1. **Mirror manifest structure** - Hierarchy should match: Intent → Global Invariants → Deliverables
 2. **Show evidence** - Link changes to deliverables, describe behavioral changes (not just file lists)
 3. **Adapt detail to complexity** - Simple task = condensed output. Complex task = full hierarchy.
-4. **Called by /verify only, after a full-suite green pass** - /done is the final step after /verify confirms a **full pass** is green — every AC across every deliverable plus every Global Invariant. Selective-mode green alone is not sufficient (per /verify's hard final gate); /verify auto-triggers a full pass after selective green and only then calls /done.
+4. **Called by /verify only, after a full-suite green pass** - /done is the final step after /verify confirms a **full pass** is green — every AC across every deliverable plus every Global Invariant — **AND no `deferred-auto` criteria are pending** (when pending deferred-auto criteria exist, /verify routes to /escalate "Deferred-Auto Pending" instead of calling /done; see narrative above and `verify/SKILL.md` Deferred-Pending Escalation). Selective-mode green alone is not sufficient (per /verify's hard final gate); /verify auto-triggers a full pass after selective green and only then calls /done.
 
 ## Post-Completion Feedback
 
-After /done has been called, the manifest is still the canonical source of truth for the PR/branch — the work isn't necessarily merged, and feedback can still arrive (user comments, PR reviews, second thoughts). The default reflex for any feedback that changes scope or contradicts something settled is the same as during /do (per `do/SKILL.md` Mid-Execution Amendment): **default to amend.**
+After /done has been called, the manifest is still the canonical source of truth for the PR/branch — or the **PR set / branch set** in the multi-repo case — because the work isn't necessarily merged, and feedback can still arrive (user comments, PR reviews, second thoughts). The default reflex for any feedback that changes scope or contradicts something settled is the same as during /do (per `do/SKILL.md` Mid-Execution Amendment): **default to amend.**
 
 **Re-entry flow:** when feedback is determined to be amendment-worthy (not a pure question), invoke `/define --amend <manifest-path>` with the feedback as input, then `/do <manifest-path> <log-path> --scope <new-or-affected-deliverables>` to implement the change. /do's selective-mode + mandatory full final gate apply to the re-entry pass — /done won't be reachable again until the full suite is green on the amended manifest.
 

--- a/dist/gemini/skills/escalate/SKILL.md
+++ b/dist/gemini/skills/escalate/SKILL.md
@@ -197,6 +197,31 @@ User explicitly asked to stop mid-workflow (e.g., "commit so I can deploy", "sto
 
 **When to use**: User interrupts workflow for legitimate reasons (deploy, review, break). Not a blocker—just a handoff.
 
+### Deferred-Auto Pending
+
+Normal-flow `/verify` completed green, but the manifest contains `method: deferred-auto` criteria that have not yet been verified green via a prior `/verify --deferred` run. This is a coordination handoff, not a blocker — `/done` is unreachable until the user signals readiness and runs `/verify --deferred`. **No 3-attempt evidence required.** Fired by `/verify`, not by `/do`.
+
+```markdown
+## Escalation: Deferred-Auto Pending
+
+**Reason:** Normal-flow verification green; deferred-auto criteria require user signal before they can run.
+
+### Pending Deferred-Auto Criteria
+- [INV-G{N} or AC-{D}.{N}]: [description from manifest]
+- ...
+
+### To Resolve
+When prerequisites are in place (e.g., "all PRs deployed"), invoke:
+
+`/verify <manifest-path> <execution-log-path> --deferred`
+
+After `--deferred` completes green, re-invoke a normal `/verify <manifest-path> <execution-log-path>` (no flags) to reach `/done`.
+```
+
+**When to use**: `/verify` finishes a normal-flow pass green and detects pending deferred-auto criteria — see `verify/SKILL.md` Deferred-Pending Escalation. **Not** a blocker — implementation is done; the user controls when cross-repo / staging / deploy-dependent verification happens.
+
+**Combined with Manual Criteria Review.** When BOTH manual criteria and pending deferred-auto criteria exist after a normal full-mode green pass, compose a single combined escalation: header `## Escalation: Manual Review + Deferred-Auto Pending`, then both sections inline (Manual Criteria block + Pending Deferred-Auto Criteria block + To Resolve combining manual review steps and the `/verify --deferred` instruction). `/done` remains unreachable until both are resolved.
+
 ## Medium Routing
 
 When medium is non-local, /do routes escalations through the medium directly — /escalate is not invoked. The escalation templates above still define the expected content structure; /do uses them when composing messages to the channel.

--- a/dist/gemini/skills/learn-define-patterns/SKILL.md
+++ b/dist/gemini/skills/learn-define-patterns/SKILL.md
@@ -22,7 +22,7 @@ Every `/define` session, users make the same corrections, add the same invariant
 | **Merge, never overwrite** | If a `## /define Preferences` section already exists, merge new patterns with existing ones. Never blindly overwrite. |
 | **Semantic deduplication** | When merging, identify patterns that say the same thing in different words and consolidate them. Don't just check for exact text matches. |
 | **Standard markdown only** | Output uses `##` headers, `###` subheaders, `- ` bullets, and `<!-- date -->` HTML comments. No custom syntax, no YAML, no special parsing. |
-| **Ask write target** | Ask the user which GEMINI.md to write to: project GEMINI.md, user `~/.gemini/GEMINI.md`, or both. Never assume. |
+| **Ask write target** | Ask the user which GEMINI.md to write to: project GEMINI.md, user `~/.claude/CLAUDE.md`, or both. Never assume. |
 | **Diff preview before write** | Show the user exactly what will be added or changed in GEMINI.md before writing. |
 | **Clean up temp files** | Delete per-session analysis files from `/tmp/` after aggregation is complete. |
 
@@ -51,7 +51,7 @@ The final output is a unified set of user preferences derived from all analyzed 
 **What the user sees before approving:**
 - Pattern statement, session frequency, project-specific vs generalizable flag, any contradictions
 - Batch selection (not per-pattern approval)
-- Choice of write target: project GEMINI.md, user `~/.gemini/GEMINI.md`, or both
+- Choice of write target: project GEMINI.md, user `~/.claude/CLAUDE.md`, or both
 - Diff/preview of exact changes before writing
 
 # GEMINI.md Output Format

--- a/dist/gemini/skills/tend-pr-tick/SKILL.md
+++ b/dist/gemini/skills/tend-pr-tick/SKILL.md
@@ -68,9 +68,9 @@ Label source first (bot vs human — read `../tend-pr/references/known-bots.md`)
 *Runs when there are CI failures to handle or when new comments were classified.*
 
 **Manifest mode:** This is the same default-to-amend reflex documented canonically in `do/SKILL.md` Mid-Execution Amendment — PR comments and CI failures are external feedback that contradicts or extends the manifest, so they route through Self-Amendment. The only difference is the trigger source (PR thread vs. user message in a session).
-1. Identify which deliverable(s) the comment or CI failure targets (include all potentially affected when ambiguous).
-2. Amend manifest via `/define --amend <manifest-path> --from-do`.
-3. Invoke `/do <manifest-path> <log-path> --scope <affected-deliverable-ids>`. If `/do` escalates, log the blocker, report the escalation to the user, and end the loop.
+1. Identify which deliverable(s) the comment or CI failure targets (include all potentially affected when ambiguous). When the manifest declares `Repos:` (multi-repo) and deliverables carry `repo:` tags, look up this PR's repo via the platform adapter (e.g., GitHub MCP returns `owner/repo` for the PR number); for each absolute path in the manifest's `Repos:` map, run `git -C <path> remote get-url origin` and parse the URL to its `owner/repo` form; the entry whose remote matches the PR's `owner/repo` is the corresponding repo. Use that entry's `name:` as the deliverable filter — prefer deliverables tagged with the matching repo name.
+2. Amend manifest via `/define --amend <manifest-path> --from-do`. **Multi-repo:** the manifest is a shared canonical `/tmp` file used by every repo's `/tend-pr-tick` — concurrent amendments are last-writer-wins (no locking; see `tend-pr/SKILL.md` §Multi-Repo PR Sets and `define/references/MULTI_REPO.md` §f). If you notice a missed amendment, re-trigger the lost tick.
+3. Invoke `/do <manifest-path> <log-path> --scope <affected-deliverable-ids>`. If `/do` escalates with **"Deferred-Auto Pending"**: implementation is green — proceed to steps 4 and 5 normally (push the fix; reply to the originating thread). Append the deferred-auto reminder to this tick's Status Report so the user sees it: "Implementation green; run `/verify <manifest> <log> --deferred` when prerequisites are in place to reach /done." Do **NOT** terminate the tick — subsequent ticks continue normally toward merge-readiness. If `/do` escalates with any other type: log the blocker, report the escalation to the user, and end the loop.
 4. Push changes.
 5. If the actionable item originated from a comment, reply on that thread.
 
@@ -87,6 +87,8 @@ Label source first (bot vs human — read `../tend-pr/references/known-bots.md`)
 *Runs when this tick produced changes (routing fixes, conflict resolution). Skip when no changes were made.*
 
 After changes, rewrite "what changed" sections to reflect the current diff. Preserve manual context (issue references, motivation, deployment notes). Update title if scope changed significantly.
+
+The PR description stays summary-only — never embed the manifest. Manifests are internal working documents (also true in multi-repo, where the same canonical manifest is shared across all PRs without surfacing to reviewers).
 
 ## Status Report
 

--- a/dist/gemini/skills/tend-pr/SKILL.md
+++ b/dist/gemini/skills/tend-pr/SKILL.md
@@ -35,6 +35,16 @@ Two modes:
 - No argument, no manifest inferrable, and no open PR for current branch: "Error: No manifest or open PR found. Provide a manifest path or PR URL. Usage: /tend-pr <manifest-path-or-pr-url> [--platform github] [--interval 10m] [--reviewers user1,user2]"
 - `--platform` value not supported: "Error: Platform '<value>' not yet supported. Currently supported: github"
 
+## Multi-Repo PR Sets
+
+When the manifest declares `Repos:` in Intent (multi-repo changeset), each repo's PR is tended by its own `/tend-pr` invocation pointing at the **same canonical `/tmp` manifest**. PR descriptions stay summary-only — manifests are internal and never embedded in PRs.
+
+All `/tend-pr-tick` instances amend the same shared manifest. There is **no locking and no concurrency engineering**. Concurrent amendments are last-writer-wins; the later write may overwrite the earlier write's amendment block. Recovery: the user notices the missing amendment in the next iteration and re-triggers the lost tick (e.g., re-add the comment, re-run `/tend-pr-tick`). **Do not add file locking** — collisions are rare and the recovery cost is small.
+
+Single-repo manifests (no `Repos:` field) are unaffected — one `/tend-pr`, one PR, no shared-manifest considerations.
+
+Full convention: `references/MULTI_REPO.md` (in `define/references/`) §f.
+
 ## Setup
 
 **Manifest-aware mode:** Ensure a non-draft PR exists for the current branch — create one if none exists. Use the manifest's Intent section for PR title/description. If `--reviewers` was provided, request review from those users. Resolve the execution log path (from `--log`, most recent `/tmp/do-log-*.md`, or conversation context).

--- a/dist/gemini/skills/verify/SKILL.md
+++ b/dist/gemini/skills/verify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: verify
-description: 'Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest.'
-user-invocable: false
+description: 'Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest. Primary user-facing entry point is /verify --deferred (run user-triggered deferred-auto criteria); other invocations normally come from /do.'
+user-invocable: true
 ---
 
 # /verify - Manifest Verification Runner
@@ -10,9 +10,9 @@ Orchestrate verification of all criteria from a Manifest by spawning parallel ve
 
 **Input**: $ARGUMENTS
 
-Format: `<manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough] [--scope D1,D2,...] [--final]`
+Format: `<manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough] [--scope D1,D2,...] [--final] [--deferred]`
 
-Both paths required — return usage error if missing. Mode defaults to `thorough` if not provided. `--scope` and `--final` are mutually exclusive (final is full by definition); when both appear, treat as final.
+Both paths required — return usage error if missing. Mode defaults to `thorough` if not provided. `--scope` and `--final` are mutually exclusive (final is full by definition); when both appear, treat as final. `--deferred` runs only `method: deferred-auto` criteria — see "Deferred-Auto Criteria" below.
 
 ## Selective vs Full Verification
 
@@ -34,11 +34,11 @@ Both paths required — return usage error if missing. Mode defaults to `thoroug
 | **All in-scope criteria, no exceptions** | Every criterion in the current pass's scope (selective: in-scope deliverables' ACs + all INV-G*; full: every AC + every INV-G*) MUST be verified. Skipping any in-scope criterion is a critical failure. |
 | **Parallelism per mode** | The active execution mode defines how many verifiers to launch concurrently within each phase. Phases always run sequentially — see Phased Execution below. |
 | **Actionable feedback** | Pass through file:line, expected vs actual, fix hints. |
-| **Don't handle user feedback** | /verify is non-user-invocable. Any user message arriving while /verify is running is semantically feedback to /do (the caller). /verify never amends, never re-prompts, never deviates from its current pass — it returns results; /do interprets new user input per its own default-to-amend rule (`do/SKILL.md` Mid-Execution Amendment). |
+| **Don't handle user feedback during a pass** | While /verify is running, any user message arriving mid-pass is semantically feedback to the caller (/do, or the user who invoked /verify --deferred directly) — /verify never amends, never re-prompts, never deviates from its current pass. It returns results; the caller interprets new user input per its own rules (e.g., /do's Mid-Execution Amendment). User-direct invocations of /verify --deferred run to completion the same way. |
 
 ## Verification Routing
 
-Route `manual` criteria to /escalate. Route `subagent` criteria to the named agent specified in the criterion. All other types (`bash`, `codebase`, `research`) spawn criteria-checker agents. If a criterion has no verification type, default to criteria-checker.
+Route `manual` criteria to /escalate. Route `subagent` criteria to the named agent specified in the criterion. Route `deferred-auto` criteria per the "Deferred-Auto Criteria" section below — they are **skipped during normal /verify flow** and only run when `--deferred` is passed; under `--deferred`, they are routed by the inner shape of their verify block (if `agent:` is set, route to that named subagent; if `command:` is set, route to criteria-checker as bash; otherwise default to criteria-checker). All other types (`bash`, `codebase`, `research`) spawn criteria-checker agents. If a criterion has no verification type, default to criteria-checker.
 
 ## Agent Prompt Composition
 
@@ -62,6 +62,8 @@ Only include paths that exist. This is informational, not directive — agents d
 - Interpretations of manifest intent ("the goal is to...", "this change is about...")
 
 The verify block's `prompt:` field is manifest-authored — pass it verbatim. These rules target language you add beyond what the manifest specifies. The optional context file paths are raw references, not framing — they provide access to source material without steering the agent's analysis.
+
+**Exception — manifest-driven `Repos:` prefix.** When the manifest declares `Repos:`, the cross-repo path prefix (`Available repos: name=/path, ...`) is prepended to every verifier's prompt per "Cross-repo path delivery to verifiers" below. This is the one prescribed exception to "Do not add your own framing" — the prefix is manifest-driven (derived from `Repos:`), not orchestrator opinion.
 
 ## Criterion Types
 
@@ -112,20 +114,53 @@ Group results by phase, then Global Invariants first, then by Deliverable.
 | Any Global Invariant failed | Return all failures, globals highlighted |
 | Any AC failed | Return failures grouped by deliverable |
 | All in-scope pass, **selective mode that actually narrowed** (`--scope` was set) | **Auto-trigger a full pass** (re-invoke /verify internally with `--final`). Do NOT call /done. Manual criteria in scope are NOT escalated yet — they're deferred to the auto-triggered full pass per the rule below. |
-| All pass, **full mode**, manual criteria exist | List manual criteria with how-to-verify, suggest /escalate |
-| All pass, **full mode** | Call /done |
+| All pass, **full mode**, manual criteria exist (no pending deferred-auto) | List manual criteria with how-to-verify, suggest /escalate |
+| All pass, **full mode**, **deferred-auto criteria exist and not all verified green via prior `--deferred` pass** (no manual criteria) | /escalate with "Deferred-Auto Pending" — see "Deferred-Pending Escalation" below. Do NOT call /done. |
+| All pass, **full mode**, **manual criteria AND pending deferred-auto criteria** | Combined /escalate (Manual Review + Deferred-Auto Pending) per "When BOTH" in Deferred-Pending Escalation below. Do NOT call /done. |
+| All pass, **full mode**, no pending deferred-auto criteria, no manual criteria | Call /done |
 
-**Selective that degenerated to full = full mode for outcome handling.** When `--scope` is absent and `--final` is absent, the pass covered every criterion already. Treat as a full pass: if manual criteria exist → escalate (do not skip the manual row); otherwise → call /done. There is no "auto-trigger another full pass" for degenerated-to-full — that's redundant since the pass already covered everything.
+**Selective that degenerated to full = full mode for outcome handling.** When `--scope` is absent and `--final` is absent, the pass covered every criterion already. Treat as a full pass: if manual criteria exist OR pending deferred-auto criteria exist → escalate (combine both per "Deferred-Pending Escalation §When BOTH"); otherwise → call /done. There is no "auto-trigger another full pass" for degenerated-to-full — that's redundant since the pass already covered everything.
 
 **Manual criteria in selective mode.** When a selective pass encounters manual criteria within its in-scope deliverables and all automated checks pass, manual escalation is **deferred** to the auto-triggered full pass. Rationale: the full pass surfaces every manual criterion across every deliverable, so escalating partial manual criteria from a selective pass would fragment the user-facing escalation. Manual escalation fires exactly once per /verify chain — at the end of the full pass — never from a selective pass.
 
-**Hard final gate.** /done is unreachable from selective-mode green alone. Per project directive ("Done means nothing more to do"), only a full-mode green pass — every AC across every deliverable + every Global Invariant — calls /done. The auto-triggered full pass is unconditional: no mode override, no opt-out. If the auto-triggered full pass fails, /verify returns the failures to /do, which enters the standard fix-loop. Failure during a final pass behaves identically to failure during any other pass — fix, then a fresh selective pass scoped to the failing deliverable, then auto-trigger full again.
+**Hard final gate.** /done is unreachable from selective-mode green alone. Per project directive ("Done means nothing more to do"), only a full-mode green pass — every AC across every deliverable + every Global Invariant — **with no pending deferred-auto criteria** calls /done. When deferred-auto criteria are pending (no prior `--deferred` pass covered them), /verify routes to /escalate ("Deferred-Auto Pending") instead — see Deferred-Pending Escalation. The auto-triggered full pass is unconditional: no mode override, no opt-out. If the auto-triggered full pass fails, /verify returns the failures to /do, which enters the standard fix-loop. Failure during a final pass behaves identically to failure during any other pass — fix, then a fresh selective pass scoped to the failing deliverable, then auto-trigger full again.
 
 **`--final` is internal-only.** /verify uses `--final` to re-invoke itself after a selective green; /do does NOT pass `--final`. /do invokes /verify either with no scope flags (degenerates to full on first pass) or with `--scope D2,D3` (selective). The internal-only constraint preserves the gate: /do can never bypass the selective→full chain by manually requesting a final-only pass.
 
 **Mode is preserved across the recursion.** When /verify auto-triggers itself with `--final`, it carries forward the active `--mode <X>` from the current invocation (efficient | balanced | thorough). The auto-triggered final pass runs at the same intensity (parallelism + model routing + skip rules) as the selective pass that triggered it — never forced to thorough. The "full suite" guarantee is unconditional; the *intensity per criterion* follows the active mode (preserves the orthogonality between selective/full and mode established earlier in this skill).
 
 **On phase failure**: Show the failed phase, then for each failed criterion: ID, description, verification method, failure details (location, expected vs actual, fix hint). Note later phases not run and their pending criteria count.
+
+## Deferred-Auto Criteria
+
+`method: deferred-auto` marks a criterion as **automatically verifiable but user-triggered** — typically a cross-repo gate the user signals readiness for (e.g., "all PRs deployed"). The verifier itself runs automatically (bash command, subagent prompt, etc.); only the *triggering* is user-controlled.
+
+**Normal flow skips them.** Selective and full passes (with or without `--scope`/`--final`) ignore `deferred-auto` criteria entirely during the pass — they never appear in the failure list of a normal pass. **However, their absence-of-coverage gates `/done` routing per "Deferred-Pending Escalation" below**: a normal-flow green pass with pending deferred-auto criteria routes to `/escalate` ("Deferred-Auto Pending"), not `/done`.
+
+**`--deferred` runs them.** When `/verify ... --deferred` is invoked, /verify runs **only** `deferred-auto` criteria (everything else is skipped, including INV-Gs and ACs of other methods).
+
+**Flag interactions:**
+- `--deferred` + `--scope` is supported. `--scope` narrows the deferred-auto set to in-scope deliverables.
+- `--deferred` does not interact with `--final` — never enters the final-gate machinery, never auto-triggers a follow-up pass, never calls /done.
+- `--deferred` inherits `--mode` — same parallelism / model routing as the parent invocation.
+- `--deferred` invoked without `--scope` covers all `deferred-auto` criteria across the manifest.
+- A manifest with no `deferred-auto` criteria sees `--deferred` as a clean no-op ("no deferred-auto criteria in manifest").
+
+**Deferred-Pending Escalation.** When a normal-flow `/verify` pass (selective or full) completes green but the manifest contains `deferred-auto` criteria that have not been verified green via a prior `/verify --deferred` run, `/verify` must NOT call `/done`. Instead, it routes to `/escalate` with type "Deferred-Auto Pending" and a message telling the user which deferred-auto criteria remain and instructing them to invoke `/verify --deferred` once prerequisites are in place. Once those criteria pass via `--deferred`, a subsequent normal `/verify` pass can call `/done`.
+
+**Coverage determination.** A deferred-auto criterion is considered "covered" when there exists a preceding pass-log block with `deferred: true`, `result: pass`, and either (a) `scope:` is empty (full deferred coverage), or (b) `scope:` contains the deliverable that owns the criterion. /verify aggregates coverage across all prior `--deferred` blocks in the log: a criterion is pending iff no prior deferred-pass block satisfies (a) or (b) for it. INV-G* deferred-auto criteria are deliverable-scope-independent — they are covered only by a `deferred: true scope: []` block.
+
+**When BOTH manual criteria and pending deferred-auto criteria exist** after a normal full-mode green pass, surface BOTH in a single combined escalation block: list the manual criteria + their how-to-verify, AND list the pending deferred-auto criteria + the `/verify --deferred` instruction. /done remains unreachable until both are resolved.
+
+**After `/verify --deferred` completes green** (all deferred-auto criteria pass), close the user-as-coordinator loop with an explicit next-step instruction: emit a message like *"Deferred-auto criteria green. Re-invoke `/verify <manifest> <log>` (no flags) to reach /done."* Do NOT call /done from the `--deferred` pass itself — `--deferred` only verifies the deferred-auto subset; the final `/done` decision belongs to a normal-flow pass that confirms the full criterion universe is still green AND the deferred coverage now satisfies the gate.
+
+**Cross-repo path delivery to verifiers.** When the manifest declares `Repos: [name: path, ...]`, **every `/verify` pass** (selective, full, and `--deferred`) prepends a verbatim string to each verifier's prompt before the criterion's own prompt:
+
+```
+Available repos: name1=/path/1, name2=/path/2, ...
+```
+
+This is the one mechanism — verifiers do not parse the manifest themselves. The injection fires on every pass, not just `--deferred`, so cross-repo verifiers can run during normal `/do→/verify` flow — that's what makes `/done` reachable for multi-repo manifests without per-repo /done independence. Single-repo manifests (no `Repos:` field) get no prefix injection. Full convention: `references/MULTI_REPO.md` (lives in `define/references/`) §e.
 
 ## /verify Pass Logging Contract
 
@@ -135,14 +170,17 @@ Every /verify invocation appends a structured block to the execution log so /do 
 ## /verify pass {N}
 
 ```yaml
-mode: selective|full
+mode: selective|full             # for --deferred passes: selective if --scope was set, else full
 scope: [<deliverable-id>, ...]   # empty list when mode is full
 result: pass|fail
 failures: [<criterion-id>, ...]  # empty when pass; criterion IDs only, no narrative
-auto_triggered_final: true|false # true when this pass was auto-triggered after selective green
+auto_triggered_final: true|false # true when this pass was auto-triggered after selective green; always false for --deferred passes
+deferred: true|false             # true when this pass ran via --deferred (only deferred-auto criteria checked); false for normal selective/full passes
 ```
 
 [narrative — failed criterion details, fix hints, etc., per Outcome Handling]
 ````
+
+When `deferred: true`, consumers should treat the pass as a partial verification (only `deferred-auto` criteria) — never as evidence that normal-flow ACs/INVs passed. The `result: pass` of a deferred pass means "the deferred-auto criteria are green," not "the whole manifest is green."
 
 Pure markdown so humans can read; fenced YAML so /do and a future /verify can parse deterministically. Pass numbers are sequential within the execution log. /do uses the most recent block to track progress and decide which pass to invoke next.

--- a/dist/opencode/README.md
+++ b/dist/opencode/README.md
@@ -6,9 +6,9 @@ Verification-first manifest workflows for OpenCode CLI. Ported from the Claude C
 
 | Type | Count | Description |
 |------|-------|-------------|
-| Skills | 13 | Core workflow skills (define, do, verify, etc.) |
+| Skills | 12 | Core workflow skills (define, do, verify, etc.) |
 | Agents | 14 | Specialized reviewer and verification agents |
-| Commands | 8 | User-invocable slash commands |
+| Commands | 9 | User-invocable slash commands |
 | Plugin | 1 | TypeScript hook plugin for workflow enforcement |
 | Context | 1 | AGENTS.md workflow overview |
 
@@ -68,12 +68,15 @@ cp dist/opencode/AGENTS.md .opencode/AGENTS.md
 After installation, invoke workflows via slash commands:
 
 ```
-/define-manifest-dev     Plan and scope a task
-/do-manifest-dev         Execute a manifest
-/auto-manifest-dev       End-to-end autonomous execution
-/figure-out-manifest-dev              Deep collaborative understanding
+/define-manifest-dev                    Plan and scope a task
+/do-manifest-dev                        Execute a manifest
+/auto-manifest-dev                      End-to-end autonomous execution
+/verify-manifest-dev                    Run parallel verifiers (use --deferred for deferred-auto criteria)
+/figure-out-manifest-dev                Deep collaborative understanding
 /stop-thinking-disciplines-manifest-dev End thinking disciplines session
-/tend-pr-manifest-dev                 PR lifecycle automation
+/tend-pr-manifest-dev                   PR lifecycle automation
+/tend-pr-tick-manifest-dev              Single PR tending iteration
+/learn-define-patterns-manifest-dev     Extract patterns from past /define sessions
 ```
 
 ## Feature Parity with Claude Code
@@ -119,15 +122,17 @@ dist/opencode/
 │   ├── docs-reviewer.md
 │   ├── manifest-verifier.md
 │   └── type-safety-reviewer.md
-├── commands/                        # 8 user commands
+├── commands/                        # 9 user commands
 │   ├── auto.md
 │   ├── define.md
 │   ├── do.md
 │   ├── figure-out.md
 │   ├── learn-define-patterns.md
 │   ├── stop-thinking-disciplines.md
-│   └── tend-pr.md
-├── skills/                          # 13 skills (with subdirectories)
+│   ├── tend-pr.md
+│   ├── tend-pr-tick.md
+│   └── verify.md
+├── skills/                          # 12 skills (with subdirectories)
 │   ├── auto/
 │   ├── define/
 │   ├── do/

--- a/dist/opencode/agents/code-maintainability-reviewer.md
+++ b/dist/opencode/agents/code-maintainability-reviewer.md
@@ -312,7 +312,7 @@ Do not fabricate issues to fill the report. A clean review is a valid outcome.
 
 - **Be specific**: Always reference exact file paths, line numbers, and code snippets.
 - **Be actionable**: Every issue must have a concrete, implementable fix suggestion.
-- **Consider context**: Account for project conventions from CLAUDE.md files and existing patterns.
+- **Consider context**: Account for project conventions from AGENTS.md files and existing patterns.
 - **Avoid false positives**: Always read full files before flagging issues. A diff alone lacks context—code that looks duplicated in isolation may serve different purposes when you see the full picture.
 - **Avoid these common false positives**:
   - Test file duplication (test setup repetition is often intentional for isolation)

--- a/dist/opencode/agents/criteria-checker.md
+++ b/dist/opencode/agents/criteria-checker.md
@@ -1,5 +1,5 @@
 ---
-description: "Read-only verification agent. Validates a single criterion using any automated method: commands, codebase analysis, file inspection, reasoning, web research. Returns structured PASS/FAIL results."
+description: "'Read-only verification agent. Validates a single criterion using any automated method: commands, codebase analysis, file inspection, reasoning, web research. Returns structured PASS/FAIL results.'"
 mode: subagent
 model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2

--- a/dist/opencode/agents/define-session-analyzer.md
+++ b/dist/opencode/agents/define-session-analyzer.md
@@ -1,5 +1,5 @@
 ---
-description: "Analyze a single /define session transcript to extract user preference patterns. Spawned by learn-define-patterns skill for parallel per-session analysis."
+description: "'Analyze a single /define session transcript to extract user preference patterns. Spawned by learn-define-patterns skill for parallel per-session analysis.'"
 mode: subagent
 model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2
@@ -36,7 +36,7 @@ Preferences about what /define should probe for or how it should probe. Examples
 Consistent trade-off resolutions the user makes. Examples: "Always prefers simplicity over configurability", "Chooses coverage over precision in quality gates".
 
 ### Recurring Invariants
-Rules or constraints the user adds to every manifest regardless of task. Examples: "Always requires CLAUDE.md adherence check", "Always includes lint/format/typecheck gate".
+Rules or constraints the user adds to every manifest regardless of task. Examples: "Always requires AGENTS.md adherence check", "Always includes lint/format/typecheck gate".
 
 ### Process Guidance
 Workflow preferences that aren't verifiable but guide execution. Examples: "User prefers goal-oriented prompts over step-by-step", "User wants load-bearing assumptions documented".

--- a/dist/opencode/agents/manifest-verifier.md
+++ b/dist/opencode/agents/manifest-verifier.md
@@ -1,5 +1,5 @@
 ---
-description: "Reviews /define manifests for gaps and outputs actionable continuation steps. Returns specific questions to ask and areas to probe so interview can continue."
+description: "'Reviews /define manifests for gaps and outputs actionable continuation steps. Returns specific questions to ask and areas to probe so interview can continue.'"
 mode: subagent
 model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2

--- a/dist/opencode/commands/tend-pr-tick.md
+++ b/dist/opencode/commands/tend-pr-tick.md
@@ -1,0 +1,5 @@
+---
+description: "Single iteration of PR tending. Reads PR state, classifies new events, routes fixes, reports status. Called by /loop via /tend-pr setup. Can be invoked manually to run a single tick."
+---
+
+Invoke the manifest-dev:tend-pr-tick skill with: "$ARGUMENTS"

--- a/dist/opencode/commands/verify.md
+++ b/dist/opencode/commands/verify.md
@@ -1,0 +1,5 @@
+---
+description: "Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest. Primary user-facing entry point is /verify --deferred (run user-triggered deferred-auto criteria); other invocations normally come from /do."
+---
+
+Invoke the manifest-dev:verify skill with: "$ARGUMENTS"

--- a/dist/opencode/install_helpers.py
+++ b/dist/opencode/install_helpers.py
@@ -36,8 +36,8 @@ AGENT_NAMES = [
 
 # Command filenames (without .md)
 COMMAND_NAMES = [
-    "auto", "define", "do", "learn-define-patterns",
-    "tend-pr", "figure-out", "stop-thinking-disciplines",
+    "auto", "define", "do", "verify", "learn-define-patterns",
+    "tend-pr", "tend-pr-tick", "figure-out", "stop-thinking-disciplines",
 ]
 
 

--- a/dist/opencode/skills/auto/SKILL.md
+++ b/dist/opencode/skills/auto/SKILL.md
@@ -33,7 +33,15 @@ The remaining text after flag extraction is the task description (`$TASK_DESCRIP
 
 4. **Tend PR** (only when `--tend-pr` is present) — After /do completes successfully (calls `/done`, not `/escalate`), invoke the manifest-dev:tend-pr skill with: "<manifest-path> --log <execution-log-path>" (the execution log path is available from the conversation context — /do logged its creation at the start of execution). Append `--platform <platform>`, `--interval <duration>`, and `--reviewers <usernames>` if specified in the original /auto arguments.
 
-   If /do escalates instead of completing: do NOT invoke /tend-pr. Report to user: "/do escalated — skipping /tend-pr. Reason: <escalation reason from /do>. Resolve the blocker and re-invoke /tend-pr manually with the manifest path."
+   If /do escalates with **"Deferred-Auto Pending"**: this is a coordination handoff, not a blocker — the implementation is green; the user just needs to run `/verify --deferred` later when prerequisites are ready. Still invoke /tend-pr for cwd's PR (per §Multi-Repo Behavior). Surface the deferred-auto reminder to the user alongside the PR link: "/auto: implementation green; /tend-pr started for cwd's PR. Deferred-auto criteria pending — run `/verify <manifest-path> <log-path> --deferred` when prerequisites are in place to reach /done."
+
+   If /do escalates with any other type: do NOT invoke /tend-pr. Report to user: "/do escalated — skipping /tend-pr. Reason: <escalation reason from /do>. Resolve the blocker and re-invoke /tend-pr manually with the manifest path."
+
+## Multi-Repo Behavior
+
+If `/define` produces a multi-repo manifest (Intent declares `Repos:`), `/auto`'s `/do` invocation **navigates all repos** declared in `Repos:` — `/do` reads the path map and uses absolute paths natively (no filter logic). A single `/auto` invocation can therefore complete the whole multi-repo implementation phase.
+
+The per-cwd limitation is `/tend-pr`: with `--tend-pr`, only cwd's PR is set up for tending, because `/tend-pr` is PR-bound by construction. To tend other repos' PRs, invoke `/tend-pr` from each other repo's cwd. See `manifest-dev:define/references/MULTI_REPO.md` §i.
 
 ## Failure Handling
 

--- a/dist/opencode/skills/define/SKILL.md
+++ b/dist/opencode/skills/define/SKILL.md
@@ -147,13 +147,21 @@ When `--amend <manifest-path>` is present: read `references/AMENDMENT_MODE.md` f
 
 ## Multi-Repo Scope
 
-When task spans multiple repositories, capture during intent (starting points):
+When the task spans multiple repositories, the manifest stays a single canonical document covering the entire changeset. Full convention is in `references/MULTI_REPO.md` — this section summarizes only what the manifest captures.
 
-- **Which repos** and their roles
-- **Cross-repo constraints** (dependencies, coordination requirements)
-- **Per-repo differences** (different rules, conventions, verification needs)
+**Conditional schema additions** (omit entirely for single-repo manifests):
 
-Scope deliverables and verification to repo context. Cross-repo invariants get explicit verification checking both sides.
+- Intent declares `Repos: [name: path, ...]` listing every repo in scope.
+- Intent optionally declares `Branch: <name>` (single string — same branch name across repos by convention).
+- Each repo-specific deliverable carries a `repo: <name>` tag matching one of the declared repos.
+
+`Repos:` and `repo:` exist for **documentation** — readers (human and agent) know which deliverable lives where. They are **not** an enforcement mechanism for `/do` or `/verify` — `/do` navigates absolute paths from `Repos:` natively (no filter logic).
+
+Cross-repo gates the user must explicitly trigger (e.g., post-deploy verification across services) get `method: deferred-auto`. Normal `/do→/verify` flow skips them during the pass, **but routes to `/escalate` ("Deferred-Auto Pending") instead of `/done` while they remain uncovered**; the user runs `/verify --deferred` when prerequisites are in place. See `references/MULTI_REPO.md` §e.
+
+**Detection** rides on the existing Domain Understanding coverage goal — when conversation, task description, or branch context indicates multiple repos, treat as multi-repo and populate `Repos:` accordingly. No separate probe step is added.
+
+Single-repo manifests omit `Repos:`, `Branch:`, and `repo:` tags entirely; the schema and downstream behavior are identical to today.
 
 ## Principles
 
@@ -377,6 +385,10 @@ Three categories, each covering **output** or **process**:
 - **Mode:** efficient | balanced | thorough *(optional, default: thorough — controls verification intensity during /do)*
 - **Interview:** minimal | autonomous | thorough *(optional, default: thorough — recorded so --amend can inherit the original interview style)*
 - **Medium:** local *(optional, default: local — currently only local is supported)*
+- **Repos:** *(optional, multi-repo only — see `references/MULTI_REPO.md`; omit for single-repo manifests)*
+    - name1: /absolute/path/to/repo1
+    - name2: /absolute/path/to/repo2
+- **Branch:** *(optional, multi-repo only — single string, same branch name across all repos by convention)*
 
 ## 2. Approach (Complex Tasks Only)
 *Initial direction, not rigid plan. Provides enough to start confidently; expect adjustment when reality diverges.*
@@ -401,13 +413,15 @@ Three categories, each covering **output** or **process**:
 - [INV-G1] Description: ... | Verify: [Method]
   ```yaml
   verify:
-    method: bash | codebase | subagent | research | manual
+    method: bash | codebase | subagent | research | manual | deferred-auto
     phase: "[numeric, optional, default 1 — higher phases run after lower phases pass]"
     command: "[if bash]"
     agent: "[if subagent]"
     model: "[if subagent, default inherit]"
     prompt: "[if subagent or research]"
   ```
+
+*`method: deferred-auto` on INV-G* = cross-repo gate the user explicitly triggers via `/verify --deferred`. Skipped during normal `/do→/verify`; routes to `/escalate` "Deferred-Auto Pending" if uncovered when normal flow would otherwise reach `/done`. INV-G* deferred-auto criteria are deliverable-scope-independent — covered only by a `--deferred` pass with empty `--scope`. See `references/MULTI_REPO.md` §e.*
 
 ## 4. Process Guidance (Non-Verifiable)
 *Constraints on HOW to work. Not gates—guidance for the implementer.*
@@ -423,16 +437,18 @@ Three categories, each covering **output** or **process**:
 *Ordered by execution order from Approach, or by dependency then importance.*
 
 ### Deliverable 1: [Name]
-*[If multi-repo: specify repo scope]*
+**Repo:** `name1` *(optional, multi-repo only — must match a name in Intent's `Repos:` map; omit for single-repo manifests)*
 
 **Acceptance Criteria:**
 - [AC-1.1] Description: ... | Verify: ...
   ```yaml
   verify:
-    method: bash | codebase | subagent | research | manual
+    method: bash | codebase | subagent | research | manual | deferred-auto
     phase: "[numeric, optional, default 1]"
     [details]
   ```
+
+*`method: deferred-auto` = automatically verifiable but skipped during normal `/do→/verify`; runs only via `/verify --deferred`. Use for cross-repo gates the user explicitly triggers. See `references/MULTI_REPO.md` §e.*
 
 ### Deliverable 2: [Name]
 ...

--- a/dist/opencode/skills/define/references/AMENDMENT_MODE.md
+++ b/dist/opencode/skills/define/references/AMENDMENT_MODE.md
@@ -4,11 +4,15 @@
 
 ## Cumulative Manifest Rule
 
-**The manifest is the canonical source of truth for the PR/branch lifetime — not for a single task.** After every amendment, the manifest must describe the FULL PR state: intent, every deliverable, every Global Invariant, every Process Guidance entry, every Known Assumption. The latest increment is layered onto the prior content, never substituted for it.
+**The manifest is the canonical source of truth for the PR/branch lifetime — or, in multi-repo cases, the entire PR set / branch set lifetime — not for a single task.** After every amendment, the manifest must describe the FULL state of every PR it covers: intent, every deliverable (across every repo when multi-repo), every Global Invariant, every Process Guidance entry, every Known Assumption. The latest increment is layered onto the prior content, never substituted for it.
 
 **No silent drops.** When applying an amendment, prior content is preserved by default. Removal is explicit — if a change supersedes an existing AC/INV/PG, the supersession is logged in the `## Amendments` section with rationale. The amendment receiver is responsible for reading the full prior manifest and confirming nothing valuable was lost.
 
-A manifest at any point in time should be readable as "everything currently in scope for this PR/branch," not "the most recent change request." This is what makes the manifest a useful artifact for PR descriptions, reviews, and future amendments.
+A manifest at any point in time should be readable as "everything currently in scope for this PR/branch (or PR set)," not "the most recent change request." This is what makes the manifest a useful working artifact for the agent and the user across the PR lifecycle.
+
+**Multi-repo specifics** — when the manifest declares `Repos:` in Intent, the canonical manifest is shared across all repo PRs (`/tmp/manifest-{ts}.md`); any consumer skill that writes amendments operates on the same file, last-writer-wins (no locking). See `MULTI_REPO.md` §f for the convention.
+
+**Deferred-auto re-verification after amendment** — when an amendment substantively changes a `method: deferred-auto` criterion's verify block (`prompt:`, `command:`, etc.), prior `/verify --deferred` coverage is conceptually invalidated for that criterion. Normal `/verify` always re-runs in-scope criteria so amendments are picked up automatically; deferred-auto bypasses the pass and relies on prior coverage. The user is responsible for re-running `/verify --deferred` for the amended criterion before the gate clears. (Consistent with the user-as-coordinator stance — there is no automatic invalidation mechanism.)
 
 ## Core Behavior
 

--- a/dist/opencode/skills/define/references/MULTI_REPO.md
+++ b/dist/opencode/skills/define/references/MULTI_REPO.md
@@ -1,0 +1,163 @@
+# Multi-Repo Manifest Workflow
+
+Canonical reference for tasks whose changeset spans multiple repositories. Read this when a manifest declares `Repos:` in its Intent. Core skills (`/define`, `/do`, `/verify`, `/done`, `/auto`, `AMENDMENT_MODE`) summarize the rules below and link here for the full specification. Optional consumer skills (`/tend-pr`, `/tend-pr-tick`, `/drive`, `/drive-tick`) describe how they ride the shared-manifest pattern in their own files — they are add-ons, not part of the core multi-repo workflow.
+
+Single-repo manifests (no `Repos:` field) are unaffected by everything below.
+
+## a. Principle
+
+The shared canonical manifest is the **default and recommended** approach for multi-repo changesets: one manifest captures the whole thing — shared intent, all deliverables (each tagged with its repo), shared invariants, shared trade-offs. The reason it's the default: splitting per PR forces the user to hold cross-PR coherence in their head, which is the work the manifest exists to externalize.
+
+Splitting per repo (one manifest per repo's PR) is a **legitimate user choice** when the work is loosely coupled and the user prefers independent scopes — they accept carrying the cross-PR coherence themselves. Everything below describes the shared-manifest case (when `Repos:` is declared in Intent); the split case is just N independent single-repo manifests and needs no special rules.
+
+The manifest is **internal**. It is a working document for the user and the agent. PR descriptions remain summary-only — no manifest embed, no PR-side surfacing.
+
+## b. Persistence
+
+The canonical manifest lives at `/tmp/manifest-{timestamp}.md`. No archival. No copying to `.manifest/` for multi-repo. No primary repo "owns" it.
+
+If the file is lost (reboot, `/tmp` cleared, session death), re-run `/define` against the same task. The recreated manifest restarts the working state; in-flight PRs continue under the new manifest path.
+
+This is an explicit trade-off: durability infrastructure is more cost than re-running `/define` is occasional pain.
+
+## c. Repo Registration
+
+The manifest's `## 1. Intent & Context` section declares its multi-repo scope:
+
+```markdown
+- **Repos:**                                  # optional, multi-repo only
+    - backend: /home/user/projects/api
+    - frontend: /home/user/projects/web
+- **Branch:** claude/sso-integration          # optional, single string (see §j)
+```
+
+Each deliverable that belongs to a specific repo carries a `repo:` tag matching one of the names above:
+
+```markdown
+### Deliverable 3: SSO endpoint
+**Repo:** `backend`
+```
+
+`Repos:` and `repo:` exist for **documentation** — readers (human and agent) know which deliverable lives where. They are **not** an enforcement mechanism for `/do` or `/verify` (see §d). Optional consumer skills may use the tags for their own scope inference (e.g., a PR-tending tool routing feedback on backend's PR to backend-tagged deliverables), but core skills do not depend on this.
+
+Single-repo manifests omit both `Repos:` and `repo:` entirely.
+
+## d. /do Navigation
+
+`/do` reads `Repos:` from the manifest and uses absolute paths in tool calls (Read/Edit/Write/Bash) when a deliverable lives outside cwd. The LLM handles navigation natively — there is no filter logic, no cwd-to-repo matching, no per-repo configuration in `/do`.
+
+The user can invoke `/do` once globally (the agent navigates between repos as deliverables require), or per-repo with `--scope` (each `/do` handles its repo's slice). Either works.
+
+`/do`'s execution log remains a single file per invocation: `/tmp/do-log-{timestamp}.md`. No per-repo log naming.
+
+Worked example — manifest declares:
+
+```markdown
+- **Repos:**
+    - backend: /home/user/projects/api
+    - frontend: /home/user/projects/web
+
+### Deliverable 1: SSO endpoint
+**Repo:** `backend`
+**Acceptance Criteria:**
+- [AC-1.1] POST /auth/sso accepts SAML assertion
+  ```yaml
+  verify:
+    method: bash
+    command: "curl -X POST http://localhost:8080/auth/sso -d @/tmp/saml-test.xml"
+  ```
+```
+
+`/do` invoked from any cwd reads `Repos:`, navigates to `/home/user/projects/api` for D1's edits via absolute paths, runs the verify command. No filter required.
+
+## e. method: deferred-auto + /verify --deferred
+
+Cross-repo gates often cannot run during normal `/do→/verify` flow because they depend on prerequisites the user controls (e.g., "all PRs deployed to staging"). They are still **automatically verifiable** — just user-triggered.
+
+`method: deferred-auto` marks such criteria. Worked example:
+
+```yaml
+- [INV-G7] Frontend SSO login round-trips through deployed backend
+  verify:
+    method: deferred-auto
+    agent: general-purpose
+    prompt: "Hit https://staging.example.com/login with a test SAML assertion. Confirm successful redirect to /dashboard with a valid session cookie."
+```
+
+Normal `/verify` invocations skip `deferred-auto` criteria during the pass itself. **However, `/verify` will not call `/done` while deferred-auto criteria remain unverified** — instead it routes to `/escalate` with type "Deferred-Auto Pending," signaling the user to run `/verify --deferred` when prerequisites are ready. Only after the deferred-auto criteria pass via `/verify --deferred` does a subsequent normal `/verify` pass reach `/done`. The pass log's `deferred: true|false` field tracks which prior runs covered the deferred-auto set.
+
+When the user signals readiness ("all PRs deployed"), they invoke:
+
+```
+/verify <manifest> <log> --deferred
+```
+
+This runs **only** `deferred-auto` criteria. Flag interactions:
+
+- `--deferred` + `--scope` is supported. `--scope` narrows the deferred set to in-scope deliverables.
+- `--deferred` does not interact with `--final`. It never enters the final-gate machinery.
+- `--deferred` inherits `--mode`. Same parallelism and model routing as the parent invocation.
+
+### Cross-repo path delivery to verifiers
+
+When the manifest declares `Repos: [name: path, ...]`, every `/verify` invocation (selective, full, and `--deferred`) prepends a verbatim string to each verifier's prompt before the criterion's own prompt:
+
+```
+Available repos: backend=/home/user/projects/api, frontend=/home/user/projects/web
+
+[criterion's own prompt follows]
+```
+
+This applies on every pass — not just `--deferred` — so cross-repo verifiers can run during normal `/do→/verify` flow. That's what allows `/done` to fire once per multi-repo manifest (§g) without forcing per-repo /done independence.
+
+Single-repo manifests (no `Repos:` field) get no prefix injection. Manifests with no `deferred-auto` criteria see `/verify --deferred` as a no-op with a clean message.
+
+## f. Shared Manifest Amendment Across PRs
+
+The canonical `/tmp` manifest is shared across all PRs in a multi-repo changeset. Any tool that writes amendments — whether the user editing the file directly, or any optional consumer skill — operates on this single shared file.
+
+There is **no concurrency engineering**. Two writers amending the same manifest at the same instant — last-writer-wins. The later write may overwrite the earlier write's amendment block. Recovery: the writer who lost their amendment notices the missing change in the next iteration and re-triggers it (e.g., re-add the comment that prompted it, or re-invoke whatever workflow generated it).
+
+**Do not add file locking.** The collision rate is low (writes are brief), and the recovery cost is small compared to the complexity of locking, deadlock handling, and stale-lock cleanup.
+
+This pattern is the contract for any optional PR-tending consumer skill (e.g., `/tend-pr`, `/drive`); those skills describe their per-PR usage in their own files.
+
+## g. /done — One Per Manifest, Gated on Deferred-Auto
+
+`/done` fires **once per manifest**, including for multi-repo manifests. There is no per-repo `/done` independence. /verify's "every AC across every deliverable" rule is preserved unchanged; for multi-repo, that means every AC in every repo's deliverables must pass before `/done` is called.
+
+This is achievable because `/verify`'s cross-repo prompt-prefix injection (§e) fires on every pass when `Repos:` is declared — verifiers in normal `/do→/verify` flow have access to all repos' paths and can verify cross-repo behavior without `--deferred`.
+
+**`/done` is gated on no deferred-auto criteria pending.** When the manifest contains `method: deferred-auto` criteria that have not been verified green via a prior `/verify --deferred`, `/verify` routes to `/escalate` ("Deferred-Auto Pending") instead of `/done` — making the user-as-coordinator handoff explicit rather than silently completing. After the user runs `/verify --deferred` and the deferred-auto criteria pass, a subsequent normal `/verify` pass reaches `/done`.
+
+For multi-repo manifests, the `/done` summary lists which repos' deliverables were verified — providing a clear inventory of what landed across the changeset.
+
+## h. User as Coordinator
+
+There is no coordinator process, no primary repo, no orchestrator skill. The user coordinates by:
+
+1. Invoking `/do` or `/auto` (once globally to navigate all repos, or per-repo with `--scope` for parallel execution).
+2. Opening / managing each repo's PR with whatever PR-management workflow they prefer (manual, or via an optional consumer skill).
+3. Triggering `/verify --deferred` once cross-repo prerequisites are in place (e.g., "all PRs merged and deployed").
+
+The system supports this workflow but does not automate it. Coordination is a human concern that the manifest captures the *state* of, not a state machine the system drives.
+
+## i. /auto Behavior
+
+`/auto` chains `/define` → `/do` → optionally `/tend-pr`. The `/do` step **navigates all repos** declared in `Repos:` (per §d — no filter logic, LLM uses absolute paths from the map). A single `/auto` invocation can therefore complete the whole multi-repo implementation phase.
+
+The per-cwd limitation is `/tend-pr`: when `--tend-pr` is set, `/auto` invokes `/tend-pr` from cwd, which sets up tending for cwd's PR only — `/tend-pr` is PR-bound by construction (see §f). To tend the other repos' PRs, invoke `/tend-pr` from each other repo's cwd.
+
+This is the only multi-repo footgun in `/auto`: users may assume `--tend-pr` covers all PRs, when it covers only cwd's. The implementation phase itself runs to completion across all repos in one go.
+
+## j. Branch-Name Convention
+
+By default, all repos in a multi-repo changeset use the **same branch name**. This matches the existing harness pattern (per-repo branch declarations in the system prompt that share a branch identifier).
+
+The manifest's Intent records the branch name as a single string:
+
+```markdown
+- **Branch:** claude/sso-integration
+```
+
+Divergent branch names per repo are not supported by this version. A future extension could replace `Branch: <string>` with `Branches: [name -> branch]` if real cases demand it.

--- a/dist/opencode/skills/define/tasks/CODING.md
+++ b/dist/opencode/skills/define/tasks/CODING.md
@@ -4,7 +4,7 @@ Base guidance for all code-change tasks (features, bugs, refactors).
 
 ## Quality Gates
 
-CLAUDE.md may specify project-specific preferences.
+AGENTS.md may specify project-specific preferences.
 
 ### Base Gates (always applicable)
 
@@ -20,7 +20,7 @@ Defect-finding agents: every finding at Low severity or above fails the gate (`n
 | Testability | code-testability-reviewer | no MEDIUM+ |
 | Documentation | docs-reviewer | no MEDIUM+ |
 | Design fitness | code-design-reviewer | no MEDIUM+ |
-| CLAUDE.md adherence | context-file-adherence-reviewer | no MEDIUM+ |
+| AGENTS.md adherence | context-file-adherence-reviewer | no MEDIUM+ |
 
 ### Conditional Gates (when applicable)
 
@@ -31,7 +31,7 @@ Defect-finding agents: every finding at Low severity or above fails the gate (`n
 
 ## Project Gates
 
-CLAUDE.md specifies project gates (typecheck, lint, test, format). These become Global Invariants.
+AGENTS.md specifies project gates (typecheck, lint, test, format). These become Global Invariants.
 
 ## E2E Verification
 
@@ -74,7 +74,7 @@ CLAUDE.md specifies project gates (typecheck, lint, test, format). These become 
 *Domain best practices for this task type.*
 
 - **Run existing tests before modifying test files** — Verify current test state before changing tests; prevents masking pre-existing failures
-- **Read project gates from CLAUDE.md** — Discover project-specific commands (typecheck, lint, test, format) before implementation
+- **Read project gates from AGENTS.md** — Discover project-specific commands (typecheck, lint, test, format) before implementation
 
 ## Multi-Repo
 

--- a/dist/opencode/skills/do/SKILL.md
+++ b/dist/opencode/skills/do/SKILL.md
@@ -71,9 +71,11 @@ When `--scope` is NOT provided, ignore this section entirely — no reference fi
 
 The mandatory full final gate (auto-triggered by /verify after selective green) is the safety net for cross-deliverable regressions. Don't try to skip or short-circuit it.
 
-**Execution log /verify contract** - /verify appends a structured block (`## /verify pass {N}` + fenced YAML with `mode`, `scope`, `result`, `failures`, `auto_triggered_final`) per invocation. Read the most recent block before deciding the next pass's scope. Format defined in `verify/SKILL.md` "Pass Logging Contract."
+**Execution log /verify contract** - /verify appends a structured block (`## /verify pass {N}` + fenced YAML with `mode`, `scope`, `result`, `failures`, `auto_triggered_final`, `deferred`) per invocation. Read the most recent block before deciding the next pass's scope. Format defined in `verify/SKILL.md` "/verify Pass Logging Contract." When scanning for the most recent /verify pass to drive scope decisions, **skip blocks with `deferred: true`** — those reflect user-direct `--deferred` invocations (now possible since /verify is user-invocable), not /do-driven normal-flow passes.
 
 **Escalation boundary** - Escalate when: (1) ACs can't be met as written (contract broken), (2) user requests a pause mid-workflow, (3) you discover an AC or invariant should be amended (use "Proposed Amendment" escalation type), or (4) the active execution mode's fix-verify loop limit is reached. If ACs remain achievable as written and no user interrupt, continue autonomously.
+
+**`/verify`-routed escalation passthrough.** When `/verify` itself routes to `/escalate` (e.g., "Deferred-Auto Pending", "Manual Criteria Review") instead of `/done`, treat as a clean terminal handoff: surface the escalation output verbatim to the caller, do NOT enter the fix-loop, do NOT increment loop counters. The implementation is green; further action belongs to the user (e.g., running `/verify --deferred` for deferred-auto pending). This is distinct from `/verify` returning failures (which enters the standard fix-loop).
 
 **Mode-aware loop tracking** - Track fix-verify iteration count and escalation count in the execution log. When the active execution mode's limits are reached, follow its escalation rules.
 
@@ -93,9 +95,19 @@ Externalize progress to survive context loss.
 
 **Refresh between deliverables** - Before starting a new deliverable, re-read the manifest's deliverable section and relevant log entries. Context degrades across long sessions.
 
+## Multi-Repo Navigation
+
+When the manifest declares `Repos: [name: path, ...]` in Intent, deliverables may live in repos other than cwd. Read the path map and use **absolute paths** in tool calls (Read/Edit/Write/Bash) when working on a deliverable tagged with a different repo. There is **no filter logic, no cwd matching, no per-repo configuration** — the LLM navigates as deliverables require.
+
+A single `/do` invocation can cover the whole multi-repo task by navigating between repos; alternatively the user invokes `/do` per repo with `--scope` for parallel execution. Either works. The execution log remains a single file per `/do` invocation.
+
+When the manifest has no `Repos:` field (single-repo manifest), this section does not apply — behavior is unchanged.
+
+Full convention: `references/MULTI_REPO.md` (lives in `define/references/`).
+
 ## Mid-Execution Amendment
 
-**Default to amend.** Any user message arriving during /do or /verify defaults to triggering Self-Amendment. The manifest is the canonical source of truth for the PR/branch (per `references/AMENDMENT_MODE.md`); feedback flows through it, not around it. The asymmetric framing is deliberate: silent scope drift (feedback acted on inline, manifest left out of date) is a worse failure than an occasional unnecessary amendment cycle.
+**Default to amend.** Any user message arriving during /do or /verify defaults to triggering Self-Amendment. The manifest is the canonical source of truth for the PR/branch — or, in multi-repo cases, the **PR set / branch set** (see `references/AMENDMENT_MODE.md`). Feedback flows through it, not around it. The asymmetric framing is deliberate: silent scope drift (feedback acted on inline, manifest left out of date) is a worse failure than an occasional unnecessary amendment cycle.
 
 **Carve-out: pure questions.** Messages that ask about the manifest or process without requesting a state change are answered inline — no amendment.
 - *Amend:* "Also handle X." / "Change Y to Z." / "That's wrong, it should be …" / "Add a check for …"
@@ -103,7 +115,7 @@ Externalize progress to survive context loss.
 
 **When ambiguous, amend.** A message that could be either ("hmm, what about the auth case?") goes to amendment. Re-running an amendment cycle is cheap; silently dropping a constraint that turns out to matter is expensive.
 
-**/verify-time feedback.** /verify is non-user-invocable orchestrator — semantically, user feedback received while /verify is running is feedback to /do (the caller), not to /verify. The same default-to-amend rule applies. /verify itself never handles user feedback inline; the message is interpreted in /do's context and routed through Self-Amendment.
+**/verify-time feedback.** While /verify is running under /do, user feedback received mid-pass is semantically feedback to /do (the caller), not to /verify. The same default-to-amend rule applies. /verify itself never handles user feedback inline; the message is interpreted in /do's context and routed through Self-Amendment. (When /verify is invoked directly by the user — e.g., `/verify --deferred` — there is no /do caller; mid-pass user messages are handled per the user's own session reflex, not via /do's amendment route.)
 
 **Amendment flow** — Amend the manifest autonomously via Self-Amendment escalation and `/define --amend <manifest-path> --from-do`, then resume with the updated manifest and existing log. Log the trigger before amending. No human wait — the entire cycle is autonomous.
 

--- a/dist/opencode/skills/done/SKILL.md
+++ b/dist/opencode/skills/done/SKILL.md
@@ -24,6 +24,14 @@ Read the execution log and manifest. Output a summary that shows:
 4. **Key changes** - Files modified, commits made
 5. **Tradeoffs applied** - How preferences were used
 
+When the manifest declares `Repos:` (multi-repo), `/done` still fires **once per manifest** — not once per repo. /verify's "every AC across every deliverable" rule is preserved unchanged; for multi-repo, that means every AC in every repo's deliverables must pass before `/done` is called. This is achievable because `/verify` injects the cross-repo path prefix (`Available repos: ...`) on every pass when `Repos:` is declared, so verifiers can reach all repos during normal flow.
+
+The multi-repo summary additionally lists which **repos' deliverables were verified in this run** — providing a clear inventory of what landed across the changeset.
+
+**`/done` is gated on no deferred-auto criteria pending.** When the manifest contains `method: deferred-auto` criteria that have not yet been verified green via `/verify --deferred`, `/verify` does NOT call `/done` — it routes to `/escalate` with type "Deferred-Auto Pending" instead, telling the user to run `/verify --deferred` when prerequisites are in place. Only after deferred-auto criteria pass via `--deferred` does a subsequent normal `/verify` pass reach `/done`. See `define/references/MULTI_REPO.md` §e/§g and `verify/SKILL.md` "Deferred-Pending Escalation".
+
+Single-repo manifests (no `Repos:` field) get the standard summary unchanged — no repo list, no deferred-auto note. The deferred-auto-pending escalation rule applies regardless of multi-repo (any manifest with deferred-auto criteria, single- or multi-repo, gates /done the same way).
+
 ## Output Format
 
 ```markdown
@@ -72,11 +80,11 @@ The trailing italic line is **mandatory** in /done's output — it surfaces the 
 1. **Mirror manifest structure** - Hierarchy should match: Intent → Global Invariants → Deliverables
 2. **Show evidence** - Link changes to deliverables, describe behavioral changes (not just file lists)
 3. **Adapt detail to complexity** - Simple task = condensed output. Complex task = full hierarchy.
-4. **Called by /verify only, after a full-suite green pass** - /done is the final step after /verify confirms a **full pass** is green — every AC across every deliverable plus every Global Invariant. Selective-mode green alone is not sufficient (per /verify's hard final gate); /verify auto-triggers a full pass after selective green and only then calls /done.
+4. **Called by /verify only, after a full-suite green pass** - /done is the final step after /verify confirms a **full pass** is green — every AC across every deliverable plus every Global Invariant — **AND no `deferred-auto` criteria are pending** (when pending deferred-auto criteria exist, /verify routes to /escalate "Deferred-Auto Pending" instead of calling /done; see narrative above and `verify/SKILL.md` Deferred-Pending Escalation). Selective-mode green alone is not sufficient (per /verify's hard final gate); /verify auto-triggers a full pass after selective green and only then calls /done.
 
 ## Post-Completion Feedback
 
-After /done has been called, the manifest is still the canonical source of truth for the PR/branch — the work isn't necessarily merged, and feedback can still arrive (user comments, PR reviews, second thoughts). The default reflex for any feedback that changes scope or contradicts something settled is the same as during /do (per `do/SKILL.md` Mid-Execution Amendment): **default to amend.**
+After /done has been called, the manifest is still the canonical source of truth for the PR/branch — or the **PR set / branch set** in the multi-repo case — because the work isn't necessarily merged, and feedback can still arrive (user comments, PR reviews, second thoughts). The default reflex for any feedback that changes scope or contradicts something settled is the same as during /do (per `do/SKILL.md` Mid-Execution Amendment): **default to amend.**
 
 **Re-entry flow:** when feedback is determined to be amendment-worthy (not a pure question), invoke `/define --amend <manifest-path>` with the feedback as input, then `/do <manifest-path> <log-path> --scope <new-or-affected-deliverables>` to implement the change. /do's selective-mode + mandatory full final gate apply to the re-entry pass — /done won't be reachable again until the full suite is green on the amended manifest.
 

--- a/dist/opencode/skills/escalate/SKILL.md
+++ b/dist/opencode/skills/escalate/SKILL.md
@@ -197,6 +197,31 @@ User explicitly asked to stop mid-workflow (e.g., "commit so I can deploy", "sto
 
 **When to use**: User interrupts workflow for legitimate reasons (deploy, review, break). Not a blocker—just a handoff.
 
+### Deferred-Auto Pending
+
+Normal-flow `/verify` completed green, but the manifest contains `method: deferred-auto` criteria that have not yet been verified green via a prior `/verify --deferred` run. This is a coordination handoff, not a blocker — `/done` is unreachable until the user signals readiness and runs `/verify --deferred`. **No 3-attempt evidence required.** Fired by `/verify`, not by `/do`.
+
+```markdown
+## Escalation: Deferred-Auto Pending
+
+**Reason:** Normal-flow verification green; deferred-auto criteria require user signal before they can run.
+
+### Pending Deferred-Auto Criteria
+- [INV-G{N} or AC-{D}.{N}]: [description from manifest]
+- ...
+
+### To Resolve
+When prerequisites are in place (e.g., "all PRs deployed"), invoke:
+
+`/verify <manifest-path> <execution-log-path> --deferred`
+
+After `--deferred` completes green, re-invoke a normal `/verify <manifest-path> <execution-log-path>` (no flags) to reach `/done`.
+```
+
+**When to use**: `/verify` finishes a normal-flow pass green and detects pending deferred-auto criteria — see `verify/SKILL.md` Deferred-Pending Escalation. **Not** a blocker — implementation is done; the user controls when cross-repo / staging / deploy-dependent verification happens.
+
+**Combined with Manual Criteria Review.** When BOTH manual criteria and pending deferred-auto criteria exist after a normal full-mode green pass, compose a single combined escalation: header `## Escalation: Manual Review + Deferred-Auto Pending`, then both sections inline (Manual Criteria block + Pending Deferred-Auto Criteria block + To Resolve combining manual review steps and the `/verify --deferred` instruction). `/done` remains unreachable until both are resolved.
+
 ## Medium Routing
 
 When medium is non-local, /do routes escalations through the medium directly — /escalate is not invoked. The escalation templates above still define the expected content structure; /do uses them when composing messages to the channel.

--- a/dist/opencode/skills/learn-define-patterns/SKILL.md
+++ b/dist/opencode/skills/learn-define-patterns/SKILL.md
@@ -22,7 +22,7 @@ Every `/define` session, users make the same corrections, add the same invariant
 | **Merge, never overwrite** | If a `## /define Preferences` section already exists, merge new patterns with existing ones. Never blindly overwrite. |
 | **Semantic deduplication** | When merging, identify patterns that say the same thing in different words and consolidate them. Don't just check for exact text matches. |
 | **Standard markdown only** | Output uses `##` headers, `###` subheaders, `- ` bullets, and `<!-- date -->` HTML comments. No custom syntax, no YAML, no special parsing. |
-| **Ask write target** | Ask the user which AGENTS.md to write to: project AGENTS.md, user `~/.config/opencode/AGENTS.md`, or both. Never assume. |
+| **Ask write target** | Ask the user which AGENTS.md to write to: project AGENTS.md, user `~/.claude/CLAUDE.md`, or both. Never assume. |
 | **Diff preview before write** | Show the user exactly what will be added or changed in AGENTS.md before writing. |
 | **Clean up temp files** | Delete per-session analysis files from `/tmp/` after aggregation is complete. |
 
@@ -51,7 +51,7 @@ The final output is a unified set of user preferences derived from all analyzed 
 **What the user sees before approving:**
 - Pattern statement, session frequency, project-specific vs generalizable flag, any contradictions
 - Batch selection (not per-pattern approval)
-- Choice of write target: project AGENTS.md, user `~/.config/opencode/AGENTS.md`, or both
+- Choice of write target: project AGENTS.md, user `~/.claude/CLAUDE.md`, or both
 - Diff/preview of exact changes before writing
 
 # AGENTS.md Output Format

--- a/dist/opencode/skills/tend-pr-tick/SKILL.md
+++ b/dist/opencode/skills/tend-pr-tick/SKILL.md
@@ -68,9 +68,9 @@ Label source first (bot vs human — read `../tend-pr/references/known-bots.md`)
 *Runs when there are CI failures to handle or when new comments were classified.*
 
 **Manifest mode:** This is the same default-to-amend reflex documented canonically in `do/SKILL.md` Mid-Execution Amendment — PR comments and CI failures are external feedback that contradicts or extends the manifest, so they route through Self-Amendment. The only difference is the trigger source (PR thread vs. user message in a session).
-1. Identify which deliverable(s) the comment or CI failure targets (include all potentially affected when ambiguous).
-2. Amend manifest via `/define --amend <manifest-path> --from-do`.
-3. Invoke `/do <manifest-path> <log-path> --scope <affected-deliverable-ids>`. If `/do` escalates, log the blocker, report the escalation to the user, and end the loop.
+1. Identify which deliverable(s) the comment or CI failure targets (include all potentially affected when ambiguous). When the manifest declares `Repos:` (multi-repo) and deliverables carry `repo:` tags, look up this PR's repo via the platform adapter (e.g., GitHub MCP returns `owner/repo` for the PR number); for each absolute path in the manifest's `Repos:` map, run `git -C <path> remote get-url origin` and parse the URL to its `owner/repo` form; the entry whose remote matches the PR's `owner/repo` is the corresponding repo. Use that entry's `name:` as the deliverable filter — prefer deliverables tagged with the matching repo name.
+2. Amend manifest via `/define --amend <manifest-path> --from-do`. **Multi-repo:** the manifest is a shared canonical `/tmp` file used by every repo's `/tend-pr-tick` — concurrent amendments are last-writer-wins (no locking; see `tend-pr/SKILL.md` §Multi-Repo PR Sets and `define/references/MULTI_REPO.md` §f). If you notice a missed amendment, re-trigger the lost tick.
+3. Invoke `/do <manifest-path> <log-path> --scope <affected-deliverable-ids>`. If `/do` escalates with **"Deferred-Auto Pending"**: implementation is green — proceed to steps 4 and 5 normally (push the fix; reply to the originating thread). Append the deferred-auto reminder to this tick's Status Report so the user sees it: "Implementation green; run `/verify <manifest> <log> --deferred` when prerequisites are in place to reach /done." Do **NOT** terminate the tick — subsequent ticks continue normally toward merge-readiness. If `/do` escalates with any other type: log the blocker, report the escalation to the user, and end the loop.
 4. Push changes.
 5. If the actionable item originated from a comment, reply on that thread.
 
@@ -87,6 +87,8 @@ Label source first (bot vs human — read `../tend-pr/references/known-bots.md`)
 *Runs when this tick produced changes (routing fixes, conflict resolution). Skip when no changes were made.*
 
 After changes, rewrite "what changed" sections to reflect the current diff. Preserve manual context (issue references, motivation, deployment notes). Update title if scope changed significantly.
+
+The PR description stays summary-only — never embed the manifest. Manifests are internal working documents (also true in multi-repo, where the same canonical manifest is shared across all PRs without surfacing to reviewers).
 
 ## Status Report
 

--- a/dist/opencode/skills/tend-pr/SKILL.md
+++ b/dist/opencode/skills/tend-pr/SKILL.md
@@ -35,6 +35,16 @@ Two modes:
 - No argument, no manifest inferrable, and no open PR for current branch: "Error: No manifest or open PR found. Provide a manifest path or PR URL. Usage: /tend-pr <manifest-path-or-pr-url> [--platform github] [--interval 10m] [--reviewers user1,user2]"
 - `--platform` value not supported: "Error: Platform '<value>' not yet supported. Currently supported: github"
 
+## Multi-Repo PR Sets
+
+When the manifest declares `Repos:` in Intent (multi-repo changeset), each repo's PR is tended by its own `/tend-pr` invocation pointing at the **same canonical `/tmp` manifest**. PR descriptions stay summary-only — manifests are internal and never embedded in PRs.
+
+All `/tend-pr-tick` instances amend the same shared manifest. There is **no locking and no concurrency engineering**. Concurrent amendments are last-writer-wins; the later write may overwrite the earlier write's amendment block. Recovery: the user notices the missing amendment in the next iteration and re-triggers the lost tick (e.g., re-add the comment, re-run `/tend-pr-tick`). **Do not add file locking** — collisions are rare and the recovery cost is small.
+
+Single-repo manifests (no `Repos:` field) are unaffected — one `/tend-pr`, one PR, no shared-manifest considerations.
+
+Full convention: `references/MULTI_REPO.md` (in `define/references/`) §f.
+
 ## Setup
 
 **Manifest-aware mode:** Ensure a non-draft PR exists for the current branch — create one if none exists. Use the manifest's Intent section for PR title/description. If `--reviewers` was provided, request review from those users. Resolve the execution log path (from `--log`, most recent `/tmp/do-log-*.md`, or conversation context).

--- a/dist/opencode/skills/verify/SKILL.md
+++ b/dist/opencode/skills/verify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: verify
-description: 'Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest.'
-user-invocable: false
+description: 'Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest. Primary user-facing entry point is /verify --deferred (run user-triggered deferred-auto criteria); other invocations normally come from /do.'
+user-invocable: true
 ---
 
 # /verify - Manifest Verification Runner
@@ -10,9 +10,9 @@ Orchestrate verification of all criteria from a Manifest by spawning parallel ve
 
 **Input**: $ARGUMENTS
 
-Format: `<manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough] [--scope D1,D2,...] [--final]`
+Format: `<manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough] [--scope D1,D2,...] [--final] [--deferred]`
 
-Both paths required — return usage error if missing. Mode defaults to `thorough` if not provided. `--scope` and `--final` are mutually exclusive (final is full by definition); when both appear, treat as final.
+Both paths required — return usage error if missing. Mode defaults to `thorough` if not provided. `--scope` and `--final` are mutually exclusive (final is full by definition); when both appear, treat as final. `--deferred` runs only `method: deferred-auto` criteria — see "Deferred-Auto Criteria" below.
 
 ## Selective vs Full Verification
 
@@ -34,11 +34,11 @@ Both paths required — return usage error if missing. Mode defaults to `thoroug
 | **All in-scope criteria, no exceptions** | Every criterion in the current pass's scope (selective: in-scope deliverables' ACs + all INV-G*; full: every AC + every INV-G*) MUST be verified. Skipping any in-scope criterion is a critical failure. |
 | **Parallelism per mode** | The active execution mode defines how many verifiers to launch concurrently within each phase. Phases always run sequentially — see Phased Execution below. |
 | **Actionable feedback** | Pass through file:line, expected vs actual, fix hints. |
-| **Don't handle user feedback** | /verify is non-user-invocable. Any user message arriving while /verify is running is semantically feedback to /do (the caller). /verify never amends, never re-prompts, never deviates from its current pass — it returns results; /do interprets new user input per its own default-to-amend rule (`do/SKILL.md` Mid-Execution Amendment). |
+| **Don't handle user feedback during a pass** | While /verify is running, any user message arriving mid-pass is semantically feedback to the caller (/do, or the user who invoked /verify --deferred directly) — /verify never amends, never re-prompts, never deviates from its current pass. It returns results; the caller interprets new user input per its own rules (e.g., /do's Mid-Execution Amendment). User-direct invocations of /verify --deferred run to completion the same way. |
 
 ## Verification Routing
 
-Route `manual` criteria to /escalate. Route `subagent` criteria to the named agent specified in the criterion. All other types (`bash`, `codebase`, `research`) spawn criteria-checker agents. If a criterion has no verification type, default to criteria-checker.
+Route `manual` criteria to /escalate. Route `subagent` criteria to the named agent specified in the criterion. Route `deferred-auto` criteria per the "Deferred-Auto Criteria" section below — they are **skipped during normal /verify flow** and only run when `--deferred` is passed; under `--deferred`, they are routed by the inner shape of their verify block (if `agent:` is set, route to that named subagent; if `command:` is set, route to criteria-checker as bash; otherwise default to criteria-checker). All other types (`bash`, `codebase`, `research`) spawn criteria-checker agents. If a criterion has no verification type, default to criteria-checker.
 
 ## Agent Prompt Composition
 
@@ -62,6 +62,8 @@ Only include paths that exist. This is informational, not directive — agents d
 - Interpretations of manifest intent ("the goal is to...", "this change is about...")
 
 The verify block's `prompt:` field is manifest-authored — pass it verbatim. These rules target language you add beyond what the manifest specifies. The optional context file paths are raw references, not framing — they provide access to source material without steering the agent's analysis.
+
+**Exception — manifest-driven `Repos:` prefix.** When the manifest declares `Repos:`, the cross-repo path prefix (`Available repos: name=/path, ...`) is prepended to every verifier's prompt per "Cross-repo path delivery to verifiers" below. This is the one prescribed exception to "Do not add your own framing" — the prefix is manifest-driven (derived from `Repos:`), not orchestrator opinion.
 
 ## Criterion Types
 
@@ -112,20 +114,53 @@ Group results by phase, then Global Invariants first, then by Deliverable.
 | Any Global Invariant failed | Return all failures, globals highlighted |
 | Any AC failed | Return failures grouped by deliverable |
 | All in-scope pass, **selective mode that actually narrowed** (`--scope` was set) | **Auto-trigger a full pass** (re-invoke /verify internally with `--final`). Do NOT call /done. Manual criteria in scope are NOT escalated yet — they're deferred to the auto-triggered full pass per the rule below. |
-| All pass, **full mode**, manual criteria exist | List manual criteria with how-to-verify, suggest /escalate |
-| All pass, **full mode** | Call /done |
+| All pass, **full mode**, manual criteria exist (no pending deferred-auto) | List manual criteria with how-to-verify, suggest /escalate |
+| All pass, **full mode**, **deferred-auto criteria exist and not all verified green via prior `--deferred` pass** (no manual criteria) | /escalate with "Deferred-Auto Pending" — see "Deferred-Pending Escalation" below. Do NOT call /done. |
+| All pass, **full mode**, **manual criteria AND pending deferred-auto criteria** | Combined /escalate (Manual Review + Deferred-Auto Pending) per "When BOTH" in Deferred-Pending Escalation below. Do NOT call /done. |
+| All pass, **full mode**, no pending deferred-auto criteria, no manual criteria | Call /done |
 
-**Selective that degenerated to full = full mode for outcome handling.** When `--scope` is absent and `--final` is absent, the pass covered every criterion already. Treat as a full pass: if manual criteria exist → escalate (do not skip the manual row); otherwise → call /done. There is no "auto-trigger another full pass" for degenerated-to-full — that's redundant since the pass already covered everything.
+**Selective that degenerated to full = full mode for outcome handling.** When `--scope` is absent and `--final` is absent, the pass covered every criterion already. Treat as a full pass: if manual criteria exist OR pending deferred-auto criteria exist → escalate (combine both per "Deferred-Pending Escalation §When BOTH"); otherwise → call /done. There is no "auto-trigger another full pass" for degenerated-to-full — that's redundant since the pass already covered everything.
 
 **Manual criteria in selective mode.** When a selective pass encounters manual criteria within its in-scope deliverables and all automated checks pass, manual escalation is **deferred** to the auto-triggered full pass. Rationale: the full pass surfaces every manual criterion across every deliverable, so escalating partial manual criteria from a selective pass would fragment the user-facing escalation. Manual escalation fires exactly once per /verify chain — at the end of the full pass — never from a selective pass.
 
-**Hard final gate.** /done is unreachable from selective-mode green alone. Per project directive ("Done means nothing more to do"), only a full-mode green pass — every AC across every deliverable + every Global Invariant — calls /done. The auto-triggered full pass is unconditional: no mode override, no opt-out. If the auto-triggered full pass fails, /verify returns the failures to /do, which enters the standard fix-loop. Failure during a final pass behaves identically to failure during any other pass — fix, then a fresh selective pass scoped to the failing deliverable, then auto-trigger full again.
+**Hard final gate.** /done is unreachable from selective-mode green alone. Per project directive ("Done means nothing more to do"), only a full-mode green pass — every AC across every deliverable + every Global Invariant — **with no pending deferred-auto criteria** calls /done. When deferred-auto criteria are pending (no prior `--deferred` pass covered them), /verify routes to /escalate ("Deferred-Auto Pending") instead — see Deferred-Pending Escalation. The auto-triggered full pass is unconditional: no mode override, no opt-out. If the auto-triggered full pass fails, /verify returns the failures to /do, which enters the standard fix-loop. Failure during a final pass behaves identically to failure during any other pass — fix, then a fresh selective pass scoped to the failing deliverable, then auto-trigger full again.
 
 **`--final` is internal-only.** /verify uses `--final` to re-invoke itself after a selective green; /do does NOT pass `--final`. /do invokes /verify either with no scope flags (degenerates to full on first pass) or with `--scope D2,D3` (selective). The internal-only constraint preserves the gate: /do can never bypass the selective→full chain by manually requesting a final-only pass.
 
 **Mode is preserved across the recursion.** When /verify auto-triggers itself with `--final`, it carries forward the active `--mode <X>` from the current invocation (efficient | balanced | thorough). The auto-triggered final pass runs at the same intensity (parallelism + model routing + skip rules) as the selective pass that triggered it — never forced to thorough. The "full suite" guarantee is unconditional; the *intensity per criterion* follows the active mode (preserves the orthogonality between selective/full and mode established earlier in this skill).
 
 **On phase failure**: Show the failed phase, then for each failed criterion: ID, description, verification method, failure details (location, expected vs actual, fix hint). Note later phases not run and their pending criteria count.
+
+## Deferred-Auto Criteria
+
+`method: deferred-auto` marks a criterion as **automatically verifiable but user-triggered** — typically a cross-repo gate the user signals readiness for (e.g., "all PRs deployed"). The verifier itself runs automatically (bash command, subagent prompt, etc.); only the *triggering* is user-controlled.
+
+**Normal flow skips them.** Selective and full passes (with or without `--scope`/`--final`) ignore `deferred-auto` criteria entirely during the pass — they never appear in the failure list of a normal pass. **However, their absence-of-coverage gates `/done` routing per "Deferred-Pending Escalation" below**: a normal-flow green pass with pending deferred-auto criteria routes to `/escalate` ("Deferred-Auto Pending"), not `/done`.
+
+**`--deferred` runs them.** When `/verify ... --deferred` is invoked, /verify runs **only** `deferred-auto` criteria (everything else is skipped, including INV-Gs and ACs of other methods).
+
+**Flag interactions:**
+- `--deferred` + `--scope` is supported. `--scope` narrows the deferred-auto set to in-scope deliverables.
+- `--deferred` does not interact with `--final` — never enters the final-gate machinery, never auto-triggers a follow-up pass, never calls /done.
+- `--deferred` inherits `--mode` — same parallelism / model routing as the parent invocation.
+- `--deferred` invoked without `--scope` covers all `deferred-auto` criteria across the manifest.
+- A manifest with no `deferred-auto` criteria sees `--deferred` as a clean no-op ("no deferred-auto criteria in manifest").
+
+**Deferred-Pending Escalation.** When a normal-flow `/verify` pass (selective or full) completes green but the manifest contains `deferred-auto` criteria that have not been verified green via a prior `/verify --deferred` run, `/verify` must NOT call `/done`. Instead, it routes to `/escalate` with type "Deferred-Auto Pending" and a message telling the user which deferred-auto criteria remain and instructing them to invoke `/verify --deferred` once prerequisites are in place. Once those criteria pass via `--deferred`, a subsequent normal `/verify` pass can call `/done`.
+
+**Coverage determination.** A deferred-auto criterion is considered "covered" when there exists a preceding pass-log block with `deferred: true`, `result: pass`, and either (a) `scope:` is empty (full deferred coverage), or (b) `scope:` contains the deliverable that owns the criterion. /verify aggregates coverage across all prior `--deferred` blocks in the log: a criterion is pending iff no prior deferred-pass block satisfies (a) or (b) for it. INV-G* deferred-auto criteria are deliverable-scope-independent — they are covered only by a `deferred: true scope: []` block.
+
+**When BOTH manual criteria and pending deferred-auto criteria exist** after a normal full-mode green pass, surface BOTH in a single combined escalation block: list the manual criteria + their how-to-verify, AND list the pending deferred-auto criteria + the `/verify --deferred` instruction. /done remains unreachable until both are resolved.
+
+**After `/verify --deferred` completes green** (all deferred-auto criteria pass), close the user-as-coordinator loop with an explicit next-step instruction: emit a message like *"Deferred-auto criteria green. Re-invoke `/verify <manifest> <log>` (no flags) to reach /done."* Do NOT call /done from the `--deferred` pass itself — `--deferred` only verifies the deferred-auto subset; the final `/done` decision belongs to a normal-flow pass that confirms the full criterion universe is still green AND the deferred coverage now satisfies the gate.
+
+**Cross-repo path delivery to verifiers.** When the manifest declares `Repos: [name: path, ...]`, **every `/verify` pass** (selective, full, and `--deferred`) prepends a verbatim string to each verifier's prompt before the criterion's own prompt:
+
+```
+Available repos: name1=/path/1, name2=/path/2, ...
+```
+
+This is the one mechanism — verifiers do not parse the manifest themselves. The injection fires on every pass, not just `--deferred`, so cross-repo verifiers can run during normal `/do→/verify` flow — that's what makes `/done` reachable for multi-repo manifests without per-repo /done independence. Single-repo manifests (no `Repos:` field) get no prefix injection. Full convention: `references/MULTI_REPO.md` (lives in `define/references/`) §e.
 
 ## /verify Pass Logging Contract
 
@@ -135,14 +170,17 @@ Every /verify invocation appends a structured block to the execution log so /do 
 ## /verify pass {N}
 
 ```yaml
-mode: selective|full
+mode: selective|full             # for --deferred passes: selective if --scope was set, else full
 scope: [<deliverable-id>, ...]   # empty list when mode is full
 result: pass|fail
 failures: [<criterion-id>, ...]  # empty when pass; criterion IDs only, no narrative
-auto_triggered_final: true|false # true when this pass was auto-triggered after selective green
+auto_triggered_final: true|false # true when this pass was auto-triggered after selective green; always false for --deferred passes
+deferred: true|false             # true when this pass ran via --deferred (only deferred-auto criteria checked); false for normal selective/full passes
 ```
 
 [narrative — failed criterion details, fix hints, etc., per Outcome Handling]
 ````
+
+When `deferred: true`, consumers should treat the pass as a partial verification (only `deferred-auto` criteria) — never as evidence that normal-flow ACs/INVs passed. The `result: pass` of a deferred pass means "the deferred-auto criteria are green," not "the whole manifest is green."
 
 Pure markdown so humans can read; fenced YAML so /do and a future /verify can parse deterministically. Pass numbers are sequential within the execution log. /do uses the most recent block to track progress and decide which pass to invoke next.


### PR DESCRIPTION
## Summary

Propagates plugin v0.92.0 source updates (multi-repo schema, `MULTI_REPO.md` reference, `AMENDMENT_MODE.md`/SKILL.md refinements) to all three CLI distributions under `dist/`. Run via the `/sync-tools` skill.

### Per-CLI changes

- **Gemini**: 12 skills resynced, 14 agents regenerated, README skill/hook counts corrected (13→12, 8→7), `gemini-extension.json` bumped to `0.92.0`
- **OpenCode**: 12 skills resynced, 14 agents regenerated, added `/verify` and `/tend-pr-tick` commands, `install_helpers.py` `COMMAND_NAMES` extended, README counts and Usage section updated
- **Codex**: 12 skills resynced, 14 agent TOMLs regenerated (all parse cleanly), README skill count corrected (13→12)

### Operational substitutions

- `CLAUDE.md` → per-CLI context file (`GEMINI.md` / `AGENTS.md`) in operational skill files (`learn-define-patterns/SKILL.md`, `define/tasks/CODING.md`) and operational agents (`code-maintainability-reviewer`, `define-session-analyzer`)
- `execution-modes/efficient.md`: Claude tier names (`haiku`) replaced with `inherit` since model tier routing is Claude Code-only
- Research/reference content left unchanged (per spec)

### Infrastructure

- `install.sh` and `install_helpers.py` updated incrementally, never regenerated. Only `dist/opencode/install_helpers.py` `COMMAND_NAMES` list extended for the two new commands
- All install helpers verified end-to-end: namespacing produces `*-manifest-dev` components correctly

## Test plan

- [x] `python3 /tmp/sync_components.py {gemini,opencode,codex}` — clean run, only expected drift remains
- [x] All 14 Codex agent TOMLs parse with `tomllib.load`
- [x] Per-CLI install_helpers.py namespacing produces all components with `-manifest-dev` suffix in temp dir test
- [x] Operational `CLAUDE.md` substitutions verified per-CLI; `~/.claude/CLAUDE.md` paths preserved correctly
- [x] `MULTI_REPO.md` copied to all three dists

https://claude.ai/code/session_01XqosV1Ltz8LSBWGXkxPt3F

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqosV1Ltz8LSBWGXkxPt3F)_