### PR TITLE
feat(define/writing): sync new rules from human-writing v1.3.0

### DIFF
--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.93.0",
+  "version": "0.93.1",
   "description": "Manifest-driven workflows for structured task execution with verification gates. Supports multi-repo changesets via a shared canonical manifest.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.93.1",
+  "version": "0.93.2",
   "description": "Manifest-driven workflows for structured task execution with verification gates. Supports multi-repo changesets via a shared canonical manifest.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/skills/define/references/WRITING-REFERENCE.md
+++ b/claude-plugins/manifest-dev/skills/define/references/WRITING-REFERENCE.md
@@ -10,7 +10,7 @@ Reference material for writing quality verification. Use as context when verifyi
 
 ## Vocabulary Kill-List
 
-Statistically flagged as AI-generated across peer-reviewed studies of millions of documents. Never use:
+Statistically flagged as AI-generated across peer-reviewed studies of millions of documents. Never use when *writing*. When *reviewing* existing prose, judge by density and clustering rather than single instances.
 
 **Nouns**: delve, tapestry, landscape, realm, testament, journey, insight, resilience, ecosystem, milestone, prowess, utilization
 
@@ -18,15 +18,19 @@ Statistically flagged as AI-generated across peer-reviewed studies of millions o
 
 **Adjectives**: seamless, robust, groundbreaking, transformative, pivotal, vibrant, compelling, crucial, invaluable, holistic, multifaceted, meticulous, commendable, intricate, comprehensive, profound, nuanced, innovative
 
-**Adverbs**: seamlessly, meticulously, notably, profoundly, predominantly, subsequently, thereby, ultimately, significantly, particularly, additionally
+**Adverbs**: seamlessly, meticulously, notably, profoundly, predominantly, subsequently, thereby, ultimately, significantly, particularly, additionally, moreover, furthermore
 
 **Phrases**: "ever-evolving landscape," "in today's fast-paced world," "as we navigate the complexities," "It isn't just X, it's Y," "it's important to note," "it's worth noting that," "without further ado," "in conclusion," "at the heart of"
+
+**Puffery / promotional drift**: "breathtaking," "stunning," "must-see," "must-visit," "iconic," "world-class," "rich cultural tapestry," "hidden gem." AI drifts toward advertisement-like writing even when prompted for a neutral or encyclopedic register — watch for this puffery vocabulary as the canary.
 
 **Hedging phrases**: "it could be argued," "this might suggest," "may potentially," "what could be considered"
 
 **Verb substitution**: AI systematically replaces simple verbs ("is," "are") with elaborate alternatives ("serves as a," "features," "offers"). Over 10% decrease in simple verb usage in AI text.
 
 **False intensifiers**: "genuinely," "truly," "actually" (when used to simulate conviction)
+
+**Era-tracked vocabulary**: AI vocabulary shifts over time. "Delve" peaked 2023–early 2024 then declined as model training data caught up to public awareness; "align with," "fostering," and "showcasing" rose with later models. Treat the kill-list as a living snapshot, not a fixed law — fresh anti-AI corpora keep moving.
 
 ## Anti-Patterns
 
@@ -51,6 +55,10 @@ Statistically flagged as AI-generated across peer-reviewed studies of millions o
 | Excessive hedging | "may potentially offer what could be considered significant benefits" | Strip to: "this works" |
 | Compulsive signposting | "It's worth noting," "It's important to remember" | Trust the reader |
 | Opinion-avoidant framing | "commonly described as," "many find," "generally considered" | State the view directly |
+| Overused conjunctions | "Moreover," "Furthermore," "Additionally," "In addition" stacking across paragraphs at AI-typical density | Cut transitions; let sentences carry the logic. One transition per page, not per paragraph |
+| "Myths busted" / contrast-and-correct | "While many think X, in fact Y" pattern used as default opener regardless of whether a myth exists | Open with the specific claim; skip the strawman setup |
+| Subject puffery | Arbitrary detail elevated to "a microcosm of [larger theme]" / "a window into [broader cultural moment]" | Stop at the specific. Don't extrapolate unless the piece earns it |
+| Statistical regression to the mean | Concrete details (names, numbers, dates) blurred into category-level language | Restore specifics. If you don't know them, say "I don't know" |
 
 ### Tonal
 
@@ -61,10 +69,14 @@ Statistically flagged as AI-generated across peer-reviewed studies of millions o
 | Equal professional distance | All subjects treated with same measured tone | Nerd out about what you care about; show impatience with boring parts |
 | Risk aversion | No confusing sentences, sharp observations, or controversial assertions | Take risks; write surprising, opinionated content |
 | Emotional overreach without depth | Exclamation marks, enthusiastic phrasing that feels oddly impersonal; polished yet hollow, like a greeting card for someone you've never met | Replace emotional proxies with actual emotional content grounded in specifics |
+| Encyclopedic-yet-promotional drift | Even when prompted for a neutral or encyclopedic register, AI drifts toward advertisement-like writing — travel-guide prose for places, marketing copy for products. Watch for puffery vocabulary ("breathtaking," "must-visit," "rich cultural tapestry") | Neutral does not mean polished-bland; it means specific, factual, and unlabored |
 
 ## Punctuation & Formatting Rules
 
 - **Em-dashes and en-dashes**: One of the most reliable AI tells. ChatGPT uses 8 per 573 words; Deepseek 9 per 555 words. Ban entirely; use commas, periods, parentheses, or colons instead.
+- **Curly quotation marks ("" '')**: ChatGPT and DeepSeek tend to produce curly quotes; Gemini and Claude tend to produce straight ("..." '...'). Curly quotes alone are not proof — word processors and typesetting tools auto-curl them — but combined with other tells they raise confidence. Prefer straight quotes for first-draft AI output; let the editor decide if curling is appropriate for the venue.
+- **Heading capitalization**: AI tends to title-case all main words in headings ("How to Write Better Prose") even when the document otherwise uses sentence case. Match the surrounding document's heading style; don't default to title case.
+- **Excessive boldface ("key takeaways" pattern)**: AI mechanically bolds phrases for emphasis, often the same word every time it appears, or in bullet lists where the bold phrase is then redeclared (`**Scalability:** The system is designed to scale...`). Use boldface sparingly and only where genuine emphasis serves the reader.
 - **Emojis**: AI overuses emojis as emotional proxies. Never add unless explicitly requested.
 - **Semicolons**: AI rarely uses them. Including some adds human texture.
 - **Contractions**: AI avoids them. Use freely in conversational prose.

