### PR TITLE
fix(sync-tools): omit model field for OpenCode agents to avoid stale Claude versions

### DIFF
--- a/.claude/skills/sync-tools/references/opencode-cli.md
+++ b/.claude/skills/sync-tools/references/opencode-cli.md
@@ -67,12 +67,11 @@ model: inherit
 ---
 ```
 
-OpenCode agent format:
+OpenCode agent format (no `model:` — agent inherits OpenCode's configured global model; see Phase 1 rule #7):
 ```yaml
 ---
 description: Agent purpose description
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2
 tools:
   bash: true
@@ -94,7 +93,7 @@ tools:
 |-------|------|---------|-------------|
 | `description` | string | REQUIRED | Brief description of agent purpose |
 | `mode` | "primary" / "subagent" / "all" | "all" | How agent can be invoked |
-| `model` | string | global config | Provider/model-id format (e.g., `anthropic/claude-sonnet-4-20250514`) |
+| `model` | string | global config | Provider/model-id format (e.g., `provider/model-id`). **Omit during sync** — let agents inherit the user's configured global model. See Phase 1 rule #7. |
 | `temperature` | number (0.0-1.0) | model default | Response randomness |
 | `top_p` | number (0.0-1.0) | model default | Nucleus sampling |
 | `steps` | positive integer | unlimited | Max agentic iterations |
@@ -112,6 +111,7 @@ tools:
 4. Add `mode: subagent` for agents spawned by other agents, `mode: primary` for top-level
 5. Keep prompt body (everything below frontmatter) unchanged
 6. Write to `.opencode/agents/` (project) or `~/.config/opencode/agents/` (global)
+7. **Omit the `model` field.** OpenCode falls back to the user's configured global model (per the field table above) — that is the desired behavior. Hardcoding any concrete `provider/model-id` makes the dist go stale at every model release; we do not want to keep chasing model names. This mirrors the source plugin convention (Claude Code agents omit `model:` and inherit), the Gemini reference (`model: inherit`), and the Codex reference (omit `model` and `model_reasoning_effort`). Do NOT add a `model:` line to converted agents under any circumstances; users override at the OpenCode global-config level if they want a specific model.
 
 **Phase 2 enrichment** (LLM):
 - Infer `temperature` from agent purpose: 0.1-0.2 for deterministic (QA, verification), 0.3 for balanced (code review), 0.5-0.7 for creative

