### PR TITLE
chore(dist): record HEAD in sync-meta + bump gemini-extension to 0.94.0

### DIFF
--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "3658fdb46565c964e1e5c47223ed39bfe9894ba0",
+  "source_commit": "6224c387eaabbd319c29aab0aff32dd65f58d1be",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-04-29T19:24:22Z"
+  "synced_at": "2026-04-29T21:59:00Z"
 }

--- a/dist/gemini/.sync-meta.json
+++ b/dist/gemini/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "3658fdb46565c964e1e5c47223ed39bfe9894ba0",
+  "source_commit": "6224c387eaabbd319c29aab0aff32dd65f58d1be",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-04-29T19:24:22Z"
+  "synced_at": "2026-04-29T21:59:00Z"
 }

--- a/dist/gemini/gemini-extension.json
+++ b/dist/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.93.2",
+  "version": "0.94.0",
   "description": "Verification-first manifest workflows for Gemini CLI",
   "mcpServers": {},
   "excludeTools": [],

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "3658fdb46565c964e1e5c47223ed39bfe9894ba0",
+  "source_commit": "6224c387eaabbd319c29aab0aff32dd65f58d1be",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-04-29T19:24:22Z"
+  "synced_at": "2026-04-29T21:59:00Z"
 }


### PR DESCRIPTION
## Summary
- Re-ran sync-tools after #100 landed. Source diff between `3658fdb..HEAD` was a pure re-namespacing of the test-coverage agent (`code-coverage-reviewer` → `test-quality-reviewer` + new `prose-value-reviewer`), and that PR already shipped the corresponding dist files. The two leftover stragglers from that sync are addressed here:
  - `dist/{gemini,opencode,codex}/.sync-meta.json` advanced from `3658fdb` to `6224c38` so the next delta-sync keys off the right baseline
  - `dist/gemini/gemini-extension.json` version bumped `0.93.2` → `0.94.0` to match `claude-plugins/manifest-dev/.claude-plugin/plugin.json`
- Verified per CLI: agent prompt bodies match source, `code-coverage-reviewer` is fully removed, both new agents (`test-quality-reviewer`, `prose-value-reviewer`) appear in component tables, install_helpers, and Codex `config.toml`. CODING.md substitutions (`CLAUDE.md` → `GEMINI.md` / `AGENTS.md`) intact and gates table updated.

## Test plan
- [x] `git diff 3658fdb..HEAD -- claude-plugins/manifest-dev/` reviewed; no source change unaccounted for in dist
- [x] All 12 modified review-agent bodies byte-equal source for Gemini, OpenCode, and Codex (TOML `developer_instructions`)
- [x] No `code-coverage-reviewer` references survive in any dist file
- [x] sync-meta files now point at `6224c38` with fresh `synced_at`

https://claude.ai/code/session_01RUwiEj3X26D5qt5nwiosqk

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUwiEj3X26D5qt5nwiosqk)_