--- a/claude-plugins/manifest-dev/skills/define/tasks/WRITING.md
+++ b/claude-plugins/manifest-dev/skills/define/tasks/WRITING.md
@@ -1,6 +1,6 @@
 # WRITING Task Guidance
 
-Base guidance for all text-authoring tasks (articles, emails, marketing copy, social media, creative writing). Source: writing plugin v1.2.0.
+Base guidance for all text-authoring tasks (articles, emails, marketing copy, social media, creative writing). Source: writing plugin v1.3.0.
 
 ## The Core Problem
 
@@ -38,11 +38,11 @@ Writer substance is ~70% of output quality; editing ~20%; prompting ~10%. No amo
 
 *Detailed reference for all sections below: `references/WRITING-REFERENCE.md` (for verification, not interview context)*
 
-**Vocabulary Kill-List** — ~60 statistically flagged AI words/phrases: nouns (delve, tapestry, landscape...), verbs (leverage, harness, navigate...), adjectives (seamless, robust, transformative...), adverbs (seamlessly, meticulously...), stock phrases, hedging phrases, false intensifiers. AI also replaces simple verbs with elaborate alternatives (10%+ decrease).
+**Vocabulary Kill-List** — ~70 statistically flagged AI words/phrases: nouns (delve, tapestry, landscape...), verbs (leverage, harness, navigate...), adjectives (seamless, robust, transformative...), adverbs (seamlessly, meticulously, moreover, furthermore...), stock phrases, hedging phrases, false intensifiers, **puffery/promotional drift** ("breathtaking," "must-visit," "iconic," "world-class," "rich cultural tapestry," "hidden gem"). AI also replaces simple verbs with elaborate alternatives (10%+ decrease). **Era-tracked**: vocabulary shifts over time (e.g. "delve" peaked 2023–early 2024 then declined; "align with"/"fostering"/"showcasing" rose with later models). Reviewers judge by density/clustering, not single instances.
 
-**Anti-Patterns** — 17 patterns: structural (6: uniform paragraphs, list addiction, formulaic scaffolding, grammar perfection, colon titles, symmetric structure), rhetorical (6: tricolon obsession, perfect antithesis, rhetorical staging, excessive hedging, compulsive signposting, opinion-avoidant framing), tonal (5: uniform register, relentless positivity, equal distance, risk aversion, emotional overreach).
+**Anti-Patterns** — 21 patterns: structural (6: uniform paragraphs, list addiction, formulaic scaffolding, grammar perfection, colon titles, symmetric structure), rhetorical (10: tricolon obsession, perfect antithesis, rhetorical staging, excessive hedging, compulsive signposting, opinion-avoidant framing, **overused conjunctions** stacking — moreover/furthermore/additionally per paragraph, **"myths busted" / contrast-and-correct** strawman openers, **subject puffery** — "a microcosm of..."/"a window into...", **statistical regression to the mean** — concrete details blurred to category-level), tonal (5: uniform register, relentless positivity, equal distance, risk aversion, **encyclopedic-yet-promotional drift** — neutral prompts drift to advertisement-like writing).
 
-**Punctuation & Formatting** — Em-dashes are the top AI tell (ban entirely). AI overuses emojis, avoids semicolons/contractions, applies Oxford commas consistently. Casual markers ("So," "Anyway," "in my experience") have disproportionate human-feel impact.
+**Punctuation & Formatting** — Em-dashes are the top AI tell (ban entirely). AI overuses emojis, avoids semicolons/contractions, applies Oxford commas consistently. **Curly quotation marks** ("" '') flag ChatGPT/DeepSeek vs straight (Gemini/Claude) — combinatorial signal, not standalone. **Heading capitalization**: AI defaults to title case even in sentence-case documents — match surrounding style. **Excessive boldface** ("key takeaways" pattern): AI mechanically bolds same phrase repeatedly or redeclares bold phrase in bullet bodies — use sparingly. Casual markers ("So," "Anyway," "in my experience") have disproportionate human-feel impact.
 
 **Craft Fundamentals** — Seven human-AI gaps: showing vs telling, specificity from lived experience, strategic omission, rhythm variation, deliberate rule-breaking, humor (AI-complete problem), genuine insight.
 
@@ -60,6 +60,8 @@ Writer substance is ~70% of output quality; editing ~20%; prompting ~10%. No amo
 
 - **Hollow output** — content passes review but lacks writer's genuine substance; probe: was the 70% (writer input) actually provided?
 - **Disembodied voice** — lacks specific experiences, opinions, data; probe: check for AUTHOR_VOICE.md?
+- **Encyclopedic-promotional drift** — neutral/factual register slides into travel-guide or marketing puffery; probe: is the register specific and unlabored, or is it polished-bland with "must-visit"/"world-class" vocabulary?
+- **Regression to the mean** — concrete details (names, numbers, dates) get blurred into category-level language during drafting; probe: are specifics restored or did the writer say "I don't know"?
 
 ## Scenario Prompts
 
@@ -70,6 +72,9 @@ Writer substance is ~70% of output quality; editing ~20%; prompting ~10%. No amo
 - **Buried critical info** — important details hidden in middle; probe: what must reader not miss?
 - **Relentless positivity kills credibility** — everything framed as great; no honest assessment; probe: are weaknesses acknowledged?
 - **Perspective collapse** — writing aggregates so many views it has none; probe: does the author take a position?
+- **Strawman opener** — piece opens with "While many think X, in fact Y" without a real myth; probe: is there an actual misconception worth correcting, or skip the contrast-and-correct framing?
+- **Subject puffery** — arbitrary detail elevated to "a microcosm of..." or "a window into..."; probe: does the piece earn the broader extrapolation, or should it stop at the specific?
+- **Conjunction stacking** — moreover/furthermore/additionally appear at AI-typical density across paragraphs; probe: can transitions be cut so sentences carry the logic?
 
 ## Trade-offs
 

--- a/dist/codex/skills/define/references/WRITING-REFERENCE.md
+++ b/dist/codex/skills/define/references/WRITING-REFERENCE.md
@@ -10,7 +10,7 @@ Reference material for writing quality verification. Use as context when verifyi
 
 ## Vocabulary Kill-List
 