--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.94.0",
+  "version": "0.94.1",
   "description": "Manifest-driven workflows for structured task execution with verification gates. Supports multi-repo changesets via a shared canonical manifest.",
   "keywords": [
     "manifest",

--- a/dist/opencode/agents/change-intent-reviewer.md
+++ b/dist/opencode/agents/change-intent-reviewer.md
@@ -1,7 +1,6 @@
 ---
 description: "Adversarially analyze whether code, prompt, or config changes achieve their stated intent. Reconstructs change intent from diff context, then systematically attacks the logic to find behavioral divergences. Use after implementing a feature, before a PR, or when validating that changes do what they're supposed to do. Triggers: intent review, does this work, logic check, behavioral analysis, change validation."
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2
 tools:
   bash: true

--- a/dist/opencode/agents/code-bugs-reviewer.md
+++ b/dist/opencode/agents/code-bugs-reviewer.md
@@ -1,7 +1,6 @@
 ---
 description: "Audit code changes for mechanical defects — runtime failures, resource issues, and structural code flaws. Focuses on defects detectable from code patterns (race conditions, resource leaks, edge cases, dangerous defaults) rather than intent-behavior analysis. Use when reviewing git diffs, checking code before merge, or auditing specific files for defects. Triggers: bug review, audit code, check for bugs, review changes, pre-merge check."
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2
 tools:
   bash: true

--- a/dist/opencode/agents/code-design-reviewer.md
+++ b/dist/opencode/agents/code-design-reviewer.md
@@ -1,7 +1,6 @@
 ---
 description: "Audit code for design fitness issues — whether code is the right approach given what already exists in the framework, codebase, and configuration systems. Identifies reinvented wheels, misplaced responsibilities, under-engineering, short-sighted interfaces, concept misuse, and incoherent changes. Use after implementing a feature, before a PR, or when code feels like the wrong approach despite being correct."
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2
 tools:
   bash: true

--- a/dist/opencode/agents/code-maintainability-reviewer.md
+++ b/dist/opencode/agents/code-maintainability-reviewer.md
@@ -1,7 +1,6 @@
 ---
 description: "Use this agent when you need a comprehensive maintainability audit of recently written or modified code. Focuses on code organization: DRY violations, coupling, cohesion, consistency, dead code, and architectural boundaries. This agent should be invoked after implementing a feature, completing a refactor, or before finalizing a pull request."
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2
 tools:
   bash: true

--- a/dist/opencode/agents/code-simplicity-reviewer.md
+++ b/dist/opencode/agents/code-simplicity-reviewer.md
@@ -1,7 +1,6 @@
 ---
 description: "Audit code for unnecessary complexity, over-engineering, and cognitive burden. Identifies solutions more complex than the problem requires — not structural issues like coupling or DRY (handled by maintainability-reviewer), but implementation complexity that makes code harder to understand than necessary. Use after implementing a feature, before a PR, or when code feels over-engineered."
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2
 tools:
   bash: true

--- a/dist/opencode/agents/code-testability-reviewer.md
+++ b/dist/opencode/agents/code-testability-reviewer.md
@@ -1,7 +1,6 @@
 ---
 description: "Audit code for testability issues. Identifies code requiring excessive mocking, business logic buried in IO, non-deterministic inputs, and tight coupling that makes verification hard. Use after implementing features, during refactoring, or before PRs. Triggers: testability, hard to test, too many mocks, testable design."
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2
 tools:
   bash: true

--- a/dist/opencode/agents/context-file-adherence-reviewer.md
+++ b/dist/opencode/agents/context-file-adherence-reviewer.md
@@ -1,7 +1,6 @@
 ---
 description: "Verify that code changes comply with context file instructions (CLAUDE.md, AGENTS.md, GEMINI.md) and project standards. Audits pull requests, new code, and refactors against rules defined in the project's context files. Use after implementing features, before PRs, or when validating adherence to project-specific rules. Triggers: context file compliance, project standards, adherence check."
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2
 tools:
   bash: true

--- a/dist/opencode/agents/contracts-reviewer.md
+++ b/dist/opencode/agents/contracts-reviewer.md
@@ -1,7 +1,6 @@
 ---
 description: "Verify API and interface contract correctness with evidence. Checks both outbound (code calls external/internal APIs correctly per documentation) and inbound (changes don't break consumers of your interfaces). Evidence-based — cites actual API docs or codebase definitions. Use when reviewing API integrations, interface changes, or cross-service boundaries. Triggers: API review, contract check, integration review, consumer impact, breaking changes."
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2
 tools:
   bash: true

--- a/dist/opencode/agents/criteria-checker.md
+++ b/dist/opencode/agents/criteria-checker.md
@@ -1,7 +1,6 @@
 ---
 description: "'Read-only verification agent. Validates a single criterion using any automated method: commands, codebase analysis, file inspection, reasoning, web research. Returns structured PASS/FAIL results.'"
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2
 tools:
   bash: true

--- a/dist/opencode/agents/define-session-analyzer.md
+++ b/dist/opencode/agents/define-session-analyzer.md
@@ -1,7 +1,6 @@
 ---
 description: "'Analyze a single /define session transcript to extract user preference patterns. Spawned by learn-define-patterns skill for parallel per-session analysis.'"
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2
 tools:
   bash: true

--- a/dist/opencode/agents/docs-reviewer.md
+++ b/dist/opencode/agents/docs-reviewer.md
@@ -1,7 +1,6 @@
 ---
 description: "Audit documentation and code comments for accuracy against recent code changes. Performs read-only analysis comparing docs to code, producing a report of required updates without modifying files. Use after implementing features, before PRs, or when validating doc accuracy. Triggers: docs review, documentation audit, stale docs check."
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2
 tools:
   bash: true

--- a/dist/opencode/agents/manifest-verifier.md
+++ b/dist/opencode/agents/manifest-verifier.md
@@ -1,7 +1,6 @@
 ---
 description: "'Reviews /define manifests for gaps and outputs actionable continuation steps. Returns specific questions to ask and areas to probe so interview can continue.'"
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2
 tools:
   glob: true

--- a/dist/opencode/agents/prose-value-reviewer.md
+++ b/dist/opencode/agents/prose-value-reviewer.md
@@ -1,7 +1,6 @@
 ---
 description: "Audit code comments and repo-resident doc files for prose value. Doc-file scope adapts to whatever documentation layout the project uses (READMEs anywhere, *.md at the repo root, plus *.md in whatever conventional doc directory the project has — discovered via filesystem inspection, not assumed). Flags narrating-the-obvious comments, generic puffery / empty buzzwords, AI rhetorical patterns (em-dash overuse, \"It's not just X — it's Y\"), and sycophantic / assistant-voice fragments. Comments must be load-bearing-WHY, not WHAT-restatement or past-iteration narration. Use after implementing features, before a PR, or when comments and docs feel padded with AI sheen. Triggers: prose review, comment value, AI tells, doc puffery, narrating obvious, doc slop, comment slop."
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2
 tools:
   bash: true

--- a/dist/opencode/agents/test-quality-reviewer.md
+++ b/dist/opencode/agents/test-quality-reviewer.md
@@ -1,7 +1,6 @@
 ---
 description: "Verify that tests for code changes are both PRESENT (coverage) and VALIDATING (not tautological). Derives test scenarios from source logic, reports coverage gaps with concrete inputs and expected outputs, and flags existing tests that mirror implementation, mock the system under test, contain trivial assertions, or are snapshots without intent. Use after implementing a feature, before a PR, or when reviewing test quality. Triggers: check coverage, test coverage, coverage gaps, tautological tests, test quality, are tests adequate, mock-the-SUT, snapshot bloat, what should I test."
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2
 tools:
   bash: true

--- a/dist/opencode/agents/type-safety-reviewer.md
+++ b/dist/opencode/agents/type-safety-reviewer.md
@@ -1,7 +1,6 @@
 ---
 description: "Audit code for type safety issues across typed languages (TypeScript, Python, Java/Kotlin, Go, Rust, C#). Identifies type holes that let bugs through, opportunities to make invalid states unrepresentable, and ways to push runtime checks into compile-time guarantees. Use when reviewing type safety, strengthening types before a PR, or auditing code for type holes."
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2
 tools:
   bash: true


### PR DESCRIPTION
## Summary

The OpenCode sync reference's example agent format hardcoded `model: anthropic/claude-sonnet-4-20250514`, which propagated through every sync into all 15 `dist/opencode/agents/*.md` files and went stale at each Claude release. Source plugin agents already omit `model:` (Claude Code inherits), Gemini already documents `model: inherit`, and Codex already documents "omit `model` and `model_reasoning_effort`." OpenCode was the only reference still committing to a specific Claude version.

This PR makes "omit `model`, inherit from global config" the documented default for OpenCode and sweeps the existing dist artifacts so the next install isn't carrying a frozen model version.

- **`.claude/skills/sync-tools/references/opencode-cli.md`**:
  - Removed `model: anthropic/claude-sonnet-4-20250514` from the OpenCode agent format YAML example.
  - Generalized the field-table row for `model` to "provider/model-id format" and marked **Omit during sync**.
  - Added Phase 1 conversion rule #7: explicit imperative to omit `model:` for converted agents, with rationale (stale-proofing, mirrors Claude Code/Gemini/Codex conventions) and a hard prohibition ("Do NOT add a `model:` line ... under any circumstances").
- **`dist/opencode/agents/*.md` (15 files)**: each had its `model: anthropic/claude-sonnet-4-...` line removed (one-line deletion per file; frontmatter and body otherwise byte-identical).
- **`claude-plugins/manifest-dev/.claude-plugin/plugin.json`**: 0.94.0 → 0.94.1 (patch).
- Line 176 (`model: anthropic/...   # optional: override model` inside a *command* format example) is preserved — `...` is a syntax-shape placeholder, not a stale model.

## Verification

- INV-G1 (no stale models in opencode-cli.md or dist agents) — PASS
- INV-G2 (only the 17 expected files modified vs origin/main) — PASS
- INV-G3 (source plugin agents still omit `model:`) — PASS
- INV-G4 (`ruff check` + `black --check` + `mypy`) — PASS
- INV-G5 (prompt-reviewer scored 9/10; rule #7 robustly defends against regression) — PASS
- AC-1.1–1.4, AC-2.1–2.3, AC-3.1, AC-4.1–4.3 — all PASS (16/16 criteria)

Manifest archived to `/tmp/manifest-1777528646.md`; execution log at `/tmp/do-log-1777528646.md`.

## Test plan

- [ ] CI passes (lint, format, typecheck)
- [ ] Spot-check one `dist/opencode/agents/*.md` to confirm frontmatter still parses without `model:`
- [ ] Confirm `.claude/skills/sync-tools/references/opencode-cli.md` Phase 1 rule #7 reads unambiguously — an LLM running the next `/sync-tools` should NOT re-introduce a `model:` line
- [ ] (Optional, on a follow-up) Decide whether to extend the omit-and-inherit policy to command Phase 2 enrichment (line 195) — currently theoretical concern, no `dist/opencode/commands/*.md` carries a hardcoded model today

## Notes

The `/define` manifest initially assumed sync-tools was distributed under `claude-plugins/manifest-dev/skills/sync-tools/`. It isn't — sync-tools is a maintainer meta-tool that lives only at `.claude/skills/sync-tools/` (excluded from plugin distribution per its own SKILL.md). Manifest paths corrected mid-execution; logged in the execution log for traceability.

https://claude.ai/code/session_01YRxPHRUdR9CDtMoqF8joLU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRxPHRUdR9CDtMoqF8joLU)_