-Statistically flagged as AI-generated across peer-reviewed studies of millions of documents. Never use:
+Statistically flagged as AI-generated across peer-reviewed studies of millions of documents. Never use when *writing*. When *reviewing* existing prose, judge by density and clustering rather than single instances.
 
 **Nouns**: delve, tapestry, landscape, realm, testament, journey, insight, resilience, ecosystem, milestone, prowess, utilization
 
@@ -18,15 +18,19 @@ Statistically flagged as AI-generated across peer-reviewed studies of millions o
 
 **Adjectives**: seamless, robust, groundbreaking, transformative, pivotal, vibrant, compelling, crucial, invaluable, holistic, multifaceted, meticulous, commendable, intricate, comprehensive, profound, nuanced, innovative
 
-**Adverbs**: seamlessly, meticulously, notably, profoundly, predominantly, subsequently, thereby, ultimately, significantly, particularly, additionally
+**Adverbs**: seamlessly, meticulously, notably, profoundly, predominantly, subsequently, thereby, ultimately, significantly, particularly, additionally, moreover, furthermore
 
 **Phrases**: "ever-evolving landscape," "in today's fast-paced world," "as we navigate the complexities," "It isn't just X, it's Y," "it's important to note," "it's worth noting that," "without further ado," "in conclusion," "at the heart of"
+
+**Puffery / promotional drift**: "breathtaking," "stunning," "must-see," "must-visit," "iconic," "world-class," "rich cultural tapestry," "hidden gem." AI drifts toward advertisement-like writing even when prompted for a neutral or encyclopedic register — watch for this puffery vocabulary as the canary.
 
 **Hedging phrases**: "it could be argued," "this might suggest," "may potentially," "what could be considered"
 
 **Verb substitution**: AI systematically replaces simple verbs ("is," "are") with elaborate alternatives ("serves as a," "features," "offers"). Over 10% decrease in simple verb usage in AI text.
 
 **False intensifiers**: "genuinely," "truly," "actually" (when used to simulate conviction)
+
+**Era-tracked vocabulary**: AI vocabulary shifts over time. "Delve" peaked 2023–early 2024 then declined as model training data caught up to public awareness; "align with," "fostering," and "showcasing" rose with later models. Treat the kill-list as a living snapshot, not a fixed law — fresh anti-AI corpora keep moving.
 
 ## Anti-Patterns
 
@@ -51,6 +55,10 @@ Statistically flagged as AI-generated across peer-reviewed studies of millions o
 | Excessive hedging | "may potentially offer what could be considered significant benefits" | Strip to: "this works" |
 | Compulsive signposting | "It's worth noting," "It's important to remember" | Trust the reader |
 | Opinion-avoidant framing | "commonly described as," "many find," "generally considered" | State the view directly |
+| Overused conjunctions | "Moreover," "Furthermore," "Additionally," "In addition" stacking across paragraphs at AI-typical density | Cut transitions; let sentences carry the logic. One transition per page, not per paragraph |
+| "Myths busted" / contrast-and-correct | "While many think X, in fact Y" pattern used as default opener regardless of whether a myth exists | Open with the specific claim; skip the strawman setup |
+| Subject puffery | Arbitrary detail elevated to "a microcosm of [larger theme]" / "a window into [broader cultural moment]" | Stop at the specific. Don't extrapolate unless the piece earns it |
+| Statistical regression to the mean | Concrete details (names, numbers, dates) blurred into category-level language | Restore specifics. If you don't know them, say "I don't know" |
 
 ### Tonal
 
@@ -61,10 +69,14 @@ Statistically flagged as AI-generated across peer-reviewed studies of millions o
 | Equal professional distance | All subjects treated with same measured tone | Nerd out about what you care about; show impatience with boring parts |
 | Risk aversion | No confusing sentences, sharp observations, or controversial assertions | Take risks; write surprising, opinionated content |
 | Emotional overreach without depth | Exclamation marks, enthusiastic phrasing that feels oddly impersonal; polished yet hollow, like a greeting card for someone you've never met | Replace emotional proxies with actual emotional content grounded in specifics |
+| Encyclopedic-yet-promotional drift | Even when prompted for a neutral or encyclopedic register, AI drifts toward advertisement-like writing — travel-guide prose for places, marketing copy for products. Watch for puffery vocabulary ("breathtaking," "must-visit," "rich cultural tapestry") | Neutral does not mean polished-bland; it means specific, factual, and unlabored |
 
 ## Punctuation & Formatting Rules
 
 - **Em-dashes and en-dashes**: One of the most reliable AI tells. ChatGPT uses 8 per 573 words; Deepseek 9 per 555 words. Ban entirely; use commas, periods, parentheses, or colons instead.
+- **Curly quotation marks ("" '')**: ChatGPT and DeepSeek tend to produce curly quotes; Gemini and Claude tend to produce straight ("..." '...'). Curly quotes alone are not proof — word processors and typesetting tools auto-curl them — but combined with other tells they raise confidence. Prefer straight quotes for first-draft AI output; let the editor decide if curling is appropriate for the venue.
+- **Heading capitalization**: AI tends to title-case all main words in headings ("How to Write Better Prose") even when the document otherwise uses sentence case. Match the surrounding document's heading style; don't default to title case.
+- **Excessive boldface ("key takeaways" pattern)**: AI mechanically bolds phrases for emphasis, often the same word every time it appears, or in bullet lists where the bold phrase is then redeclared (`**Scalability:** The system is designed to scale...`). Use boldface sparingly and only where genuine emphasis serves the reader.
 - **Emojis**: AI overuses emojis as emotional proxies. Never add unless explicitly requested.
 - **Semicolons**: AI rarely uses them. Including some adds human texture.
 - **Contractions**: AI avoids them. Use freely in conversational prose.

--- a/dist/codex/skills/define/tasks/WRITING.md
+++ b/dist/codex/skills/define/tasks/WRITING.md
@@ -1,6 +1,6 @@
 # WRITING Task Guidance
 
-Base guidance for all text-authoring tasks (articles, emails, marketing copy, social media, creative writing). Source: writing plugin v1.2.0.
+Base guidance for all text-authoring tasks (articles, emails, marketing copy, social media, creative writing). Source: writing plugin v1.3.0.
 
 ## The Core Problem
 
@@ -38,11 +38,11 @@ Writer substance is ~70% of output quality; editing ~20%; prompting ~10%. No amo
 
 *Detailed reference for all sections below: `references/WRITING-REFERENCE.md` (for verification, not interview context)*
 
-**Vocabulary Kill-List** — ~60 statistically flagged AI words/phrases: nouns (delve, tapestry, landscape...), verbs (leverage, harness, navigate...), adjectives (seamless, robust, transformative...), adverbs (seamlessly, meticulously...), stock phrases, hedging phrases, false intensifiers. AI also replaces simple verbs with elaborate alternatives (10%+ decrease).
+**Vocabulary Kill-List** — ~70 statistically flagged AI words/phrases: nouns (delve, tapestry, landscape...), verbs (leverage, harness, navigate...), adjectives (seamless, robust, transformative...), adverbs (seamlessly, meticulously, moreover, furthermore...), stock phrases, hedging phrases, false intensifiers, **puffery/promotional drift** ("breathtaking," "must-visit," "iconic," "world-class," "rich cultural tapestry," "hidden gem"). AI also replaces simple verbs with elaborate alternatives (10%+ decrease). **Era-tracked**: vocabulary shifts over time (e.g. "delve" peaked 2023–early 2024 then declined; "align with"/"fostering"/"showcasing" rose with later models). Reviewers judge by density/clustering, not single instances.
 
-**Anti-Patterns** — 17 patterns: structural (6: uniform paragraphs, list addiction, formulaic scaffolding, grammar perfection, colon titles, symmetric structure), rhetorical (6: tricolon obsession, perfect antithesis, rhetorical staging, excessive hedging, compulsive signposting, opinion-avoidant framing), tonal (5: uniform register, relentless positivity, equal distance, risk aversion, emotional overreach).
+**Anti-Patterns** — 21 patterns: structural (6: uniform paragraphs, list addiction, formulaic scaffolding, grammar perfection, colon titles, symmetric structure), rhetorical (10: tricolon obsession, perfect antithesis, rhetorical staging, excessive hedging, compulsive signposting, opinion-avoidant framing, **overused conjunctions** stacking — moreover/furthermore/additionally per paragraph, **"myths busted" / contrast-and-correct** strawman openers, **subject puffery** — "a microcosm of..."/"a window into...", **statistical regression to the mean** — concrete details blurred to category-level), tonal (5: uniform register, relentless positivity, equal distance, risk aversion, **encyclopedic-yet-promotional drift** — neutral prompts drift to advertisement-like writing).
 
-**Punctuation & Formatting** — Em-dashes are the top AI tell (ban entirely). AI overuses emojis, avoids semicolons/contractions, applies Oxford commas consistently. Casual markers ("So," "Anyway," "in my experience") have disproportionate human-feel impact.
+**Punctuation & Formatting** — Em-dashes are the top AI tell (ban entirely). AI overuses emojis, avoids semicolons/contractions, applies Oxford commas consistently. **Curly quotation marks** ("" '') flag ChatGPT/DeepSeek vs straight (Gemini/Claude) — combinatorial signal, not standalone. **Heading capitalization**: AI defaults to title case even in sentence-case documents — match surrounding style. **Excessive boldface** ("key takeaways" pattern): AI mechanically bolds same phrase repeatedly or redeclares bold phrase in bullet bodies — use sparingly. Casual markers ("So," "Anyway," "in my experience") have disproportionate human-feel impact.
 
 **Craft Fundamentals** — Seven human-AI gaps: showing vs telling, specificity from lived experience, strategic omission, rhythm variation, deliberate rule-breaking, humor (AI-complete problem), genuine insight.
 
@@ -60,6 +60,8 @@ Writer substance is ~70% of output quality; editing ~20%; prompting ~10%. No amo
 
 - **Hollow output** — content passes review but lacks writer's genuine substance; probe: was the 70% (writer input) actually provided?
 - **Disembodied voice** — lacks specific experiences, opinions, data; probe: check for AUTHOR_VOICE.md?
+- **Encyclopedic-promotional drift** — neutral/factual register slides into travel-guide or marketing puffery; probe: is the register specific and unlabored, or is it polished-bland with "must-visit"/"world-class" vocabulary?
+- **Regression to the mean** — concrete details (names, numbers, dates) get blurred into category-level language during drafting; probe: are specifics restored or did the writer say "I don't know"?
 
 ## Scenario Prompts
 
@@ -70,6 +72,9 @@ Writer substance is ~70% of output quality; editing ~20%; prompting ~10%. No amo
 - **Buried critical info** — important details hidden in middle; probe: what must reader not miss?
 - **Relentless positivity kills credibility** — everything framed as great; no honest assessment; probe: are weaknesses acknowledged?
 - **Perspective collapse** — writing aggregates so many views it has none; probe: does the author take a position?
+- **Strawman opener** — piece opens with "While many think X, in fact Y" without a real myth; probe: is there an actual misconception worth correcting, or skip the contrast-and-correct framing?
+- **Subject puffery** — arbitrary detail elevated to "a microcosm of..." or "a window into..."; probe: does the piece earn the broader extrapolation, or should it stop at the specific?
+- **Conjunction stacking** — moreover/furthermore/additionally appear at AI-typical density across paragraphs; probe: can transitions be cut so sentences carry the logic?
 
 ## Trade-offs
 

--- a/dist/gemini/gemini-extension.json
+++ b/dist/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.93.0",
+  "version": "0.93.1",
   "description": "Verification-first manifest workflows for Gemini CLI",
   "mcpServers": {},
   "excludeTools": [],

--- a/dist/gemini/gemini-extension.json
+++ b/dist/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.93.1",
+  "version": "0.93.2",
   "description": "Verification-first manifest workflows for Gemini CLI",
   "mcpServers": {},
   "excludeTools": [],

--- a/dist/gemini/skills/define/references/WRITING-REFERENCE.md
+++ b/dist/gemini/skills/define/references/WRITING-REFERENCE.md
@@ -10,7 +10,7 @@ Reference material for writing quality verification. Use as context when verifyi
 
 ## Vocabulary Kill-List
 
-Statistically flagged as AI-generated across peer-reviewed studies of millions of documents. Never use:
+Statistically flagged as AI-generated across peer-reviewed studies of millions of documents. Never use when *writing*. When *reviewing* existing prose, judge by density and clustering rather than single instances.
 
 **Nouns**: delve, tapestry, landscape, realm, testament, journey, insight, resilience, ecosystem, milestone, prowess, utilization
 
@@ -18,15 +18,19 @@ Statistically flagged as AI-generated across peer-reviewed studies of millions o
 
 **Adjectives**: seamless, robust, groundbreaking, transformative, pivotal, vibrant, compelling, crucial, invaluable, holistic, multifaceted, meticulous, commendable, intricate, comprehensive, profound, nuanced, innovative
 
-**Adverbs**: seamlessly, meticulously, notably, profoundly, predominantly, subsequently, thereby, ultimately, significantly, particularly, additionally
+**Adverbs**: seamlessly, meticulously, notably, profoundly, predominantly, subsequently, thereby, ultimately, significantly, particularly, additionally, moreover, furthermore
 
 **Phrases**: "ever-evolving landscape," "in today's fast-paced world," "as we navigate the complexities," "It isn't just X, it's Y," "it's important to note," "it's worth noting that," "without further ado," "in conclusion," "at the heart of"
+
+**Puffery / promotional drift**: "breathtaking," "stunning," "must-see," "must-visit," "iconic," "world-class," "rich cultural tapestry," "hidden gem." AI drifts toward advertisement-like writing even when prompted for a neutral or encyclopedic register — watch for this puffery vocabulary as the canary.
 
 **Hedging phrases**: "it could be argued," "this might suggest," "may potentially," "what could be considered"
 
 **Verb substitution**: AI systematically replaces simple verbs ("is," "are") with elaborate alternatives ("serves as a," "features," "offers"). Over 10% decrease in simple verb usage in AI text.
 
 **False intensifiers**: "genuinely," "truly," "actually" (when used to simulate conviction)
+
+**Era-tracked vocabulary**: AI vocabulary shifts over time. "Delve" peaked 2023–early 2024 then declined as model training data caught up to public awareness; "align with," "fostering," and "showcasing" rose with later models. Treat the kill-list as a living snapshot, not a fixed law — fresh anti-AI corpora keep moving.
 
 ## Anti-Patterns
 
@@ -51,6 +55,10 @@ Statistically flagged as AI-generated across peer-reviewed studies of millions o
 | Excessive hedging | "may potentially offer what could be considered significant benefits" | Strip to: "this works" |
 | Compulsive signposting | "It's worth noting," "It's important to remember" | Trust the reader |
 | Opinion-avoidant framing | "commonly described as," "many find," "generally considered" | State the view directly |
+| Overused conjunctions | "Moreover," "Furthermore," "Additionally," "In addition" stacking across paragraphs at AI-typical density | Cut transitions; let sentences carry the logic. One transition per page, not per paragraph |
+| "Myths busted" / contrast-and-correct | "While many think X, in fact Y" pattern used as default opener regardless of whether a myth exists | Open with the specific claim; skip the strawman setup |
+| Subject puffery | Arbitrary detail elevated to "a microcosm of [larger theme]" / "a window into [broader cultural moment]" | Stop at the specific. Don't extrapolate unless the piece earns it |
+| Statistical regression to the mean | Concrete details (names, numbers, dates) blurred into category-level language | Restore specifics. If you don't know them, say "I don't know" |
 
 ### Tonal
 
@@ -61,10 +69,14 @@ Statistically flagged as AI-generated across peer-reviewed studies of millions o
 | Equal professional distance | All subjects treated with same measured tone | Nerd out about what you care about; show impatience with boring parts |
 | Risk aversion | No confusing sentences, sharp observations, or controversial assertions | Take risks; write surprising, opinionated content |
 | Emotional overreach without depth | Exclamation marks, enthusiastic phrasing that feels oddly impersonal; polished yet hollow, like a greeting card for someone you've never met | Replace emotional proxies with actual emotional content grounded in specifics |
+| Encyclopedic-yet-promotional drift | Even when prompted for a neutral or encyclopedic register, AI drifts toward advertisement-like writing — travel-guide prose for places, marketing copy for products. Watch for puffery vocabulary ("breathtaking," "must-visit," "rich cultural tapestry") | Neutral does not mean polished-bland; it means specific, factual, and unlabored |
 
 ## Punctuation & Formatting Rules
 
 - **Em-dashes and en-dashes**: One of the most reliable AI tells. ChatGPT uses 8 per 573 words; Deepseek 9 per 555 words. Ban entirely; use commas, periods, parentheses, or colons instead.
+- **Curly quotation marks ("" '')**: ChatGPT and DeepSeek tend to produce curly quotes; Gemini and Claude tend to produce straight ("..." '...'). Curly quotes alone are not proof — word processors and typesetting tools auto-curl them — but combined with other tells they raise confidence. Prefer straight quotes for first-draft AI output; let the editor decide if curling is appropriate for the venue.
+- **Heading capitalization**: AI tends to title-case all main words in headings ("How to Write Better Prose") even when the document otherwise uses sentence case. Match the surrounding document's heading style; don't default to title case.
+- **Excessive boldface ("key takeaways" pattern)**: AI mechanically bolds phrases for emphasis, often the same word every time it appears, or in bullet lists where the bold phrase is then redeclared (`**Scalability:** The system is designed to scale...`). Use boldface sparingly and only where genuine emphasis serves the reader.
 - **Emojis**: AI overuses emojis as emotional proxies. Never add unless explicitly requested.
 - **Semicolons**: AI rarely uses them. Including some adds human texture.
 - **Contractions**: AI avoids them. Use freely in conversational prose.

--- a/dist/gemini/skills/define/tasks/WRITING.md
+++ b/dist/gemini/skills/define/tasks/WRITING.md
@@ -1,6 +1,6 @@
 # WRITING Task Guidance
 
-Base guidance for all text-authoring tasks (articles, emails, marketing copy, social media, creative writing). Source: writing plugin v1.2.0.
+Base guidance for all text-authoring tasks (articles, emails, marketing copy, social media, creative writing). Source: writing plugin v1.3.0.
 
 ## The Core Problem
 
@@ -38,11 +38,11 @@ Writer substance is ~70% of output quality; editing ~20%; prompting ~10%. No amo
 
 *Detailed reference for all sections below: `references/WRITING-REFERENCE.md` (for verification, not interview context)*
 
-**Vocabulary Kill-List** — ~60 statistically flagged AI words/phrases: nouns (delve, tapestry, landscape...), verbs (leverage, harness, navigate...), adjectives (seamless, robust, transformative...), adverbs (seamlessly, meticulously...), stock phrases, hedging phrases, false intensifiers. AI also replaces simple verbs with elaborate alternatives (10%+ decrease).
+**Vocabulary Kill-List** — ~70 statistically flagged AI words/phrases: nouns (delve, tapestry, landscape...), verbs (leverage, harness, navigate...), adjectives (seamless, robust, transformative...), adverbs (seamlessly, meticulously, moreover, furthermore...), stock phrases, hedging phrases, false intensifiers, **puffery/promotional drift** ("breathtaking," "must-visit," "iconic," "world-class," "rich cultural tapestry," "hidden gem"). AI also replaces simple verbs with elaborate alternatives (10%+ decrease). **Era-tracked**: vocabulary shifts over time (e.g. "delve" peaked 2023–early 2024 then declined; "align with"/"fostering"/"showcasing" rose with later models). Reviewers judge by density/clustering, not single instances.
 
-**Anti-Patterns** — 17 patterns: structural (6: uniform paragraphs, list addiction, formulaic scaffolding, grammar perfection, colon titles, symmetric structure), rhetorical (6: tricolon obsession, perfect antithesis, rhetorical staging, excessive hedging, compulsive signposting, opinion-avoidant framing), tonal (5: uniform register, relentless positivity, equal distance, risk aversion, emotional overreach).
+**Anti-Patterns** — 21 patterns: structural (6: uniform paragraphs, list addiction, formulaic scaffolding, grammar perfection, colon titles, symmetric structure), rhetorical (10: tricolon obsession, perfect antithesis, rhetorical staging, excessive hedging, compulsive signposting, opinion-avoidant framing, **overused conjunctions** stacking — moreover/furthermore/additionally per paragraph, **"myths busted" / contrast-and-correct** strawman openers, **subject puffery** — "a microcosm of..."/"a window into...", **statistical regression to the mean** — concrete details blurred to category-level), tonal (5: uniform register, relentless positivity, equal distance, risk aversion, **encyclopedic-yet-promotional drift** — neutral prompts drift to advertisement-like writing).
 
-**Punctuation & Formatting** — Em-dashes are the top AI tell (ban entirely). AI overuses emojis, avoids semicolons/contractions, applies Oxford commas consistently. Casual markers ("So," "Anyway," "in my experience") have disproportionate human-feel impact.
+**Punctuation & Formatting** — Em-dashes are the top AI tell (ban entirely). AI overuses emojis, avoids semicolons/contractions, applies Oxford commas consistently. **Curly quotation marks** ("" '') flag ChatGPT/DeepSeek vs straight (Gemini/Claude) — combinatorial signal, not standalone. **Heading capitalization**: AI defaults to title case even in sentence-case documents — match surrounding style. **Excessive boldface** ("key takeaways" pattern): AI mechanically bolds same phrase repeatedly or redeclares bold phrase in bullet bodies — use sparingly. Casual markers ("So," "Anyway," "in my experience") have disproportionate human-feel impact.
 
 **Craft Fundamentals** — Seven human-AI gaps: showing vs telling, specificity from lived experience, strategic omission, rhythm variation, deliberate rule-breaking, humor (AI-complete problem), genuine insight.
 
@@ -60,6 +60,8 @@ Writer substance is ~70% of output quality; editing ~20%; prompting ~10%. No amo
 
 - **Hollow output** — content passes review but lacks writer's genuine substance; probe: was the 70% (writer input) actually provided?
 - **Disembodied voice** — lacks specific experiences, opinions, data; probe: check for AUTHOR_VOICE.md?
+- **Encyclopedic-promotional drift** — neutral/factual register slides into travel-guide or marketing puffery; probe: is the register specific and unlabored, or is it polished-bland with "must-visit"/"world-class" vocabulary?
+- **Regression to the mean** — concrete details (names, numbers, dates) get blurred into category-level language during drafting; probe: are specifics restored or did the writer say "I don't know"?
 
 ## Scenario Prompts
 
@@ -70,6 +72,9 @@ Writer substance is ~70% of output quality; editing ~20%; prompting ~10%. No amo
 - **Buried critical info** — important details hidden in middle; probe: what must reader not miss?
 - **Relentless positivity kills credibility** — everything framed as great; no honest assessment; probe: are weaknesses acknowledged?
 - **Perspective collapse** — writing aggregates so many views it has none; probe: does the author take a position?
+- **Strawman opener** — piece opens with "While many think X, in fact Y" without a real myth; probe: is there an actual misconception worth correcting, or skip the contrast-and-correct framing?
+- **Subject puffery** — arbitrary detail elevated to "a microcosm of..." or "a window into..."; probe: does the piece earn the broader extrapolation, or should it stop at the specific?
+- **Conjunction stacking** — moreover/furthermore/additionally appear at AI-typical density across paragraphs; probe: can transitions be cut so sentences carry the logic?
 
 ## Trade-offs
 

--- a/dist/opencode/skills/define/references/WRITING-REFERENCE.md
+++ b/dist/opencode/skills/define/references/WRITING-REFERENCE.md
@@ -10,7 +10,7 @@ Reference material for writing quality verification. Use as context when verifyi
 
 ## Vocabulary Kill-List
 
-Statistically flagged as AI-generated across peer-reviewed studies of millions of documents. Never use:
+Statistically flagged as AI-generated across peer-reviewed studies of millions of documents. Never use when *writing*. When *reviewing* existing prose, judge by density and clustering rather than single instances.
 
 **Nouns**: delve, tapestry, landscape, realm, testament, journey, insight, resilience, ecosystem, milestone, prowess, utilization
 
@@ -18,15 +18,19 @@ Statistically flagged as AI-generated across peer-reviewed studies of millions o
 
 **Adjectives**: seamless, robust, groundbreaking, transformative, pivotal, vibrant, compelling, crucial, invaluable, holistic, multifaceted, meticulous, commendable, intricate, comprehensive, profound, nuanced, innovative
 
-**Adverbs**: seamlessly, meticulously, notably, profoundly, predominantly, subsequently, thereby, ultimately, significantly, particularly, additionally
+**Adverbs**: seamlessly, meticulously, notably, profoundly, predominantly, subsequently, thereby, ultimately, significantly, particularly, additionally, moreover, furthermore
 
 **Phrases**: "ever-evolving landscape," "in today's fast-paced world," "as we navigate the complexities," "It isn't just X, it's Y," "it's important to note," "it's worth noting that," "without further ado," "in conclusion," "at the heart of"
+
+**Puffery / promotional drift**: "breathtaking," "stunning," "must-see," "must-visit," "iconic," "world-class," "rich cultural tapestry," "hidden gem." AI drifts toward advertisement-like writing even when prompted for a neutral or encyclopedic register — watch for this puffery vocabulary as the canary.
 
 **Hedging phrases**: "it could be argued," "this might suggest," "may potentially," "what could be considered"
 
 **Verb substitution**: AI systematically replaces simple verbs ("is," "are") with elaborate alternatives ("serves as a," "features," "offers"). Over 10% decrease in simple verb usage in AI text.
 
 **False intensifiers**: "genuinely," "truly," "actually" (when used to simulate conviction)
+
+**Era-tracked vocabulary**: AI vocabulary shifts over time. "Delve" peaked 2023–early 2024 then declined as model training data caught up to public awareness; "align with," "fostering," and "showcasing" rose with later models. Treat the kill-list as a living snapshot, not a fixed law — fresh anti-AI corpora keep moving.
 
 ## Anti-Patterns
 
@@ -51,6 +55,10 @@ Statistically flagged as AI-generated across peer-reviewed studies of millions o
 | Excessive hedging | "may potentially offer what could be considered significant benefits" | Strip to: "this works" |
 | Compulsive signposting | "It's worth noting," "It's important to remember" | Trust the reader |
 | Opinion-avoidant framing | "commonly described as," "many find," "generally considered" | State the view directly |
+| Overused conjunctions | "Moreover," "Furthermore," "Additionally," "In addition" stacking across paragraphs at AI-typical density | Cut transitions; let sentences carry the logic. One transition per page, not per paragraph |
+| "Myths busted" / contrast-and-correct | "While many think X, in fact Y" pattern used as default opener regardless of whether a myth exists | Open with the specific claim; skip the strawman setup |
+| Subject puffery | Arbitrary detail elevated to "a microcosm of [larger theme]" / "a window into [broader cultural moment]" | Stop at the specific. Don't extrapolate unless the piece earns it |
+| Statistical regression to the mean | Concrete details (names, numbers, dates) blurred into category-level language | Restore specifics. If you don't know them, say "I don't know" |
 
 ### Tonal
 
@@ -61,10 +69,14 @@ Statistically flagged as AI-generated across peer-reviewed studies of millions o
 | Equal professional distance | All subjects treated with same measured tone | Nerd out about what you care about; show impatience with boring parts |
 | Risk aversion | No confusing sentences, sharp observations, or controversial assertions | Take risks; write surprising, opinionated content |
 | Emotional overreach without depth | Exclamation marks, enthusiastic phrasing that feels oddly impersonal; polished yet hollow, like a greeting card for someone you've never met | Replace emotional proxies with actual emotional content grounded in specifics |
+| Encyclopedic-yet-promotional drift | Even when prompted for a neutral or encyclopedic register, AI drifts toward advertisement-like writing — travel-guide prose for places, marketing copy for products. Watch for puffery vocabulary ("breathtaking," "must-visit," "rich cultural tapestry") | Neutral does not mean polished-bland; it means specific, factual, and unlabored |
 
 ## Punctuation & Formatting Rules
 
 - **Em-dashes and en-dashes**: One of the most reliable AI tells. ChatGPT uses 8 per 573 words; Deepseek 9 per 555 words. Ban entirely; use commas, periods, parentheses, or colons instead.
+- **Curly quotation marks ("" '')**: ChatGPT and DeepSeek tend to produce curly quotes; Gemini and Claude tend to produce straight ("..." '...'). Curly quotes alone are not proof — word processors and typesetting tools auto-curl them — but combined with other tells they raise confidence. Prefer straight quotes for first-draft AI output; let the editor decide if curling is appropriate for the venue.
+- **Heading capitalization**: AI tends to title-case all main words in headings ("How to Write Better Prose") even when the document otherwise uses sentence case. Match the surrounding document's heading style; don't default to title case.
+- **Excessive boldface ("key takeaways" pattern)**: AI mechanically bolds phrases for emphasis, often the same word every time it appears, or in bullet lists where the bold phrase is then redeclared (`**Scalability:** The system is designed to scale...`). Use boldface sparingly and only where genuine emphasis serves the reader.
 - **Emojis**: AI overuses emojis as emotional proxies. Never add unless explicitly requested.
 - **Semicolons**: AI rarely uses them. Including some adds human texture.
 - **Contractions**: AI avoids them. Use freely in conversational prose.

--- a/dist/opencode/skills/define/tasks/WRITING.md
+++ b/dist/opencode/skills/define/tasks/WRITING.md
@@ -1,6 +1,6 @@
 # WRITING Task Guidance
 
-Base guidance for all text-authoring tasks (articles, emails, marketing copy, social media, creative writing). Source: writing plugin v1.2.0.
+Base guidance for all text-authoring tasks (articles, emails, marketing copy, social media, creative writing). Source: writing plugin v1.3.0.
 
 ## The Core Problem
 
@@ -38,11 +38,11 @@ Writer substance is ~70% of output quality; editing ~20%; prompting ~10%. No amo
 
 *Detailed reference for all sections below: `references/WRITING-REFERENCE.md` (for verification, not interview context)*
 
-**Vocabulary Kill-List** — ~60 statistically flagged AI words/phrases: nouns (delve, tapestry, landscape...), verbs (leverage, harness, navigate...), adjectives (seamless, robust, transformative...), adverbs (seamlessly, meticulously...), stock phrases, hedging phrases, false intensifiers. AI also replaces simple verbs with elaborate alternatives (10%+ decrease).
+**Vocabulary Kill-List** — ~70 statistically flagged AI words/phrases: nouns (delve, tapestry, landscape...), verbs (leverage, harness, navigate...), adjectives (seamless, robust, transformative...), adverbs (seamlessly, meticulously, moreover, furthermore...), stock phrases, hedging phrases, false intensifiers, **puffery/promotional drift** ("breathtaking," "must-visit," "iconic," "world-class," "rich cultural tapestry," "hidden gem"). AI also replaces simple verbs with elaborate alternatives (10%+ decrease). **Era-tracked**: vocabulary shifts over time (e.g. "delve" peaked 2023–early 2024 then declined; "align with"/"fostering"/"showcasing" rose with later models). Reviewers judge by density/clustering, not single instances.
 
-**Anti-Patterns** — 17 patterns: structural (6: uniform paragraphs, list addiction, formulaic scaffolding, grammar perfection, colon titles, symmetric structure), rhetorical (6: tricolon obsession, perfect antithesis, rhetorical staging, excessive hedging, compulsive signposting, opinion-avoidant framing), tonal (5: uniform register, relentless positivity, equal distance, risk aversion, emotional overreach).
+**Anti-Patterns** — 21 patterns: structural (6: uniform paragraphs, list addiction, formulaic scaffolding, grammar perfection, colon titles, symmetric structure), rhetorical (10: tricolon obsession, perfect antithesis, rhetorical staging, excessive hedging, compulsive signposting, opinion-avoidant framing, **overused conjunctions** stacking — moreover/furthermore/additionally per paragraph, **"myths busted" / contrast-and-correct** strawman openers, **subject puffery** — "a microcosm of..."/"a window into...", **statistical regression to the mean** — concrete details blurred to category-level), tonal (5: uniform register, relentless positivity, equal distance, risk aversion, **encyclopedic-yet-promotional drift** — neutral prompts drift to advertisement-like writing).
 
-**Punctuation & Formatting** — Em-dashes are the top AI tell (ban entirely). AI overuses emojis, avoids semicolons/contractions, applies Oxford commas consistently. Casual markers ("So," "Anyway," "in my experience") have disproportionate human-feel impact.
+**Punctuation & Formatting** — Em-dashes are the top AI tell (ban entirely). AI overuses emojis, avoids semicolons/contractions, applies Oxford commas consistently. **Curly quotation marks** ("" '') flag ChatGPT/DeepSeek vs straight (Gemini/Claude) — combinatorial signal, not standalone. **Heading capitalization**: AI defaults to title case even in sentence-case documents — match surrounding style. **Excessive boldface** ("key takeaways" pattern): AI mechanically bolds same phrase repeatedly or redeclares bold phrase in bullet bodies — use sparingly. Casual markers ("So," "Anyway," "in my experience") have disproportionate human-feel impact.
 
 **Craft Fundamentals** — Seven human-AI gaps: showing vs telling, specificity from lived experience, strategic omission, rhythm variation, deliberate rule-breaking, humor (AI-complete problem), genuine insight.
 
@@ -60,6 +60,8 @@ Writer substance is ~70% of output quality; editing ~20%; prompting ~10%. No amo
 
 - **Hollow output** — content passes review but lacks writer's genuine substance; probe: was the 70% (writer input) actually provided?
 - **Disembodied voice** — lacks specific experiences, opinions, data; probe: check for AUTHOR_VOICE.md?
+- **Encyclopedic-promotional drift** — neutral/factual register slides into travel-guide or marketing puffery; probe: is the register specific and unlabored, or is it polished-bland with "must-visit"/"world-class" vocabulary?
+- **Regression to the mean** — concrete details (names, numbers, dates) get blurred into category-level language during drafting; probe: are specifics restored or did the writer say "I don't know"?
 
 ## Scenario Prompts
 
@@ -70,6 +72,9 @@ Writer substance is ~70% of output quality; editing ~20%; prompting ~10%. No amo
 - **Buried critical info** — important details hidden in middle; probe: what must reader not miss?
 - **Relentless positivity kills credibility** — everything framed as great; no honest assessment; probe: are weaknesses acknowledged?
 - **Perspective collapse** — writing aggregates so many views it has none; probe: does the author take a position?
+- **Strawman opener** — piece opens with "While many think X, in fact Y" without a real myth; probe: is there an actual misconception worth correcting, or skip the contrast-and-correct framing?
+- **Subject puffery** — arbitrary detail elevated to "a microcosm of..." or "a window into..."; probe: does the piece earn the broader extrapolation, or should it stop at the specific?
+- **Conjunction stacking** — moreover/furthermore/additionally appear at AI-typical density across paragraphs; probe: can transitions be cut so sentences carry the logic?
 
 ## Trade-offs
 


### PR DESCRIPTION
## Summary

Sync new writing rules from upstream `doodledood/claude-code-plugins` `human-writing` skill (v1.2.0 → v1.3.0) into our `define/tasks/WRITING.md` and `define/references/WRITING-REFERENCE.md` so `/define` probes for them and the writing-reviewer fallback flags them.

### What was added upstream

**Vocabulary**
- New category: **puffery / promotional drift** — "breathtaking," "stunning," "must-see," "must-visit," "iconic," "world-class," "rich cultural tapestry," "hidden gem"
- Added to adverbs: `moreover`, `furthermore`
- New note: **era-tracked vocabulary** — "delve" peaked 2023–early 2024 then declined; "align with" / "fostering" / "showcasing" rose with later models
- Reviewers should judge by density/clustering, not single instances

**Rhetorical anti-patterns (4 new)**
- Overused conjunctions stacking (moreover/furthermore/additionally per paragraph)
- "Myths busted" / contrast-and-correct strawman openers
- Subject puffery — "a microcosm of..." / "a window into..."
- Statistical regression to the mean — concrete details blurred to category-level

**Tonal anti-pattern (1 new)**
- Encyclopedic-yet-promotional drift — neutral prompts drift toward advertisement-like writing

**Punctuation / formatting tells (3 new)**
- Curly quotation marks (combinatorial signal — ChatGPT/DeepSeek vs Gemini/Claude)
- Heading capitalization mismatches (title case in sentence-case docs)
- Excessive boldface — "key takeaways" pattern with redeclared phrases

### Files

- `claude-plugins/manifest-dev/skills/define/tasks/WRITING.md` — compressed summaries + new risks and scenario prompts so `/define` surfaces these patterns
- `claude-plugins/manifest-dev/skills/define/references/WRITING-REFERENCE.md` — full detail used by writing-reviewer fallback
- `claude-plugins/manifest-dev/.claude-plugin/plugin.json` — bumped to `0.93.1` (patch, content sync only)
- `dist/{codex,gemini,opencode}/...` — synced copies; bumped `gemini-extension.json` to `0.93.1`

## Test plan

- [ ] Run `/define` on a writing task and confirm interview probes touch the new patterns (encyclopedic drift, subject puffery, conjunction stacking, strawman openers)
- [ ] Trigger writing-reviewer fallback path and verify `WRITING-REFERENCE.md` content drives detection of the new tells
- [ ] Sanity-check `dist/` copies match source

https://claude.ai/code/session_01UiY4fDjwhsBCSjcysVicV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiY4fDjwhsBCSjcysVicV2)_