### PR TITLE
fix(tend-pr,drive): fetch all comment surfaces + full merge-state taxonomy

### DIFF
--- a/.manifest/fix-drive-tend-pr-comment-fetching-and-merge-state-2026-04-30.md
+++ b/.manifest/fix-drive-tend-pr-comment-fetching-and-merge-state-2026-04-30.md
@@ -1,0 +1,274 @@
+# Definition: Fix /drive and /tend-pr — full comment fetching + merge-state health
+
+## 1. Intent & Context
+
+- **Goal:** Close two reported gaps in `/drive` (github adapter) and `/tend-pr-tick`: (a) top-level PR comments are routinely missed because the skills don't enumerate the three distinct `pull_request_read` methods (file-level review threads, formal review submissions, top-level issue-style comments); (b) branch-protection blockers — specifically "branch must be up-to-date with base" — aren't detected, so merge-readiness fires while GitHub still blocks the merge. While fixing (a) and (b), also close two adjacent gaps that compromise the same goal: pagination is unspecified (so paginated comment lists silently truncate), and PR title/description sync is gated on commit-producing ticks (so a manifest amendment that changes scope/intent doesn't propagate to the PR until /do produces a commit).
+- **Mental Model:** The skill exists to drive a PR to merge-ready. Every fix here is framed by that higher-order goal: a missed top-level comment delays merge-ready; a missed `mergeable_state: "behind"` blocks merge silently; a stale PR description after a scope amendment confuses reviewers. "Merge State Health" is the unifying lens — replace the narrower "Merge Conflicts" framing with a section that enumerates the GitHub `mergeable_state` taxonomy and a fallback rule for unspecified values. Skills stay non-prescriptive about HOW (model knows MCP semantics) but explicit about WHAT must be fetched and WHICH conditions block merge-ready.
+- **Mode:** thorough
+- **Interview:** thorough
+
+## 2. Approach
+
+- **Architecture:** Parallel edits to `claude-plugins/manifest-dev/skills/tend-pr-tick/SKILL.md` and `claude-plugins/manifest-dev-experimental/skills/drive/references/platforms/github.md`. Both skills get: (i) explicit three-method comment-fetch enumeration with pagination in their Read State sections, (ii) renamed `Merge State Health` section replacing `Merge Conflicts`, covering `behind | blocked | unstable | unknown | dirty (conflicts) | other` with explicit dispositions, (iii) `Merge Readiness` preconditions reference `Merge State Health` as authoritative, (iv) PR Description Sync expanded trigger: fires on Intent/Deliverable amendment OR commit-producing tick, with combined-single-sync when both apply. `classification-examples.md` (in `claude-plugins/manifest-dev/skills/tend-pr/references/`) gains top-level-comment rows. tend-pr-tick mirrors drive's `### Inbox — ` disposition log shape (per-event `kind: inline | top-level | review-body`). Wrappers (`tend-pr/SKILL.md`, `drive/SKILL.md`, `drive-tick/SKILL.md`) untouched — the issues live in tick + adapter.
+
+- **Execution Order:**
+  - D1 (drive github.md) → D2 (tend-pr-tick) → D3 (classification examples) → D4 (version bumps) → D5 (sync-tools dist regen)
+  - Rationale: D1 is the more elaborate adapter — establish the structure there, then mirror to D2. D3 is independent. D4 (versions) before D5 (sync) so dist regenerates with new versions baked in.
+
+- **Risk Areas:**
+  - [R-1] drive github.md and tend-pr-tick diverge after the fix despite same root cause | Detect: cross-read both files post-edit; spec must be functionally equivalent on the four touched concerns (comment fetch, merge state, sync trigger, inbox tagging).
+  - [R-2] `mergeable_state` enumeration has a gap — an unspecified value triggers undefined behavior | Detect: the new `Merge State Health` section explicitly states a fallback rule for unspecified values.
+  - [R-3] Pagination instruction added to one method but not all | Detect: each of the three `pull_request_read` comment methods has explicit pagination guidance.
+  - [R-4] Top-level classification examples are too narrow / overfit a few patterns | Detect: examples span actionable / FP / uncertain with diverse top-level patterns (scope-extension request, ship-it acknowledgement, design question, etc.).
+  - [R-5] dist drift — source changes land but `dist/` not regenerated | Detect: post-D5, run `sync-tools` and verify all three CLI dists carry the new content.
+  - [R-6] Behavior regression — over-instructing destabilizes existing classification or terminal-state logic | Detect: change-intent-reviewer flags no LOW+ regressions; cross-read existing logic (Thread Hygiene, CI Triage, Terminal States) post-edit to confirm untouched.
+  - [R-7] Scope creep — "broad" framing tempts unrelated edits | Detect: every edit traces to one of the four user-confirmed gaps + dist sync + version bump.
+
+- **Trade-offs:**
+  - [T-1] Inline three-method enumeration vs shared reference file → Prefer inline because it keeps each skill self-contained and parallel; the ~5 lines of duplication is acceptable.
+  - [T-2] Rename Merge Conflicts → Merge State Health vs inline edit → Prefer rename because the broader taxonomy doesn't fit under the old name; downstream cross-refs (Gotchas, Merge Readiness) must be updated to the new section name.
+  - [T-3] Combined single sync vs two separate syncs per tick → Prefer combined to keep PR edit history low-noise.
+  - [T-4] Explicit per-method pagination vs single global pagination rule → Per the user's pick: explicit per method (pagination is the kind of thing where general guidance gets skipped).
+
+## 3. Global Invariants
+
+- [INV-G1] change-intent-reviewer reports no LOW+ findings on the diff. | Verify:
+  ```yaml
+  verify:
+    method: subagent
+    agent: change-intent-reviewer
+    prompt: "Review the diff against this manifest's intent (close two reported /drive and /tend-pr gaps: missed top-level PR comments and missed branch-protection 'behind' blocker, plus pagination and amendment-sync correctness). Flag any LOW+ behavioral divergence between intent and changes."
+  ```
+
+- [INV-G2] prompt-reviewer reports no MEDIUM+ findings on edited skill files. | Verify:
+  ```yaml
+  verify:
+    method: subagent
+    agent: prompt-reviewer
+    prompt: "Review the prompt quality of the edited files: claude-plugins/manifest-dev/skills/tend-pr-tick/SKILL.md, claude-plugins/manifest-dev-experimental/skills/drive/references/platforms/github.md, and claude-plugins/manifest-dev/skills/tend-pr/references/classification-examples.md. Flag MEDIUM+ issues against the prompt-engineering principles."
+  ```
+
+- [INV-G3] Skill-pair parity: every concept added to one skill (three-method comment fetch, Merge State Health section, amendment-driven sync trigger, per-event kind tagging) is present in the other. | Verify:
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Cross-read claude-plugins/manifest-dev/skills/tend-pr-tick/SKILL.md and claude-plugins/manifest-dev-experimental/skills/drive/references/platforms/github.md. Verify both files cover: (1) explicit enumeration of pull_request_read methods get_review_comments + get_reviews + get_comments with pagination; (2) a 'Merge State Health' section handling mergeable_state values behind / blocked / unstable / unknown / dirty + a fallback rule; (3) PR description sync trigger fires on Intent/Deliverable amendment as well as commit-producing ticks, with combined-single-sync when both apply same tick; (4) per-classified-comment kind tagging in the disposition log/output. Report any concept present in one but missing in the other."
+  ```
+
+- [INV-G4] Wrapper skills (`tend-pr/SKILL.md`, `drive/SKILL.md`, `drive-tick/SKILL.md`) are unchanged in this PR — **with one explicit exception** (per Amendments §A1): `drive-tick/SKILL.md` §P (Tend PR) may add ONE new step "PR Description Sync — runs every tick, after Thread Hygiene completes; adapter owns the trigger logic; adapter may no-op." No other edits to drive-tick are permitted. | Verify:
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Inspect git diff for the three wrapper paths (claude-plugins/manifest-dev/skills/tend-pr/SKILL.md, claude-plugins/manifest-dev-experimental/skills/drive/SKILL.md, claude-plugins/manifest-dev-experimental/skills/drive-tick/SKILL.md). The first two MUST be unchanged. The third (drive-tick/SKILL.md) MAY contain exactly one additive change to §P (Tend PR): a new step 'PR Description Sync' added after Thread Hygiene, with adapter-owned trigger logic. Confirm: tend-pr/SKILL.md and drive/SKILL.md are byte-identical to origin/main. drive-tick/SKILL.md's only change is the §P additive step described above — no other section modified. Run: git diff -- <three paths> and inspect."
+  ```
+
+## 4. Process Guidance
+
+- [PG-1] Frame all fixes around the higher-order goal: get the PR to merge-ready. When deciding placement or wording, ask "does this serve merge-readiness, and is it the right concern in the right section?" — don't add a check that doesn't trace back to a merge blocker.
+- [PG-2] Maintain parity between `/drive` github adapter and `/tend-pr-tick`. When editing one, mirror the change in the other in the same /do iteration — don't defer the second skill to a later cycle.
+- [PG-3] Don't restructure unrelated sections (Thread Hygiene, CI Triage, Terminal States). Scope is strictly: comment fetching, merge-state taxonomy, PR sync trigger, classification examples, dist sync, version bumps.
+- [PG-4] Edit source in `claude-plugins/`, NOT the `.claude/` hardlinks (CLAUDE.md rule). Hardlinks propagate automatically.
+- [PG-5] Trust LLM capability — the spec states WHAT must be fetched and WHICH conditions matter, not HOW to make MCP calls. No procedural step-by-step.
+- [PG-6] Run `sync-tools` skill at the end (D5), AFTER source edits and version bumps land — so dist captures both.
+
+## 5. Known Assumptions
+
+- [ASM-1] `mcp__github__pull_request_read` continues to expose `get_review_comments`, `get_reviews`, `get_comments` methods as currently documented. | Default: trust the schema verified during /define. | Impact if wrong: spec lands referencing a method that no longer exists; user reports breakage and we patch.
+- [ASM-2] GitHub's `mergeable_state` taxonomy stays stable around the named values (`clean | behind | blocked | dirty | unstable | unknown | has_hooks | draft`). | Default: assume stable; the fallback rule for unspecified values protects against new states. | Impact if wrong: low — fallback handles unknown values.
+- [ASM-3] `sync-tools` skill is functional and produces correct dist output for `gemini | opencode | codex`. | Default: trust the existing skill. | Impact if wrong: dist drift; user re-runs sync.
+- [ASM-4] Hardlinks between `claude-plugins/manifest-dev/skills/...` and `.claude/skills/...` are intact. | Default: per CLAUDE.md, hardlinks are committed; `git status` after editing source should not show `.claude/` separately. | Impact if wrong: edits land in source but session reads stale `.claude/` copy; surfaced by inspection.
+
+## Amendments
+
+### §A1 — 2026-04-30 (from /do, user-approved Option A)
+
+**Trigger:** /verify pass 2 INV-G1 (change-intent-reviewer) found that drive's amendment-only PR Description Sync trigger is unreachable: §PR Description Sync was invoked only from §Write Outputs step 4, and drive-tick gates §Write Outputs on code changes. On amendment-only ticks, drive-tick skips §Write Outputs → trigger (b) was dead text on drive. INV-G4 (wrappers untouched) blocked the structural fix. /escalated as Proposed Amendment with three options; user picked Option A.
+
+**Change:**
+- **INV-G4 relaxed** with one explicit exception: `drive-tick/SKILL.md` §P may add ONE new step "PR Description Sync — runs every tick, after Thread Hygiene; adapter owns trigger logic; adapter may no-op." All other drive-tick edits remain forbidden.
+- **AC-1.4 updated**: §PR Description Sync is hoisted out of §Write Outputs into its own contract slot in github.md; invoked unconditionally from drive-tick §P via the new step.
+- **AC-1.7 added**: explicit verifiable criterion for the drive-tick §P new step.
+
+**Nothing removed.** Prior content (D1–D5, INV-G1–G3, PG-1–G6, ASM-1–4, R-1–R-7, T-1–T-4, AC-1.1–1.6, AC-2.*, AC-3.*, AC-4.*, AC-5.*) is preserved unchanged.
+
+## 6. Deliverables
+
+### Deliverable 1: /drive github adapter — comment fetching + Merge State Health + amendment-driven sync
+
+File: `claude-plugins/manifest-dev-experimental/skills/drive/references/platforms/github.md`
+
+**Acceptance Criteria:**
+
+- [AC-1.1] `Read State` → `Inputs` enumerates three pull_request_read methods explicitly: `get_review_comments` (inline file-level threads), `get_reviews` (formal review bodies), `get_comments` (top-level PR/issue comments). Each method's listing is paginated to exhaustion (perPage + page or cursor-based pagination per the method's contract). | Verify:
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Open claude-plugins/manifest-dev-experimental/skills/drive/references/platforms/github.md and confirm the Read State Inputs section names all three pull_request_read methods (get_review_comments, get_reviews, get_comments) explicitly, and instructs to paginate each to exhaustion."
+  ```
+
+- [AC-1.2] `Merge Conflicts` section is renamed to `Merge State Health` and covers the full `mergeable_state` taxonomy: `dirty` (conflicts → existing auto-merge path), `behind` (auto-merge from base — branch protection requires up-to-date), `blocked` (block merge-ready precondition; do not auto-resolve), `unstable` (informational only — non-required check failing), `unknown` (wait for next tick), plus a fallback rule for unspecified values. The existing rebase-vs-merge rule is preserved. | Verify:
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Open claude-plugins/manifest-dev-experimental/skills/drive/references/platforms/github.md. Confirm: (1) section header is now 'Merge State Health' (not 'Merge Conflicts'); (2) all five named mergeable_state values are addressed with explicit dispositions; (3) a fallback rule exists for unspecified values; (4) the prefer-merge-over-rebase rule is preserved."
+  ```
+
+- [AC-1.3] `Merge Readiness` precondition list references `Merge State Health` as authoritative for merge-state checks (replacing the older "mergeable conflicts = none" wording). | Verify:
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Open claude-plugins/manifest-dev-experimental/skills/drive/references/platforms/github.md and confirm the Merge Readiness preconditions reference the Merge State Health section as the authoritative check (not just 'no conflicts')."
+  ```
+
+- [AC-1.4] `PR Description Sync` triggers fire on (a) commit-producing ticks (status quo) AND (b) ticks where a manifest amendment changed Intent (Goal/Mental Model) or Deliverables (added/removed/renamed). When both fire in the same tick, the section specifies a single combined sync with the merged picture. **Invocation path on drive:** §PR Description Sync is hoisted out of §Write Outputs into its own contract slot, invoked unconditionally from drive-tick §P (Tend PR) per the new step (see AC-1.7). Trigger logic in github.md decides whether to fire or no-op. | Verify:
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Open claude-plugins/manifest-dev-experimental/skills/drive/references/platforms/github.md PR Description Sync section. Confirm: (1) both triggers (commit-producing tick AND Intent/Deliverable-amendment tick) and the combined-single-sync rule; (2) §PR Description Sync is its own contract (no longer invoked from inside §Write Outputs step 4 — that step is removed or rewritten as a cross-reference); (3) the §Write Outputs step 4 entry is removed or refers to §PR Description Sync as separately invoked."
+  ```
+
+- [AC-1.5] `Read State` `## Inbox` per-comment line tags `kind: inline | top-level | review-body` (today says `inline | top-level | review`; if the rename to `review-body` is adopted for clarity, both files use the same vocabulary). | Verify:
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Open claude-plugins/manifest-dev-experimental/skills/drive/references/platforms/github.md and confirm the Read State Output Inbox section's per-comment template tags each event with its kind across the three sources."
+  ```
+
+- [AC-1.7] `drive-tick/SKILL.md` §P (Tend PR) gains exactly one new step "PR Description Sync — runs every tick, after Thread Hygiene completes; adapter owns the trigger logic; adapter may no-op." No other edits to drive-tick. This is the INV-G4 exception per Amendments §A1. | Verify:
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Open claude-plugins/manifest-dev-experimental/skills/drive-tick/SKILL.md §P (Tend PR). Confirm: (1) a new third numbered step 'PR Description Sync' exists, runs every tick, after Thread Hygiene; (2) adapter owns the trigger logic; (3) no other section of drive-tick was modified beyond this addition (run git diff to confirm)."
+  ```
+
+- [AC-1.6] No unrelated sections changed: Thread Hygiene, CI Failure Triage classification rules, Terminal States detection (other than wording around merge-state references), Bootstrap. | Verify:
+  ```yaml
+  verify:
+    method: bash
+    command: "git diff origin/main...HEAD -- claude-plugins/manifest-dev-experimental/skills/drive/references/platforms/github.md | grep -E '^[-+]' | grep -vE '(^[+-]{3}|^[-+]\\s*$)' | head -200"
+    prompt: "Manually inspect — every changed hunk should map to AC-1.1 through AC-1.5. Flag any change to Thread Hygiene rules, CI Triage classification, Terminal State detection (beyond merge-state reference rewording), or Bootstrap."
+  ```
+
+### Deliverable 2: /tend-pr-tick — parity with drive
+
+File: `claude-plugins/manifest-dev/skills/tend-pr-tick/SKILL.md`
+
+**Acceptance Criteria:**
+
+- [AC-2.1] `Read State` section enumerates the three `pull_request_read` methods (`get_review_comments`, `get_reviews`, `get_comments`) with pagination-to-exhaustion guidance, parallel to drive's spec. | Verify:
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Open claude-plugins/manifest-dev/skills/tend-pr-tick/SKILL.md Read State section. Confirm explicit enumeration of all three pull_request_read methods with pagination guidance."
+  ```
+
+- [AC-2.2] `Merge Conflicts` section is renamed to `Merge State Health`, covering the same `mergeable_state` taxonomy as drive (dirty / behind / blocked / unstable / unknown + fallback). Behavior parallels drive's adapter on each value. | Verify:
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Open claude-plugins/manifest-dev/skills/tend-pr-tick/SKILL.md. Confirm the Merge Conflicts section is renamed to Merge State Health and covers the same five mergeable_state values plus a fallback as drive's github.md adapter."
+  ```
+
+- [AC-2.3] `Merge Readiness` preconditions reference `Merge State Health` as authoritative (consistent with AC-1.3). | Verify:
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Open claude-plugins/manifest-dev/skills/tend-pr-tick/SKILL.md Merge Readiness section. Confirm preconditions reference Merge State Health (not just conflicts) as the authoritative merge-state gate."
+  ```
+
+- [AC-2.4] `PR Description Sync` trigger expanded: fires on Intent/Deliverable amendment in addition to commit-producing tick; combined-single-sync rule for same-tick collisions, parallel to AC-1.4. Babysit-mode behavior (no manifest, no amendment trigger) unchanged. | Verify:
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Open claude-plugins/manifest-dev/skills/tend-pr-tick/SKILL.md PR Description Sync section. Confirm both triggers (commit-producing + Intent/Deliverable amendment) and the combined-single-sync rule. Confirm babysit-mode (no manifest) is explicitly noted as N/A for amendment trigger."
+  ```
+
+- [AC-2.5] `Comment Classification` (or its log) tags each classified comment with its `kind: inline | top-level | review-body`, mirroring drive's `### Inbox — ` disposition log. The classification rules themselves (actionable / FP / uncertain) are not modified. | Verify:
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Open claude-plugins/manifest-dev/skills/tend-pr-tick/SKILL.md. Confirm classified comments are logged with a kind tag (inline | top-level | review-body) consistent with drive's adapter. Confirm classification rules (actionable / FP / uncertain) are unchanged."
+  ```
+
+- [AC-2.6] No unrelated sections changed (Setup, Concurrency Guard, CI Failure Triage rules, Routing, Status Report, Output Protocol, Security). | Verify:
+  ```yaml
+  verify:
+    method: bash
+    command: "git diff origin/main...HEAD -- claude-plugins/manifest-dev/skills/tend-pr-tick/SKILL.md"
+    prompt: "Manually inspect — every changed hunk should map to AC-2.1 through AC-2.5."
+  ```
+
+### Deliverable 3: classification-examples.md — top-level patterns
+
+File: `claude-plugins/manifest-dev/skills/tend-pr/references/classification-examples.md`
+
+**Acceptance Criteria:**
+
+- [AC-3.1] Each of the three classification tables (Actionable, False Positive, Uncertain) contains at least one top-level-comment example. Examples are diverse (e.g., scope-extension request, ship-it acknowledgement, design question) and not narrowly templated on a single phrasing. | Verify:
+  ```yaml
+  verify:
+    method: codebase
+    prompt: "Open claude-plugins/manifest-dev/skills/tend-pr/references/classification-examples.md. Confirm each classification table (Actionable, False Positive, Uncertain) has at least one example labelled or recognizably representing a top-level PR/issue-style comment, and the new examples are diverse rather than templated."
+  ```
+
+- [AC-3.2] Existing examples and the Classification Decision Tree are preserved unchanged. | Verify:
+  ```yaml
+  verify:
+    method: bash
+    command: "git diff origin/main...HEAD -- claude-plugins/manifest-dev/skills/tend-pr/references/classification-examples.md | grep -E '^-[^-]' | head -50"
+    prompt: "Inspect removed lines — should be empty or strictly formatting. No existing example or rule deleted."
+  ```
+
+### Deliverable 4: Plugin version bumps
+
+Files: `claude-plugins/manifest-dev/.claude-plugin/plugin.json`, `claude-plugins/manifest-dev-experimental/.claude-plugin/plugin.json`
+
+**Acceptance Criteria:**
+
+- [AC-4.1] `manifest-dev` plugin.json version is patch-bumped (Z+1 in X.Y.Z). | Verify:
+  ```yaml
+  verify:
+    method: bash
+    command: "diff <(git show origin/main:claude-plugins/manifest-dev/.claude-plugin/plugin.json | grep version) <(grep version claude-plugins/manifest-dev/.claude-plugin/plugin.json) || echo 'changed'"
+    prompt: "Confirm the version field changed by exactly the patch component (e.g., 0.4.5 -> 0.4.6); no minor or major bump."
+  ```
+
+- [AC-4.2] `manifest-dev-experimental` plugin.json version is patch-bumped. | Verify:
+  ```yaml
+  verify:
+    method: bash
+    command: "diff <(git show origin/main:claude-plugins/manifest-dev-experimental/.claude-plugin/plugin.json | grep version) <(grep version claude-plugins/manifest-dev-experimental/.claude-plugin/plugin.json) || echo 'changed'"
+    prompt: "Confirm the version field changed by exactly the patch component; no minor or major bump."
+  ```
+
+### Deliverable 5: Dist regeneration via sync-tools
+
+**Note (amendment, not scope change):** `sync-tools` is scoped to `claude-plugins/manifest-dev/` only — `manifest-dev-experimental` (where `/drive` and `/drive-tick` live) is NOT synced to dist by design (the sync-tools SKILL.md states this explicitly, and no `dist/*/skills/drive*` directories exist). So the only D5 changes are for tend-pr, tend-pr-tick, and classification-examples.
+
+**Acceptance Criteria:**
+
+- [AC-5.1] `sync-tools` skill is invoked AFTER D1–D4 land, regenerating `dist/{gemini,opencode,codex}/` packages from source for the manifest-dev plugin. | Verify:
+  ```yaml
+  verify:
+    method: bash
+    command: "git diff --stat origin/main...HEAD -- dist/ | tail -30"
+    prompt: "Confirm dist/ has changes for tend-pr, tend-pr-tick, and classification-examples across the three CLI distributions (gemini, opencode, codex). manifest-dev-experimental skills (drive, drive-tick) are NOT synced to dist by design — their absence is expected. If no dist/ changes for tend-pr family, sync-tools wasn't run or didn't pick up the source changes."
+  ```
+
+- [AC-5.2] Dist content reflects the source changes (three-method comment fetch + Merge State Health + amendment sync trigger + per-comment kind tagging) for at least one CLI distribution's tend-pr-tick. Spot-check rather than exhaustive. | Verify:
+  ```yaml
+  verify:
+    method: subagent
+    agent: general-purpose
+    prompt: "Open dist/gemini/skills/tend-pr-tick/SKILL.md and dist/gemini/skills/tend-pr/references/classification-examples.md. Confirm the new content appears: (1) three pull_request_read methods enumerated in Read State, (2) Merge State Health section replacing Merge Conflicts, (3) PR Description Sync covers both commit-producing and Intent/Deliverable amendment triggers with combined-single-sync rule, (4) Comment Classification disposition log includes a kind tag. (5) classification-examples.md has top-level-comment patterns. Report whether content is present and properly translated for the gemini distribution format."
+  ```
+
+- [AC-5.3] No source files outside this manifest's scope changed during the sync. | Verify:
+  ```yaml
+  verify:
+    method: bash
+    command: "git diff --name-only origin/main...HEAD | grep -vE '^(claude-plugins/manifest-dev/skills/tend-pr|claude-plugins/manifest-dev-experimental/skills/drive|claude-plugins/manifest-dev/\\.claude-plugin/plugin\\.json|claude-plugins/manifest-dev-experimental/\\.claude-plugin/plugin\\.json|dist/|\\.claude/skills/(tend-pr|drive))' || echo 'OK: no out-of-scope files'"
+    prompt: "Output should be empty or 'OK' or contain only files explicitly in scope. Any out-of-scope source change indicates scope creep."
+  ```

--- a/claude-plugins/manifest-dev-experimental/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev-experimental/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev-experimental",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Experimental tick-based manifest runner. /drive + /drive-tick: stateless wide-tick driver that takes a manifest (or PR) to terminal state via pluggable adapters. Uses /loop for cron; auto-falls back to inline scheduler when /loop isn't installed. Supports multi-repo PR sets via a shared canonical manifest.",
   "keywords": [
     "drive",

--- a/claude-plugins/manifest-dev-experimental/skills/drive-tick/SKILL.md
+++ b/claude-plugins/manifest-dev-experimental/skills/drive-tick/SKILL.md
@@ -186,12 +186,13 @@ Runs when the platform adapter exposes a `CI Failure Triage` contract (currently
 
 ### P. Tend PR (platform adapter contracts)
 
-Runs when the platform adapter exposes `Write Outputs` and `Thread Hygiene` contracts (currently: github). After CI triage (when the adapter returned `continue` rather than `terminal`), invoke the two contracts in order:
+Runs when the platform adapter exposes `Write Outputs`, `Thread Hygiene`, and `PR Description Sync` contracts (currently: github). After CI triage (when the adapter returned `continue` rather than `terminal`), invoke the three contracts in order:
 
-1. **Write Outputs** — **gated on code changes this tick.** Handles commit, push, execution-log append, PR description sync, inbox follow-up replies, and updating requested reviewers if configured. Skipped entirely on ticks with no code changes. On retrigger-only ticks (only commits are retrigger-empty-commits), PR description sync within this contract is skipped — there is no new diff to describe.
+1. **Write Outputs** — **gated on code changes this tick.** Handles commit, push, execution-log append, inbox follow-up replies, and updating requested reviewers if configured. Skipped entirely on ticks with no code changes.
 2. **Thread Hygiene** — **runs every tick**, strictly after Write Outputs completes (never before, never in parallel). Resolves bot threads whose disposition is "addressed" per the adapter's rules. Never resolves human threads. Independent of whether code changed this tick — this is what resolves bot threads on FP-reply-only ticks where §I Inbox Handling posted a reply but produced no commit. On retrigger-only ticks, Thread Hygiene no-ops (no new disposition data).
+3. **PR Description Sync** — **runs every tick**, strictly after Thread Hygiene completes. Adapter owns the trigger logic; adapter may no-op when neither trigger fires. Independent of code changes — fires on amendment-only ticks where §Write Outputs was skipped, and on commit-producing ticks (combined-single-sync when both triggers apply same tick). Adapter contract details in `drive/references/platforms/github.md` §PR Description Sync.
 
-Both contracts are invoked at the tick level; the adapter owns how each one is realized on its platform.
+All three contracts are invoked at the tick level; the adapter owns how each one is realized on its platform.
 
 ### C. Continue
 

--- a/claude-plugins/manifest-dev-experimental/skills/drive/references/platforms/github.md
+++ b/claude-plugins/manifest-dev-experimental/skills/drive/references/platforms/github.md
@@ -31,9 +31,12 @@ Produced every tick. Returns a markdown state report with all five sections popu
 ### Inputs
 
 - `git rev-parse HEAD`, `git symbolic-ref --short HEAD`, `git status --porcelain` (git state)
-- `mcp__github__pull_request_read` (PR summary: mergeable, approvals, requested reviewers, unresolved thread count, draft status, merged/closed status)
+- `mcp__github__pull_request_read` method `get` — PR summary including `mergeable`, `mergeable_state` (the merge-state taxonomy: `clean | dirty | behind | blocked | unstable | unknown | has_hooks | draft`), approvals, requested reviewers, unresolved thread count, draft/closed/merged status. The `mergeable_state` value drives §Merge State Health.
 - `mcp__github__get_commit` or `mcp__github__list_commits` (CI check statuses on HEAD)
-- `mcp__github__pull_request_read` with comments view (inline + top-level + formal review comments)
+- **Comments — three distinct sources, ALL required.** Each is a separate `pull_request_read` method, each is paginated, each MUST be exhausted (page through `perPage`/`page` or cursor parameters until the response signals no more results). Missing any source means missing real reviewer feedback.
+  - `mcp__github__pull_request_read` method `get_review_comments` — inline file-level review threads (comments anchored to specific code locations).
+  - `mcp__github__pull_request_read` method `get_reviews` — formal review submissions; the review's own `body` (the text the reviewer wrote when submitting Approve / Request Changes / Comment) is a comment surface and counts as a top-level review-body comment.
+  - `mcp__github__pull_request_read` method `get_comments` — top-level PR/issue-style comments (the conversation tab below the diff). These are the comments most often missed when only `get_review_comments` is consulted.
 - Base branch CI status for triage (pre-existing vs. new failures)
 - Execution log — already loaded by the tick's Memento Pattern step; adapter relies on the tick's read rather than reopening the file
 - Manifest (manifest mode) — tick reads this during its Read State step; adapter consumes via the tick
@@ -59,9 +62,9 @@ Note: <optional — e.g., "no CI configured on this PR">
 
 ## Inbox
 New since the most recent `## Tick N — Continuing` entry's timestamp:
-- <Comment #id (source: bot-name | human-login, kind: inline | top-level | review) "quoted excerpt">
+- <Comment #id (source: bot-name | human-login, kind: inline | top-level | review-body) "quoted excerpt">
 - ...
-(Omit section if no new events.)
+(Omit section if no new events. `kind` values map to the §Inputs comment sources: `inline` from `get_review_comments`, `top-level` from `get_comments`, `review-body` from `get_reviews`.)
 
 ## Terminal Check
 <Terminal: <state-name> | Not terminal: <reason>>
@@ -89,7 +92,7 @@ Six terminal states on this platform. Each has specific detection and tick actio
 ### `merge-ready`
 
 - **Detection:** Merge-ready requires all of the following preconditions:
-  1. **Platform merge-state is green** — use GitHub's native merge-state query (required checks pass, required approvals obtained, no unresolved threads, mergeable conflicts = none). Do not hardcode assumptions about what's required.
+  1. **Platform merge-state is green per §Merge State Health** — required checks pass, required approvals obtained, no unresolved threads, AND `mergeable_state` is a green value (`clean` / `unstable` / `has_hooks` — see §Merge State Health for the per-value disposition). `behind` and `blocked` and `unknown` and `dirty` are NOT green; `unstable` is green-with-warning (a non-required check is failing, merge button is enabled). Do not hardcode assumptions about what's required — query GitHub's native merge state.
   2. **Manifest-mode extra**: the most recent `execution-complete-head: <sha>` line in the log must exist.
   3. **Manifest-mode extra**: that `execution-complete-head` sha must either equal current PR HEAD, or be followed in the log only by retrigger-empty-commits (matches the retrigger-only-skip's ancestor rule — source state hasn't changed since /do converged).
 
@@ -157,9 +160,10 @@ See `./data/classification-examples.md` for concrete examples across bot types a
 Every classified comment emits one disposition log line to the tick's execution log, prefixed `### Inbox — ` for a stable anchor. §Thread Hygiene consumes these entries via the memento pattern across ticks.
 
 Fields:
-- `thread-id`: GitHub review-thread id of the originating thread.
+- `thread-id`: GitHub review-thread id (for inline / review-body sources) or comment id (for top-level).
 - `source`: `bot` or `human`.
 - `bot-name`: bot login when `source=bot`; omitted otherwise.
+- `kind`: `inline | top-level | review-body` — which §Read State `## Inbox` comment source the comment came from. Required so the skill can prove all three sources were consumed and so future ticks can dedup correctly.
 - `classification`: `FP` | `Actionable` | `Uncertain`.
 - `fingerprint`: content hash of the comment body, per the §Gotchas finding-content hashing rule (same hash used for dedup).
 - `tick`: tick number of this classification.
@@ -201,7 +205,7 @@ Two retrigger methods, keyed to the failing check's type:
    git commit --allow-empty -m "chore: retrigger CI [drive]"
    git push
    ```
-   The `[drive]` tag makes these commits distinguishable from user-authored ones for downstream tooling. Push semantics inherit §Write Outputs (retry with exponential backoff, never `--force`, append new HEAD sha to log). PR description sync (§Write Outputs step 4) is skipped when the only commits produced this tick are retrigger-only empty commits — there is no new diff to describe. One push = one retrigger action, covers every external-status check failing on this tick simultaneously.
+   The `[drive]` tag makes these commits distinguishable from user-authored ones for downstream tooling. Push semantics inherit §Write Outputs (retry with exponential backoff, never `--force`, append new HEAD sha to log). §PR Description Sync trigger (a) explicitly excludes retrigger-only-empty-commit ticks (see that section's "Exception" clause) — no new diff to describe. One push = one retrigger action, covers every external-status check failing on this tick simultaneously.
 
 ### Retrigger algorithm (per-tick)
 
@@ -262,23 +266,46 @@ One entry per uncertain escalation. `<check-name>` is the exact check name as re
 - **Native-first iteration can starve empty-commit retriggers under tight cap.** When the cap is tight (e.g., prior count 9, multiple native candidates), native runs consume slots before the single-slot empty-commit action is considered. Intentional: native rerun is leaner per action and less disruptive to history. Users preferring "maximize checks covered per slot" can reorder in this file.
 - **Push-restarts-all-checks assumption.** Stage T step 0 assumes a push restarts required status checks (true on typical GitHub setups). For checks keyed off non-push events, retrigger is deferred by one tick rather than skipped permanently — next tick's fresh state surfaces the still-failing check for step 5.
 
-## Merge Conflicts
+## Merge State Health
 
-Detected every tick during §Read State (the adapter surfaces conflict status from the PR summary); resolution is performed by the tick executing the adapter's merge rules below.
+Detected every tick during §Read State, which surfaces `mergeable_state` from the PR summary. The framing is broader than conflicts alone: the adapter must reason about every value GitHub may report, because each blocks merge-readiness in a different way and each has its own resolution path. This section is the single authoritative statement; §Merge Readiness and §Gotchas cross-reference it.
 
-- **No conflicts:** nothing to do.
-- **Conflicts:** the tick updates the PR branch from the base by running `git merge origin/<base>`. Prefer `git merge` over `git rebase` — rebase destroys review-comment anchors by rewriting commit history. Rebase ONLY when a reviewer explicitly requests it AND acknowledges the resulting loss of comment anchoring. This is the single authoritative statement of the rule; §Gotchas cross-references this section.
-- **Ambiguous conflicts:** when the `git merge` attempt produces conflict markers the tick cannot confidently resolve mechanically (e.g., overlapping edits requiring semantic understanding), the tick aborts the merge (`git merge --abort`) and escalates via sink with code `UNRESOLVED_CONFLICT`. This maps to the `escalation` terminal state — loop ends; user resolves the conflict manually and re-invokes `/drive` to resume.
+The taxonomy below maps every documented `mergeable_state` value to its disposition. Resolution is performed by the tick executing these rules.
+
+### Per-value dispositions
+
+- **`clean`** — green. No merge-state action; merge-readiness preconditions can pass on this value (subject to other gates).
+- **`dirty` (conflicts)** — the PR has actual merge conflicts against base. Update the PR branch by running `git merge origin/<base>`. Prefer `git merge` over `git rebase` — rebase destroys review-comment anchors by rewriting commit history. Rebase ONLY when a reviewer explicitly requests it AND acknowledges the resulting loss of comment anchoring.
+  - **Ambiguous conflicts:** when the `git merge` attempt produces conflict markers the tick cannot confidently resolve mechanically (e.g., overlapping edits requiring semantic understanding), abort the merge (`git merge --abort`) and escalate via sink with code `UNRESOLVED_CONFLICT`. Maps to the `escalation` terminal state — loop ends; user resolves manually and re-invokes `/drive`.
+- **`behind`** — branch protection requires the PR branch to be up-to-date with base, and base has new commits. This is GitHub's signal that the "Update branch" button is required before merge. Update via `git merge origin/<base>` (same path as `dirty`, minus the conflict markers — when there are no actual conflicts, the merge is a clean fast-forward or merge commit). Preserve review-comment anchors (no rebase). When `mergeable_state` is `clean` even though base has advanced, branch protection does NOT require up-to-date — leave the branch alone.
+- **`blocked`** — non-conflict gate failing (missing required reviews, failing required checks, branch-protection rule beyond up-to-date, etc.). Do NOT auto-resolve — these gates require external action (reviewer approval, CI fix). Inputs to merge-readiness: §Merge Readiness treats `blocked` as not-green and does not advance to merge-ready. The tick continues tending normally; CI failures are owned by §CI Failure Triage and review feedback by §Inbox Handling.
+- **`unstable`** — mergeable, but a non-required check is failing. GitHub's merge button is enabled. Informational only; does NOT block merge-readiness. The tick continues normally and §CI Failure Triage may still classify the failing non-required check (typically falls to Pre-existing or Code-caused without retrigger).
+- **`unknown`** — GitHub is still computing the merge state. Wait for the next tick — do not act. The next tick's §Read State will reflect a resolved value. Do NOT treat `unknown` as terminal or as implicit-green.
+- **`has_hooks`** — mergeable, hooks installed on the repo. Treat as `clean` for merge-state purposes; hooks are GitHub's concern, not the adapter's.
+- **`draft`** — PR is in draft state. The §Terminal States `draft` rule fires on this — handled there, not here. (Listed for completeness; this section's other paths don't apply.)
+
+### Fallback rule for unspecified values
+
+If `mergeable_state` returns a value not enumerated above (GitHub may add new states; the field has historically expanded), treat as **`unknown` semantics** — wait for the next tick, do not act, do not advance to merge-ready, do not infer green. Log the encountered value to the execution log so the user can extend this section if the unexpected value persists.
 
 ## PR Description Sync
 
-Runs only when this tick produced changes (any commit from Do Invocation (/do), or conflict resolution). Skipped when nothing changed. **Exception**: a tick whose only commits are retrigger-only empty commits skips description sync — there is no new diff to describe (see §CI Failure Triage → Retrigger).
+**Contract slot:** runs every tick, invoked by `drive-tick/SKILL.md` §P (Tend PR) **after §Thread Hygiene completes**. Adapter owns the trigger logic — adapter may no-op when neither trigger fires. Independent of §Write Outputs (§Write Outputs is gated on code changes; §PR Description Sync is not — that's how trigger (b) fires on amendment-only ticks).
 
-After changes:
+The PR description and title must reflect the PR's current intent, not just its current diff. Two distinct triggers fire this contract:
 
-1. Rewrite "what changed" sections of the PR body to reflect the current diff.
+1. **Commit-producing tick** — any commit from Do Invocation (/do) or merge-state resolution (§Merge State Health). Skipped when nothing changed. **Exception**: a tick whose only commits are retrigger-only empty commits skips description sync — there is no new diff to describe (see §CI Failure Triage → Retrigger).
+2. **Intent/Deliverable amendment tick** — manifest mode only. When this tick's §Amendment (see `drive-tick/SKILL.md`) modified the manifest's **Intent** (Goal, Mental Model) OR added/removed/renamed a **Deliverable**, sync fires even if no code commit landed this tick. Mid-AC tweaks (e.g., adjusting an AC's verify block, adding a Risk note) do NOT trigger sync — they don't change the PR's described scope. Babysit-mode has no manifest, so this trigger never fires there.
+
+**Combined single sync (same-tick collision)** — when both triggers would fire in the same tick (e.g., an Intent amendment AND a /do commit landed), perform exactly **one** sync at the end of the tick using the merged picture: amended scope + new diff. This avoids two consecutive PR edits per tick and keeps PR edit history low-noise.
+
+### Sync action
+
+After determining a trigger fires:
+
+1. Rewrite "what changed" sections of the PR body to reflect the current scope (manifest Intent + diff in commit-producing case; manifest Intent alone when amendment-only).
 2. **Preserve manual context** — issue references, motivation notes, deployment notes, hand-written rationale. Do NOT overwrite these.
-3. Update title if scope changed significantly (e.g., the work migrated from one component to another). Keep conservative — don't update on every tick.
+3. Update title if scope changed significantly (e.g., the work migrated from one component to another, or the manifest's Goal was rewritten). Keep conservative — don't update on every tick.
 
 Use `mcp__github__update_pull_request` for the sync.
 
@@ -316,8 +343,9 @@ After any code change:
 1. **Stage and commit** with descriptive message (`drive: implement AC-3.4 (crash recovery)`, `drive: fix failing CI on lint step`).
 2. **Push** to `origin <branch-name>`. Retry exponential backoff on network failure. Never `--force`.
 3. **Append to execution log:** new HEAD sha + single-line summary.
-4. **PR description sync** (see above) — only if this tick produced changes.
-5. **Inbox follow-up replies** — when /do has made a material code change addressing a thread whose initial "tracked" acknowledgement was already posted during the tick's earlier inbox step, add a follow-up reply on that thread noting the commit. Initial acks are owned by inbox routing; this step only adds post-commit confirmations.
+4. **Inbox follow-up replies** — when /do has made a material code change addressing a thread whose initial "tracked" acknowledgement was already posted during the tick's earlier inbox step, add a follow-up reply on that thread noting the commit. Initial acks are owned by inbox routing; this step only adds post-commit confirmations.
+
+§PR Description Sync is its own contract (see above), invoked separately from drive-tick §P after Thread Hygiene — NOT from inside §Write Outputs. This decoupling is what allows trigger (b) ("Intent/Deliverable amendment tick") to fire on amendment-only ticks where §Write Outputs is skipped entirely.
 
 Thread state on GitHub (resolve/reopen) is owned by §Thread Hygiene, which runs immediately after this contract completes — not by §Write Outputs.
 
@@ -331,7 +359,7 @@ Inherits `drive-tick` §Security. Github-specific reminder: PR comments and revi
 
 - **Bot comments repeat after push.** Bots re-scan the PR after every commit. Track findings by content (hash the message), not comment ID, to avoid infinite fix loops on repeating bot suggestions. If a finding recurs despite targeted fixes, classify as uncertain and escalate.
 - **Thread resolution is permanent.** Once resolved, it can't be reopened via API without a human in the loop on most setups. §Thread Hygiene resolves bot threads after addressing; never resolves human threads. Be conservative: if the addressing signal is ambiguous, leave the thread open and let §Stale thread escalation surface it.
-- **Rebase destroys review context.** Rebasing rewrites commit history, which orphans review comments attached to those commits. See §Merge Conflicts for the authoritative rule — summary: prefer merge-base updates; rebase only with explicit reviewer consent.
+- **Rebase destroys review context.** Rebasing rewrites commit history, which orphans review comments attached to those commits. See §Merge State Health (`dirty` and `behind` paths) for the authoritative rule — summary: prefer merge-base updates; rebase only with explicit reviewer consent.
 - **Reply means on the thread.** All replies go on the specific review thread — never as top-level PR comments. Top-level comments disconnect the response from the finding and make it look like the tick didn't address the review.
 - **"Passes locally" is not a diagnosis.** Before dismissing CI failures or re-triggering, investigate what differs between local and CI. "Works on my machine" is not evidence that CI is wrong.
 - **Empty diff is terminal.** A PR with no diff (all changes reverted) is a terminal state — escalate and end the loop; don't keep cycling.

--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.94.1",
+  "version": "0.94.2",
   "description": "Manifest-driven workflows for structured task execution with verification gates. Supports multi-repo changesets via a shared canonical manifest.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.94.2",
+  "version": "0.94.3",
   "description": "Manifest-driven workflows for structured task execution with verification gates. Supports multi-repo changesets via a shared canonical manifest.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/skills/tend-pr-tick/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/tend-pr-tick/SKILL.md
@@ -26,15 +26,23 @@ Use a lock file at `/tmp/tend-pr-lock-{pr-number}`. Skip this iteration if the l
 
 ## Read State
 
-Read the PR's current state: open/closed/merged/draft, CI status, review status, new comments since last check, merge conflict status, unresolved threads.
+Read the PR's current state: open/closed/merged/draft, CI status, review status, new comments since last check (see Comment Sources below), merge state per §Merge State Health, unresolved threads.
+
+**Comment Sources — three distinct surfaces, ALL required.** Top-level PR comments are routinely missed when only file-level review threads are fetched. Each source is a separate `mcp__github__pull_request_read` method, each is paginated, and each MUST be exhausted (page through `perPage`/`page` or cursor parameters until the response signals no more results). Missing any source means missing real reviewer feedback.
+
+- `mcp__github__pull_request_read` method `get_review_comments` — inline file-level review threads (comments anchored to specific code locations).
+- `mcp__github__pull_request_read` method `get_reviews` — formal review submissions; the review's own `body` (the text the reviewer wrote when submitting Approve / Request Changes / Comment) is a comment surface and counts as a top-level review-body comment.
+- `mcp__github__pull_request_read` method `get_comments` — top-level PR/issue-style comments (the conversation tab below the diff). These are the comments most often missed when only `get_review_comments` is consulted.
+
+**PR summary** — `mcp__github__pull_request_read` method `get` returns `mergeable_state` (the merge-state taxonomy: `clean | dirty | behind | blocked | unstable | unknown | has_hooks | draft`). The value drives §Merge State Health.
 
 **Terminal states** — Merged, Closed, or Draft. Handle per Output Protocol (end the loop).
 
 **First tick** (tend-pr-log has no prior iterations): Everything is unprocessed — run the full pipeline.
 
 **Check categories:**
-- **Every tick:** CI status, merge conflicts, merge readiness — these change independent of comments (base branch updates, CI re-runs, review approvals).
-- **Comment-gated:** Comment classification — only runs when new comments exist since last check.
+- **Every tick:** CI status, merge state health, merge readiness — these change independent of comments (base branch updates, CI re-runs, review approvals).
+- **Comment-gated:** Comment classification — only runs when new comments exist since last check across any of the three sources.
 - **Conditional:** Routing — runs when there are CI failures to handle or when new comments were classified.
 
 ## CI Failure Triage
@@ -47,21 +55,53 @@ Compare against base branch first:
 - **Infrastructure**: Flaky/timeout/runner → retrigger.
 - **Code-caused**: New failure from PR → actionable.
 
-## Merge Conflicts
+## Merge State Health
 
 *Runs every tick.*
 
-Update the PR branch from the base branch. Preserve review comment history — rebase destroys it (see Gotchas). Flag ambiguous conflicts to the user.
+The framing is broader than conflicts alone: GitHub's `mergeable_state` (read from §Read State) reports a taxonomy of values, each blocking merge-readiness in a different way. Reason about every value, not just conflicts.
+
+### Per-value dispositions
+
+- **`clean`** — green. No action.
+- **`dirty` (conflicts)** — actual merge conflicts against base. Update the PR branch by running `git merge origin/<base>`. Prefer `git merge` over `git rebase` — rebase destroys review-comment anchors by rewriting commit history (see Gotchas). Rebase ONLY when a reviewer explicitly requests it AND acknowledges the loss of comment anchoring. Flag ambiguous conflicts (overlapping edits requiring semantic understanding) to the user.
+- **`behind`** — branch protection requires the PR branch to be up-to-date with base, and base has new commits. This is GitHub's signal that the "Update branch" button is required before merge. Update via `git merge origin/<base>` (same path as `dirty`, minus the conflict markers). Preserve review-comment anchors (no rebase). When `mergeable_state` is `clean` even though base has advanced, branch protection does NOT require up-to-date — leave the branch alone.
+- **`blocked`** — non-conflict gate failing (missing required reviews, failing required checks, branch-protection rule beyond up-to-date). Do NOT auto-resolve — these gates require external action. Treat as not-green for §Merge Readiness; CI failures are owned by §CI Failure Triage and review feedback by §Comment Classification + §Routing.
+- **`unstable`** — mergeable, but a non-required check is failing. GitHub's merge button is enabled. Informational only; does NOT block merge-readiness.
+- **`unknown`** — GitHub is still computing the merge state. Wait for the next tick — do not act, do not advance to merge-ready, do not infer green.
+- **`has_hooks`** — mergeable, hooks installed on the repo. Treat as `clean` for merge-state purposes.
+- **`draft`** — handled by §Read State terminal-state rule, not here.
+
+### Fallback rule for unspecified values
+
+If `mergeable_state` returns a value not enumerated above (GitHub may add new states), treat as **`unknown` semantics** — wait for the next tick, do not act, do not advance to merge-ready. Log the encountered value so the user can extend this section if the value persists.
 
 ## Comment Classification
 
-*Runs when new comments exist since last check. Skip when no new comments.*
+*Runs when new comments exist since last check across any of the three sources from §Read State. Skip when no new comments.*
 
 Label source first (bot vs human — read `../tend-pr/references/known-bots.md`), then classify intent (read `../tend-pr/references/classification-examples.md`):
 
 - **Actionable**: Genuine issue to fix.
 - **False positive**: Intentional or not a problem.
 - **Uncertain**: Ambiguous — needs clarification.
+
+The same classification rules apply to all three comment surfaces — a top-level "Could you also handle X?" comment is just as actionable as an inline file-level "this branch is missing the null check" comment.
+
+### Disposition log
+
+Every classified comment emits one disposition log line to `/tmp/tend-pr-log-{pr-number}.md`, prefixed `### Inbox — ` for a stable anchor.
+
+Fields:
+- `thread-id`: GitHub review-thread id (for inline / review-body sources) or comment id (for top-level).
+- `source`: `bot` or `human`.
+- `bot-name`: bot login when `source=bot`; omitted otherwise.
+- `kind`: `inline | top-level | review-body` — which §Read State Comment Source the comment came from. Required so the skill can prove all three sources were consumed and so future ticks can dedup correctly.
+- `classification`: `Actionable` | `FP` | `Uncertain`.
+- `fingerprint`: content hash of the comment body (used for dedup; bots re-scan after every push and emit new comment IDs for the same finding).
+- `tick`: tick number of this classification.
+
+One line per classified comment, across all routing branches.
 
 ## Routing
 
@@ -84,9 +124,14 @@ Label source first (bot vs human — read `../tend-pr/references/known-bots.md`)
 
 ## PR Description Sync
 
-*Runs when this tick produced changes (routing fixes, conflict resolution). Skip when no changes were made.*
+The PR description and title must reflect the PR's current intent, not just its current diff. Two distinct triggers fire this contract:
 
-After changes, rewrite "what changed" sections to reflect the current diff. Preserve manual context (issue references, motivation, deployment notes). Update title if scope changed significantly.
+1. **Commit-producing tick** — routing fixes (/do commits in manifest-aware mode, direct fixes in babysit mode) or merge-state resolution (§Merge State Health). Skipped when nothing changed.
+2. **Intent/Deliverable amendment tick** — manifest-aware mode only. When this tick's amendment (via `/define --amend <manifest-path> --from-do` from §Routing) modified the manifest's **Intent** (Goal, Mental Model) OR added/removed/renamed a **Deliverable**, sync fires even if no /do commit landed this tick. Mid-AC tweaks (e.g., adjusting an AC's verify block, adding a Risk note) do NOT trigger sync — they don't change the PR's described scope. Babysit-mode has no manifest, so this trigger never fires there.
+
+**Combined single sync (same-tick collision)** — when both triggers would fire in the same tick (e.g., an Intent amendment AND a /do commit landed), perform exactly **one** sync at the end of the tick using the merged picture: amended scope + new diff. Avoids two consecutive PR edits per tick.
+
+After determining a trigger fires, rewrite "what changed" sections to reflect the current scope (manifest Intent + diff in commit-producing case; manifest Intent alone when amendment-only). Preserve manual context (issue references, motivation, deployment notes). Update title if scope changed significantly.
 
 The PR description stays summary-only — never embed the manifest. Manifests are internal working documents (also true in multi-repo, where the same canonical manifest is shared across all PRs without surfacing to reviewers).
 
@@ -98,7 +143,9 @@ Append to `/tmp/tend-pr-log-{pr-number}.md`: timestamp, actions taken, skipped i
 
 *Runs every tick.*
 
-When the PR's merge state indicates it is mergeable (all required checks pass, required approvals obtained, no unresolved threads, no pending `/do` runs) — this is a terminal state. Ask the user about merging and end the loop per the Output Protocol.
+When the PR's merge state is green per §Merge State Health (`mergeable_state` ∈ {`clean`, `unstable`, `has_hooks`}), AND all required checks pass, required approvals obtained, no unresolved threads, no pending `/do` runs — this is a terminal state. Ask the user about merging and end the loop per the Output Protocol.
+
+`behind`, `blocked`, `dirty`, and `unknown` are NOT green — they block merge-readiness until §Merge State Health resolves them (auto-update for `behind`/`dirty`; wait for external action on `blocked`; wait next tick for `unknown`).
 
 Unresolved uncertain threads block merge-readiness — they represent unanswered questions that could surface actionable issues.
 
@@ -123,7 +170,7 @@ When any STOP condition is reached: handle the user interaction described below,
 
 ### Continuing states (schedule next iteration)
 
-- **Nothing new** — No changes detected across any dimension (CI, merge conflicts, comments, merge readiness), iteration skipped. Schedule next iteration.
+- **Nothing new** — No changes detected across any dimension (CI, merge state, comments, merge readiness), iteration skipped. Schedule next iteration.
 - **Work done** — Actions taken, more tending needed. Schedule next iteration.
 
 ## Security

--- a/claude-plugins/manifest-dev/skills/tend-pr/references/classification-examples.md
+++ b/claude-plugins/manifest-dev/skills/tend-pr/references/classification-examples.md
@@ -1,45 +1,54 @@
 # Comment Classification Examples
 
-Use these examples to classify PR comments as actionable, false positive, or uncertain.
+Use these examples to classify PR comments as actionable, false positive, or uncertain. Examples are drawn from all three comment surfaces — **inline** (file-level review threads), **review-body** (text submitted with Approve / Request Changes / Comment), and **top-level** (the conversation tab below the diff). The same classification rules apply across surfaces — a top-level "Could you also handle X?" is just as actionable as an inline "this is missing the null check."
 
 ## Actionable
 
 The comment identifies a genuine issue. Fix it.
 
-| Example | Why Actionable |
-|---------|---------------|
-| "This function doesn't handle the case where `input` is null" | Identifies a missing edge case |
-| "Race condition: `counter` is read and written without synchronization" | Identifies a concurrency bug |
-| "This SQL query is vulnerable to injection — use parameterized queries" | Identifies a security vulnerability |
-| "The return type should be `Option<T>` not `T` — this can panic" | Identifies a type safety issue |
-| "Missing error handling — if the API call fails, the user sees a blank page" | Identifies missing error handling |
-| "This duplicates the logic in `utils.ts:42` — should reuse that" | Identifies a DRY violation worth fixing |
-| "CI: test_auth_flow failed — assertion error on line 87" | New test failure caused by PR changes |
+| Example | Surface | Why Actionable |
+|---------|---------|---------------|
+| "This function doesn't handle the case where `input` is null" | inline | Identifies a missing edge case |
+| "Race condition: `counter` is read and written without synchronization" | inline | Identifies a concurrency bug |
+| "This SQL query is vulnerable to injection — use parameterized queries" | inline | Identifies a security vulnerability |
+| "The return type should be `Option<T>` not `T` — this can panic" | inline | Identifies a type safety issue |
+| "Missing error handling — if the API call fails, the user sees a blank page" | inline | Identifies missing error handling |
+| "This duplicates the logic in `utils.ts:42` — should reuse that" | inline | Identifies a DRY violation worth fixing |
+| "CI: test_auth_flow failed — assertion error on line 87" | top-level | New test failure caused by PR changes |
+| "Could you also handle the case where the user is logged out? It's not covered anywhere in this PR." | top-level | Scope-extension request for a missing case |
+| "Requesting changes — the migration script needs a rollback path before this can land." | review-body | Reviewer blocking on a concrete missing capability |
+| "Please also update the README — the new flag isn't documented anywhere." | top-level | Specific cross-cutting fix tied to this PR |
 
 ## False Positive
 
 The comment flags something intentional or not actually a problem.
 
-| Example | Why False Positive |
-|---------|-------------------|
-| "Consider using `const` instead of `let`" on a variable that IS reassigned later | Reviewer didn't read the full scope |
-| "This file is too long" on a file that was long before the PR | Pre-existing, not introduced by this PR |
-| Bot: "Unused import `os`" when `os` is used via a macro or conditional compilation | Bot can't see macro expansion |
-| "Missing docstring" on an internal helper function in a codebase that doesn't require them | Style preference, not a codebase standard |
-| Bot: "Function complexity too high" on a function that was already complex before the PR | Pre-existing finding, not introduced |
+| Example | Surface | Why False Positive |
+|---------|---------|-------------------|
+| "Consider using `const` instead of `let`" on a variable that IS reassigned later | inline | Reviewer didn't read the full scope |
+| "This file is too long" on a file that was long before the PR | inline | Pre-existing, not introduced by this PR |
+| Bot: "Unused import `os`" when `os` is used via a macro or conditional compilation | inline | Bot can't see macro expansion |
+| "Missing docstring" on an internal helper function in a codebase that doesn't require them | inline | Style preference, not a codebase standard |
+| Bot: "Function complexity too high" on a function that was already complex before the PR | inline | Pre-existing finding, not introduced |
+| "Looks great, ship it 🚀" | top-level | Approval acknowledgement, no change requested |
+| "Approving — nice cleanup." | review-body | Approval, not actionable |
+| "Why are we not just deleting this whole module?" — when the module is actively used by another consumer not visible in the PR diff | top-level | Misunderstanding of broader usage; not a real ask |
 
 ## Uncertain
 
 The comment is ambiguous — you can't tell if it's actionable or a false positive without more context.
 
-| Example | Why Uncertain |
-|---------|--------------|
-| "Is this the right approach?" | Could be rhetorical (approval) or genuine concern |
-| "What about performance?" | Unclear if they've identified a specific issue or asking generally |
-| "Hmm" | No actionable content |
-| "This could be simplified" | Might be a suggestion (low priority) or a blocking concern |
-| "Have you considered using X instead?" | Could be a suggestion or a request for change |
-| "Not sure about this" | Unclear what specifically concerns them |
+| Example | Surface | Why Uncertain |
+|---------|---------|--------------|
+| "Is this the right approach?" | inline | Could be rhetorical (approval) or genuine concern |
+| "What about performance?" | inline | Unclear if they've identified a specific issue or asking generally |
+| "Hmm" | inline | No actionable content |
+| "This could be simplified" | inline | Might be a suggestion (low priority) or a blocking concern |
+| "Have you considered using X instead?" | inline | Could be a suggestion or a request for change |
+| "Not sure about this" | inline | Unclear what specifically concerns them |
+| "Should we revisit the design here?" | top-level | Could mean "block this PR" or "let's chat after merge" |
+| "Have you thought about how this interacts with the new auth system?" | top-level | Could be an informational question or a blocking concern; surface area unspecified |
+| "I'm leaning toward not shipping this until we discuss." | review-body | Direction unclear: pause-pending-discussion vs request-changes — needs reviewer clarification |
 
 ## Classification Decision Tree
 

--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "66b4ed320a3cd284436d8a80111247be80ca6670",
+  "source_commit": "08262ea04148c7a5810257137457eee1f9d023ed",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-04-30T09:39:07Z"
+  "synced_at": "2026-04-30T11:17:33Z"
 }

--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "6224c387eaabbd319c29aab0aff32dd65f58d1be",
+  "source_commit": "66b4ed320a3cd284436d8a80111247be80ca6670",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-04-29T21:59:00Z"
+  "synced_at": "2026-04-30T09:39:07Z"
 }

--- a/dist/codex/skills/define/tasks/PROMPTING.md
+++ b/dist/codex/skills/define/tasks/PROMPTING.md
@@ -21,7 +21,7 @@ When prompt-reviewer is not available, encode these as individual criteria verif
 | No conflicts | No contradictory rules, no priority collisions, edge cases covered |
 | Structure | Critical rules surfaced prominently, clear hierarchy, no unintentional redundancy |
 | Information density | Every word earns its place |
-| No anti-patterns | No prescriptive HOW, arbitrary limits, capability instructions, weak language |
+| No anti-patterns | No prescriptive HOW, arbitrary limits, capability instructions, weak hedging, unjustified absolutes |
 | Invocation fit | Prompt's trigger, caller identity, and output consumer match deployment context |
 | Domain context | Domain terms, conventions, and constraints captured—not guessed |
 | Complexity fit | Prompt complexity matches the task—not over-engineered, not under-specified |
@@ -63,7 +63,8 @@ Before defining a prompt, probe for these—missing context creates ambiguous pr
 | Arbitrary limits | "Max 3 iterations", "2-4 examples" | Principle: "until converged", "as needed" |
 | Capability instructions | "Use grep to search", "Read the file" | Remove—model knows how |
 | Rigid checklists in authored prompts | "Step 1: search. Step 2: read. Step 3: analyze." baked into the prompt | Convert to goal + constraints (discipline patterns like memento are exempt) |
-| Weak language | "Try to", "maybe", "if possible" | Direct: "Do X", "Never Y" |
+| Weak hedging | "Try to", "maybe", "if possible" | Direct imperative: "Do X" |
+| Absolutes for judgment calls | "ALWAYS", "NEVER", "MUST" applied to non-invariants (when to search, ask, iterate, retry) | Decision rules: "When X, do Y; otherwise Z". Reserve absolutes for true invariants — safety rules, required fields, hard constraints |
 | Buried critical info | Important rules in middle | Surface prominently |
 | Over-engineering | 10 phases for a simple task | Match complexity to need |
 

--- a/dist/codex/skills/tend-pr-tick/SKILL.md
+++ b/dist/codex/skills/tend-pr-tick/SKILL.md
@@ -26,15 +26,23 @@ Use a lock file at `/tmp/tend-pr-lock-{pr-number}`. Skip this iteration if the l
 
 ## Read State
 
-Read the PR's current state: open/closed/merged/draft, CI status, review status, new comments since last check, merge conflict status, unresolved threads.
+Read the PR's current state: open/closed/merged/draft, CI status, review status, new comments since last check (see Comment Sources below), merge state per §Merge State Health, unresolved threads.
+
+**Comment Sources — three distinct surfaces, ALL required.** Top-level PR comments are routinely missed when only file-level review threads are fetched. Each source is a separate `mcp__github__pull_request_read` method, each is paginated, and each MUST be exhausted (page through `perPage`/`page` or cursor parameters until the response signals no more results). Missing any source means missing real reviewer feedback.
+
+- `mcp__github__pull_request_read` method `get_review_comments` — inline file-level review threads (comments anchored to specific code locations).
+- `mcp__github__pull_request_read` method `get_reviews` — formal review submissions; the review's own `body` (the text the reviewer wrote when submitting Approve / Request Changes / Comment) is a comment surface and counts as a top-level review-body comment.
+- `mcp__github__pull_request_read` method `get_comments` — top-level PR/issue-style comments (the conversation tab below the diff). These are the comments most often missed when only `get_review_comments` is consulted.
+
+**PR summary** — `mcp__github__pull_request_read` method `get` returns `mergeable_state` (the merge-state taxonomy: `clean | dirty | behind | blocked | unstable | unknown | has_hooks | draft`). The value drives §Merge State Health.
 
 **Terminal states** — Merged, Closed, or Draft. Handle per Output Protocol (end the loop).
 
 **First tick** (tend-pr-log has no prior iterations): Everything is unprocessed — run the full pipeline.
 
 **Check categories:**
-- **Every tick:** CI status, merge conflicts, merge readiness — these change independent of comments (base branch updates, CI re-runs, review approvals).
-- **Comment-gated:** Comment classification — only runs when new comments exist since last check.
+- **Every tick:** CI status, merge state health, merge readiness — these change independent of comments (base branch updates, CI re-runs, review approvals).
+- **Comment-gated:** Comment classification — only runs when new comments exist since last check across any of the three sources.
 - **Conditional:** Routing — runs when there are CI failures to handle or when new comments were classified.
 
 ## CI Failure Triage
@@ -47,21 +55,53 @@ Compare against base branch first:
 - **Infrastructure**: Flaky/timeout/runner → retrigger.
 - **Code-caused**: New failure from PR → actionable.
 
-## Merge Conflicts
+## Merge State Health
 
 *Runs every tick.*
 
-Update the PR branch from the base branch. Preserve review comment history — rebase destroys it (see Gotchas). Flag ambiguous conflicts to the user.
+The framing is broader than conflicts alone: GitHub's `mergeable_state` (read from §Read State) reports a taxonomy of values, each blocking merge-readiness in a different way. Reason about every value, not just conflicts.
+
+### Per-value dispositions
+
+- **`clean`** — green. No action.
+- **`dirty` (conflicts)** — actual merge conflicts against base. Update the PR branch by running `git merge origin/<base>`. Prefer `git merge` over `git rebase` — rebase destroys review-comment anchors by rewriting commit history (see Gotchas). Rebase ONLY when a reviewer explicitly requests it AND acknowledges the loss of comment anchoring. Flag ambiguous conflicts (overlapping edits requiring semantic understanding) to the user.
+- **`behind`** — branch protection requires the PR branch to be up-to-date with base, and base has new commits. This is GitHub's signal that the "Update branch" button is required before merge. Update via `git merge origin/<base>` (same path as `dirty`, minus the conflict markers). Preserve review-comment anchors (no rebase). When `mergeable_state` is `clean` even though base has advanced, branch protection does NOT require up-to-date — leave the branch alone.
+- **`blocked`** — non-conflict gate failing (missing required reviews, failing required checks, branch-protection rule beyond up-to-date). Do NOT auto-resolve — these gates require external action. Treat as not-green for §Merge Readiness; CI failures are owned by §CI Failure Triage and review feedback by §Comment Classification + §Routing.
+- **`unstable`** — mergeable, but a non-required check is failing. GitHub's merge button is enabled. Informational only; does NOT block merge-readiness.
+- **`unknown`** — GitHub is still computing the merge state. Wait for the next tick — do not act, do not advance to merge-ready, do not infer green.
+- **`has_hooks`** — mergeable, hooks installed on the repo. Treat as `clean` for merge-state purposes.
+- **`draft`** — handled by §Read State terminal-state rule, not here.
+
+### Fallback rule for unspecified values
+
+If `mergeable_state` returns a value not enumerated above (GitHub may add new states), treat as **`unknown` semantics** — wait for the next tick, do not act, do not advance to merge-ready. Log the encountered value so the user can extend this section if the value persists.
 
 ## Comment Classification
 
-*Runs when new comments exist since last check. Skip when no new comments.*
+*Runs when new comments exist since last check across any of the three sources from §Read State. Skip when no new comments.*
 
 Label source first (bot vs human — read `../tend-pr/references/known-bots.md`), then classify intent (read `../tend-pr/references/classification-examples.md`):
 
 - **Actionable**: Genuine issue to fix.
 - **False positive**: Intentional or not a problem.
 - **Uncertain**: Ambiguous — needs clarification.
+
+The same classification rules apply to all three comment surfaces — a top-level "Could you also handle X?" comment is just as actionable as an inline file-level "this branch is missing the null check" comment.
+
+### Disposition log
+
+Every classified comment emits one disposition log line to `/tmp/tend-pr-log-{pr-number}.md`, prefixed `### Inbox — ` for a stable anchor.
+
+Fields:
+- `thread-id`: GitHub review-thread id (for inline / review-body sources) or comment id (for top-level).
+- `source`: `bot` or `human`.
+- `bot-name`: bot login when `source=bot`; omitted otherwise.
+- `kind`: `inline | top-level | review-body` — which §Read State Comment Source the comment came from. Required so the skill can prove all three sources were consumed and so future ticks can dedup correctly.
+- `classification`: `Actionable` | `FP` | `Uncertain`.
+- `fingerprint`: content hash of the comment body (used for dedup; bots re-scan after every push and emit new comment IDs for the same finding).
+- `tick`: tick number of this classification.
+
+One line per classified comment, across all routing branches.
 
 ## Routing
 
@@ -84,9 +124,14 @@ Label source first (bot vs human — read `../tend-pr/references/known-bots.md`)
 
 ## PR Description Sync
 
-*Runs when this tick produced changes (routing fixes, conflict resolution). Skip when no changes were made.*
+The PR description and title must reflect the PR's current intent, not just its current diff. Two distinct triggers fire this contract:
 
-After changes, rewrite "what changed" sections to reflect the current diff. Preserve manual context (issue references, motivation, deployment notes). Update title if scope changed significantly.
+1. **Commit-producing tick** — routing fixes (/do commits in manifest-aware mode, direct fixes in babysit mode) or merge-state resolution (§Merge State Health). Skipped when nothing changed.
+2. **Intent/Deliverable amendment tick** — manifest-aware mode only. When this tick's amendment (via `/define --amend <manifest-path> --from-do` from §Routing) modified the manifest's **Intent** (Goal, Mental Model) OR added/removed/renamed a **Deliverable**, sync fires even if no /do commit landed this tick. Mid-AC tweaks (e.g., adjusting an AC's verify block, adding a Risk note) do NOT trigger sync — they don't change the PR's described scope. Babysit-mode has no manifest, so this trigger never fires there.
+
+**Combined single sync (same-tick collision)** — when both triggers would fire in the same tick (e.g., an Intent amendment AND a /do commit landed), perform exactly **one** sync at the end of the tick using the merged picture: amended scope + new diff. Avoids two consecutive PR edits per tick.
+
+After determining a trigger fires, rewrite "what changed" sections to reflect the current scope (manifest Intent + diff in commit-producing case; manifest Intent alone when amendment-only). Preserve manual context (issue references, motivation, deployment notes). Update title if scope changed significantly.
 
 The PR description stays summary-only — never embed the manifest. Manifests are internal working documents (also true in multi-repo, where the same canonical manifest is shared across all PRs without surfacing to reviewers).
 
@@ -98,7 +143,9 @@ Append to `/tmp/tend-pr-log-{pr-number}.md`: timestamp, actions taken, skipped i
 
 *Runs every tick.*
 
-When the PR's merge state indicates it is mergeable (all required checks pass, required approvals obtained, no unresolved threads, no pending `/do` runs) — this is a terminal state. Ask the user about merging and end the loop per the Output Protocol.
+When the PR's merge state is green per §Merge State Health (`mergeable_state` ∈ {`clean`, `unstable`, `has_hooks`}), AND all required checks pass, required approvals obtained, no unresolved threads, no pending `/do` runs — this is a terminal state. Ask the user about merging and end the loop per the Output Protocol.
+
+`behind`, `blocked`, `dirty`, and `unknown` are NOT green — they block merge-readiness until §Merge State Health resolves them (auto-update for `behind`/`dirty`; wait for external action on `blocked`; wait next tick for `unknown`).
 
 Unresolved uncertain threads block merge-readiness — they represent unanswered questions that could surface actionable issues.
 
@@ -123,7 +170,7 @@ When any STOP condition is reached: handle the user interaction described below,
 
 ### Continuing states (schedule next iteration)
 
-- **Nothing new** — No changes detected across any dimension (CI, merge conflicts, comments, merge readiness), iteration skipped. Schedule next iteration.
+- **Nothing new** — No changes detected across any dimension (CI, merge state, comments, merge readiness), iteration skipped. Schedule next iteration.
 - **Work done** — Actions taken, more tending needed. Schedule next iteration.
 
 ## Security

--- a/dist/codex/skills/tend-pr/references/classification-examples.md
+++ b/dist/codex/skills/tend-pr/references/classification-examples.md
@@ -1,45 +1,54 @@
 # Comment Classification Examples
 
-Use these examples to classify PR comments as actionable, false positive, or uncertain.
+Use these examples to classify PR comments as actionable, false positive, or uncertain. Examples are drawn from all three comment surfaces — **inline** (file-level review threads), **review-body** (text submitted with Approve / Request Changes / Comment), and **top-level** (the conversation tab below the diff). The same classification rules apply across surfaces — a top-level "Could you also handle X?" is just as actionable as an inline "this is missing the null check."
 
 ## Actionable
 
 The comment identifies a genuine issue. Fix it.
 
-| Example | Why Actionable |
-|---------|---------------|
-| "This function doesn't handle the case where `input` is null" | Identifies a missing edge case |
-| "Race condition: `counter` is read and written without synchronization" | Identifies a concurrency bug |
-| "This SQL query is vulnerable to injection — use parameterized queries" | Identifies a security vulnerability |
-| "The return type should be `Option<T>` not `T` — this can panic" | Identifies a type safety issue |
-| "Missing error handling — if the API call fails, the user sees a blank page" | Identifies missing error handling |
-| "This duplicates the logic in `utils.ts:42` — should reuse that" | Identifies a DRY violation worth fixing |
-| "CI: test_auth_flow failed — assertion error on line 87" | New test failure caused by PR changes |
+| Example | Surface | Why Actionable |
+|---------|---------|---------------|
+| "This function doesn't handle the case where `input` is null" | inline | Identifies a missing edge case |
+| "Race condition: `counter` is read and written without synchronization" | inline | Identifies a concurrency bug |
+| "This SQL query is vulnerable to injection — use parameterized queries" | inline | Identifies a security vulnerability |
+| "The return type should be `Option<T>` not `T` — this can panic" | inline | Identifies a type safety issue |
+| "Missing error handling — if the API call fails, the user sees a blank page" | inline | Identifies missing error handling |
+| "This duplicates the logic in `utils.ts:42` — should reuse that" | inline | Identifies a DRY violation worth fixing |
+| "CI: test_auth_flow failed — assertion error on line 87" | top-level | New test failure caused by PR changes |
+| "Could you also handle the case where the user is logged out? It's not covered anywhere in this PR." | top-level | Scope-extension request for a missing case |
+| "Requesting changes — the migration script needs a rollback path before this can land." | review-body | Reviewer blocking on a concrete missing capability |
+| "Please also update the README — the new flag isn't documented anywhere." | top-level | Specific cross-cutting fix tied to this PR |
 
 ## False Positive
 
 The comment flags something intentional or not actually a problem.
 
-| Example | Why False Positive |
-|---------|-------------------|
-| "Consider using `const` instead of `let`" on a variable that IS reassigned later | Reviewer didn't read the full scope |
-| "This file is too long" on a file that was long before the PR | Pre-existing, not introduced by this PR |
-| Bot: "Unused import `os`" when `os` is used via a macro or conditional compilation | Bot can't see macro expansion |
-| "Missing docstring" on an internal helper function in a codebase that doesn't require them | Style preference, not a codebase standard |
-| Bot: "Function complexity too high" on a function that was already complex before the PR | Pre-existing finding, not introduced |
+| Example | Surface | Why False Positive |
+|---------|---------|-------------------|
+| "Consider using `const` instead of `let`" on a variable that IS reassigned later | inline | Reviewer didn't read the full scope |
+| "This file is too long" on a file that was long before the PR | inline | Pre-existing, not introduced by this PR |
+| Bot: "Unused import `os`" when `os` is used via a macro or conditional compilation | inline | Bot can't see macro expansion |
+| "Missing docstring" on an internal helper function in a codebase that doesn't require them | inline | Style preference, not a codebase standard |
+| Bot: "Function complexity too high" on a function that was already complex before the PR | inline | Pre-existing finding, not introduced |
+| "Looks great, ship it 🚀" | top-level | Approval acknowledgement, no change requested |
+| "Approving — nice cleanup." | review-body | Approval, not actionable |
+| "Why are we not just deleting this whole module?" — when the module is actively used by another consumer not visible in the PR diff | top-level | Misunderstanding of broader usage; not a real ask |
 
 ## Uncertain
 
 The comment is ambiguous — you can't tell if it's actionable or a false positive without more context.
 
-| Example | Why Uncertain |
-|---------|--------------|
-| "Is this the right approach?" | Could be rhetorical (approval) or genuine concern |
-| "What about performance?" | Unclear if they've identified a specific issue or asking generally |
-| "Hmm" | No actionable content |
-| "This could be simplified" | Might be a suggestion (low priority) or a blocking concern |
-| "Have you considered using X instead?" | Could be a suggestion or a request for change |
-| "Not sure about this" | Unclear what specifically concerns them |
+| Example | Surface | Why Uncertain |
+|---------|---------|--------------|
+| "Is this the right approach?" | inline | Could be rhetorical (approval) or genuine concern |
+| "What about performance?" | inline | Unclear if they've identified a specific issue or asking generally |
+| "Hmm" | inline | No actionable content |
+| "This could be simplified" | inline | Might be a suggestion (low priority) or a blocking concern |
+| "Have you considered using X instead?" | inline | Could be a suggestion or a request for change |
+| "Not sure about this" | inline | Unclear what specifically concerns them |
+| "Should we revisit the design here?" | top-level | Could mean "block this PR" or "let's chat after merge" |
+| "Have you thought about how this interacts with the new auth system?" | top-level | Could be an informational question or a blocking concern; surface area unspecified |
+| "I'm leaning toward not shipping this until we discuss." | review-body | Direction unclear: pause-pending-discussion vs request-changes — needs reviewer clarification |
 
 ## Classification Decision Tree
 

--- a/dist/gemini/.sync-meta.json
+++ b/dist/gemini/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "66b4ed320a3cd284436d8a80111247be80ca6670",
+  "source_commit": "08262ea04148c7a5810257137457eee1f9d023ed",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-04-30T09:39:07Z"
+  "synced_at": "2026-04-30T11:17:33Z"
 }

--- a/dist/gemini/.sync-meta.json
+++ b/dist/gemini/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "6224c387eaabbd319c29aab0aff32dd65f58d1be",
+  "source_commit": "66b4ed320a3cd284436d8a80111247be80ca6670",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-04-29T21:59:00Z"
+  "synced_at": "2026-04-30T09:39:07Z"
 }

--- a/dist/gemini/skills/define/tasks/PROMPTING.md
+++ b/dist/gemini/skills/define/tasks/PROMPTING.md
@@ -21,7 +21,7 @@ When prompt-reviewer is not available, encode these as individual criteria verif
 | No conflicts | No contradictory rules, no priority collisions, edge cases covered |
 | Structure | Critical rules surfaced prominently, clear hierarchy, no unintentional redundancy |
 | Information density | Every word earns its place |
-| No anti-patterns | No prescriptive HOW, arbitrary limits, capability instructions, weak language |
+| No anti-patterns | No prescriptive HOW, arbitrary limits, capability instructions, weak hedging, unjustified absolutes |
 | Invocation fit | Prompt's trigger, caller identity, and output consumer match deployment context |
 | Domain context | Domain terms, conventions, and constraints captured—not guessed |
 | Complexity fit | Prompt complexity matches the task—not over-engineered, not under-specified |
@@ -63,7 +63,8 @@ Before defining a prompt, probe for these—missing context creates ambiguous pr
 | Arbitrary limits | "Max 3 iterations", "2-4 examples" | Principle: "until converged", "as needed" |
 | Capability instructions | "Use grep to search", "Read the file" | Remove—model knows how |
 | Rigid checklists in authored prompts | "Step 1: search. Step 2: read. Step 3: analyze." baked into the prompt | Convert to goal + constraints (discipline patterns like memento are exempt) |
-| Weak language | "Try to", "maybe", "if possible" | Direct: "Do X", "Never Y" |
+| Weak hedging | "Try to", "maybe", "if possible" | Direct imperative: "Do X" |
+| Absolutes for judgment calls | "ALWAYS", "NEVER", "MUST" applied to non-invariants (when to search, ask, iterate, retry) | Decision rules: "When X, do Y; otherwise Z". Reserve absolutes for true invariants — safety rules, required fields, hard constraints |
 | Buried critical info | Important rules in middle | Surface prominently |
 | Over-engineering | 10 phases for a simple task | Match complexity to need |
 

--- a/dist/gemini/skills/tend-pr-tick/SKILL.md
+++ b/dist/gemini/skills/tend-pr-tick/SKILL.md
@@ -26,15 +26,23 @@ Use a lock file at `/tmp/tend-pr-lock-{pr-number}`. Skip this iteration if the l
 
 ## Read State
 
-Read the PR's current state: open/closed/merged/draft, CI status, review status, new comments since last check, merge conflict status, unresolved threads.
+Read the PR's current state: open/closed/merged/draft, CI status, review status, new comments since last check (see Comment Sources below), merge state per §Merge State Health, unresolved threads.
+
+**Comment Sources — three distinct surfaces, ALL required.** Top-level PR comments are routinely missed when only file-level review threads are fetched. Each source is a separate `mcp__github__pull_request_read` method, each is paginated, and each MUST be exhausted (page through `perPage`/`page` or cursor parameters until the response signals no more results). Missing any source means missing real reviewer feedback.
+
+- `mcp__github__pull_request_read` method `get_review_comments` — inline file-level review threads (comments anchored to specific code locations).
+- `mcp__github__pull_request_read` method `get_reviews` — formal review submissions; the review's own `body` (the text the reviewer wrote when submitting Approve / Request Changes / Comment) is a comment surface and counts as a top-level review-body comment.
+- `mcp__github__pull_request_read` method `get_comments` — top-level PR/issue-style comments (the conversation tab below the diff). These are the comments most often missed when only `get_review_comments` is consulted.
+
+**PR summary** — `mcp__github__pull_request_read` method `get` returns `mergeable_state` (the merge-state taxonomy: `clean | dirty | behind | blocked | unstable | unknown | has_hooks | draft`). The value drives §Merge State Health.
 
 **Terminal states** — Merged, Closed, or Draft. Handle per Output Protocol (end the loop).
 
 **First tick** (tend-pr-log has no prior iterations): Everything is unprocessed — run the full pipeline.
 
 **Check categories:**
-- **Every tick:** CI status, merge conflicts, merge readiness — these change independent of comments (base branch updates, CI re-runs, review approvals).
-- **Comment-gated:** Comment classification — only runs when new comments exist since last check.
+- **Every tick:** CI status, merge state health, merge readiness — these change independent of comments (base branch updates, CI re-runs, review approvals).
+- **Comment-gated:** Comment classification — only runs when new comments exist since last check across any of the three sources.
 - **Conditional:** Routing — runs when there are CI failures to handle or when new comments were classified.
 
 ## CI Failure Triage
@@ -47,21 +55,53 @@ Compare against base branch first:
 - **Infrastructure**: Flaky/timeout/runner → retrigger.
 - **Code-caused**: New failure from PR → actionable.
 
-## Merge Conflicts
+## Merge State Health
 
 *Runs every tick.*
 
-Update the PR branch from the base branch. Preserve review comment history — rebase destroys it (see Gotchas). Flag ambiguous conflicts to the user.
+The framing is broader than conflicts alone: GitHub's `mergeable_state` (read from §Read State) reports a taxonomy of values, each blocking merge-readiness in a different way. Reason about every value, not just conflicts.
+
+### Per-value dispositions
+
+- **`clean`** — green. No action.
+- **`dirty` (conflicts)** — actual merge conflicts against base. Update the PR branch by running `git merge origin/<base>`. Prefer `git merge` over `git rebase` — rebase destroys review-comment anchors by rewriting commit history (see Gotchas). Rebase ONLY when a reviewer explicitly requests it AND acknowledges the loss of comment anchoring. Flag ambiguous conflicts (overlapping edits requiring semantic understanding) to the user.
+- **`behind`** — branch protection requires the PR branch to be up-to-date with base, and base has new commits. This is GitHub's signal that the "Update branch" button is required before merge. Update via `git merge origin/<base>` (same path as `dirty`, minus the conflict markers). Preserve review-comment anchors (no rebase). When `mergeable_state` is `clean` even though base has advanced, branch protection does NOT require up-to-date — leave the branch alone.
+- **`blocked`** — non-conflict gate failing (missing required reviews, failing required checks, branch-protection rule beyond up-to-date). Do NOT auto-resolve — these gates require external action. Treat as not-green for §Merge Readiness; CI failures are owned by §CI Failure Triage and review feedback by §Comment Classification + §Routing.
+- **`unstable`** — mergeable, but a non-required check is failing. GitHub's merge button is enabled. Informational only; does NOT block merge-readiness.
+- **`unknown`** — GitHub is still computing the merge state. Wait for the next tick — do not act, do not advance to merge-ready, do not infer green.
+- **`has_hooks`** — mergeable, hooks installed on the repo. Treat as `clean` for merge-state purposes.
+- **`draft`** — handled by §Read State terminal-state rule, not here.
+
+### Fallback rule for unspecified values
+
+If `mergeable_state` returns a value not enumerated above (GitHub may add new states), treat as **`unknown` semantics** — wait for the next tick, do not act, do not advance to merge-ready. Log the encountered value so the user can extend this section if the value persists.
 
 ## Comment Classification
 
-*Runs when new comments exist since last check. Skip when no new comments.*
+*Runs when new comments exist since last check across any of the three sources from §Read State. Skip when no new comments.*
 
 Label source first (bot vs human — read `../tend-pr/references/known-bots.md`), then classify intent (read `../tend-pr/references/classification-examples.md`):
 
 - **Actionable**: Genuine issue to fix.
 - **False positive**: Intentional or not a problem.
 - **Uncertain**: Ambiguous — needs clarification.
+
+The same classification rules apply to all three comment surfaces — a top-level "Could you also handle X?" comment is just as actionable as an inline file-level "this branch is missing the null check" comment.
+
+### Disposition log
+
+Every classified comment emits one disposition log line to `/tmp/tend-pr-log-{pr-number}.md`, prefixed `### Inbox — ` for a stable anchor.
+
+Fields:
+- `thread-id`: GitHub review-thread id (for inline / review-body sources) or comment id (for top-level).
+- `source`: `bot` or `human`.
+- `bot-name`: bot login when `source=bot`; omitted otherwise.
+- `kind`: `inline | top-level | review-body` — which §Read State Comment Source the comment came from. Required so the skill can prove all three sources were consumed and so future ticks can dedup correctly.
+- `classification`: `Actionable` | `FP` | `Uncertain`.
+- `fingerprint`: content hash of the comment body (used for dedup; bots re-scan after every push and emit new comment IDs for the same finding).
+- `tick`: tick number of this classification.
+
+One line per classified comment, across all routing branches.
 
 ## Routing
 
@@ -84,9 +124,14 @@ Label source first (bot vs human — read `../tend-pr/references/known-bots.md`)
 
 ## PR Description Sync
 
-*Runs when this tick produced changes (routing fixes, conflict resolution). Skip when no changes were made.*
+The PR description and title must reflect the PR's current intent, not just its current diff. Two distinct triggers fire this contract:
 
-After changes, rewrite "what changed" sections to reflect the current diff. Preserve manual context (issue references, motivation, deployment notes). Update title if scope changed significantly.
+1. **Commit-producing tick** — routing fixes (/do commits in manifest-aware mode, direct fixes in babysit mode) or merge-state resolution (§Merge State Health). Skipped when nothing changed.
+2. **Intent/Deliverable amendment tick** — manifest-aware mode only. When this tick's amendment (via `/define --amend <manifest-path> --from-do` from §Routing) modified the manifest's **Intent** (Goal, Mental Model) OR added/removed/renamed a **Deliverable**, sync fires even if no /do commit landed this tick. Mid-AC tweaks (e.g., adjusting an AC's verify block, adding a Risk note) do NOT trigger sync — they don't change the PR's described scope. Babysit-mode has no manifest, so this trigger never fires there.
+
+**Combined single sync (same-tick collision)** — when both triggers would fire in the same tick (e.g., an Intent amendment AND a /do commit landed), perform exactly **one** sync at the end of the tick using the merged picture: amended scope + new diff. Avoids two consecutive PR edits per tick.
+
+After determining a trigger fires, rewrite "what changed" sections to reflect the current scope (manifest Intent + diff in commit-producing case; manifest Intent alone when amendment-only). Preserve manual context (issue references, motivation, deployment notes). Update title if scope changed significantly.
 
 The PR description stays summary-only — never embed the manifest. Manifests are internal working documents (also true in multi-repo, where the same canonical manifest is shared across all PRs without surfacing to reviewers).
 
@@ -98,7 +143,9 @@ Append to `/tmp/tend-pr-log-{pr-number}.md`: timestamp, actions taken, skipped i
 
 *Runs every tick.*
 
-When the PR's merge state indicates it is mergeable (all required checks pass, required approvals obtained, no unresolved threads, no pending `/do` runs) — this is a terminal state. Ask the user about merging and end the loop per the Output Protocol.
+When the PR's merge state is green per §Merge State Health (`mergeable_state` ∈ {`clean`, `unstable`, `has_hooks`}), AND all required checks pass, required approvals obtained, no unresolved threads, no pending `/do` runs — this is a terminal state. Ask the user about merging and end the loop per the Output Protocol.
+
+`behind`, `blocked`, `dirty`, and `unknown` are NOT green — they block merge-readiness until §Merge State Health resolves them (auto-update for `behind`/`dirty`; wait for external action on `blocked`; wait next tick for `unknown`).
 
 Unresolved uncertain threads block merge-readiness — they represent unanswered questions that could surface actionable issues.
 
@@ -123,7 +170,7 @@ When any STOP condition is reached: handle the user interaction described below,
 
 ### Continuing states (schedule next iteration)
 
-- **Nothing new** — No changes detected across any dimension (CI, merge conflicts, comments, merge readiness), iteration skipped. Schedule next iteration.
+- **Nothing new** — No changes detected across any dimension (CI, merge state, comments, merge readiness), iteration skipped. Schedule next iteration.
 - **Work done** — Actions taken, more tending needed. Schedule next iteration.
 
 ## Security

--- a/dist/gemini/skills/tend-pr/references/classification-examples.md
+++ b/dist/gemini/skills/tend-pr/references/classification-examples.md
@@ -1,45 +1,54 @@
 # Comment Classification Examples
 
-Use these examples to classify PR comments as actionable, false positive, or uncertain.
+Use these examples to classify PR comments as actionable, false positive, or uncertain. Examples are drawn from all three comment surfaces — **inline** (file-level review threads), **review-body** (text submitted with Approve / Request Changes / Comment), and **top-level** (the conversation tab below the diff). The same classification rules apply across surfaces — a top-level "Could you also handle X?" is just as actionable as an inline "this is missing the null check."
 
 ## Actionable
 
 The comment identifies a genuine issue. Fix it.
 
-| Example | Why Actionable |
-|---------|---------------|
-| "This function doesn't handle the case where `input` is null" | Identifies a missing edge case |
-| "Race condition: `counter` is read and written without synchronization" | Identifies a concurrency bug |
-| "This SQL query is vulnerable to injection — use parameterized queries" | Identifies a security vulnerability |
-| "The return type should be `Option<T>` not `T` — this can panic" | Identifies a type safety issue |
-| "Missing error handling — if the API call fails, the user sees a blank page" | Identifies missing error handling |
-| "This duplicates the logic in `utils.ts:42` — should reuse that" | Identifies a DRY violation worth fixing |
-| "CI: test_auth_flow failed — assertion error on line 87" | New test failure caused by PR changes |
+| Example | Surface | Why Actionable |
+|---------|---------|---------------|
+| "This function doesn't handle the case where `input` is null" | inline | Identifies a missing edge case |
+| "Race condition: `counter` is read and written without synchronization" | inline | Identifies a concurrency bug |
+| "This SQL query is vulnerable to injection — use parameterized queries" | inline | Identifies a security vulnerability |
+| "The return type should be `Option<T>` not `T` — this can panic" | inline | Identifies a type safety issue |
+| "Missing error handling — if the API call fails, the user sees a blank page" | inline | Identifies missing error handling |
+| "This duplicates the logic in `utils.ts:42` — should reuse that" | inline | Identifies a DRY violation worth fixing |
+| "CI: test_auth_flow failed — assertion error on line 87" | top-level | New test failure caused by PR changes |
+| "Could you also handle the case where the user is logged out? It's not covered anywhere in this PR." | top-level | Scope-extension request for a missing case |
+| "Requesting changes — the migration script needs a rollback path before this can land." | review-body | Reviewer blocking on a concrete missing capability |
+| "Please also update the README — the new flag isn't documented anywhere." | top-level | Specific cross-cutting fix tied to this PR |
 
 ## False Positive
 
 The comment flags something intentional or not actually a problem.
 
-| Example | Why False Positive |
-|---------|-------------------|
-| "Consider using `const` instead of `let`" on a variable that IS reassigned later | Reviewer didn't read the full scope |
-| "This file is too long" on a file that was long before the PR | Pre-existing, not introduced by this PR |
-| Bot: "Unused import `os`" when `os` is used via a macro or conditional compilation | Bot can't see macro expansion |
-| "Missing docstring" on an internal helper function in a codebase that doesn't require them | Style preference, not a codebase standard |
-| Bot: "Function complexity too high" on a function that was already complex before the PR | Pre-existing finding, not introduced |
+| Example | Surface | Why False Positive |
+|---------|---------|-------------------|
+| "Consider using `const` instead of `let`" on a variable that IS reassigned later | inline | Reviewer didn't read the full scope |
+| "This file is too long" on a file that was long before the PR | inline | Pre-existing, not introduced by this PR |
+| Bot: "Unused import `os`" when `os` is used via a macro or conditional compilation | inline | Bot can't see macro expansion |
+| "Missing docstring" on an internal helper function in a codebase that doesn't require them | inline | Style preference, not a codebase standard |
+| Bot: "Function complexity too high" on a function that was already complex before the PR | inline | Pre-existing finding, not introduced |
+| "Looks great, ship it 🚀" | top-level | Approval acknowledgement, no change requested |
+| "Approving — nice cleanup." | review-body | Approval, not actionable |
+| "Why are we not just deleting this whole module?" — when the module is actively used by another consumer not visible in the PR diff | top-level | Misunderstanding of broader usage; not a real ask |
 
 ## Uncertain
 
 The comment is ambiguous — you can't tell if it's actionable or a false positive without more context.
 
-| Example | Why Uncertain |
-|---------|--------------|
-| "Is this the right approach?" | Could be rhetorical (approval) or genuine concern |
-| "What about performance?" | Unclear if they've identified a specific issue or asking generally |
-| "Hmm" | No actionable content |
-| "This could be simplified" | Might be a suggestion (low priority) or a blocking concern |
-| "Have you considered using X instead?" | Could be a suggestion or a request for change |
-| "Not sure about this" | Unclear what specifically concerns them |
+| Example | Surface | Why Uncertain |
+|---------|---------|--------------|
+| "Is this the right approach?" | inline | Could be rhetorical (approval) or genuine concern |
+| "What about performance?" | inline | Unclear if they've identified a specific issue or asking generally |
+| "Hmm" | inline | No actionable content |
+| "This could be simplified" | inline | Might be a suggestion (low priority) or a blocking concern |
+| "Have you considered using X instead?" | inline | Could be a suggestion or a request for change |
+| "Not sure about this" | inline | Unclear what specifically concerns them |
+| "Should we revisit the design here?" | top-level | Could mean "block this PR" or "let's chat after merge" |
+| "Have you thought about how this interacts with the new auth system?" | top-level | Could be an informational question or a blocking concern; surface area unspecified |
+| "I'm leaning toward not shipping this until we discuss." | review-body | Direction unclear: pause-pending-discussion vs request-changes — needs reviewer clarification |
 
 ## Classification Decision Tree
 

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "66b4ed320a3cd284436d8a80111247be80ca6670",
+  "source_commit": "08262ea04148c7a5810257137457eee1f9d023ed",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-04-30T09:39:07Z"
+  "synced_at": "2026-04-30T11:17:33Z"
 }

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "6224c387eaabbd319c29aab0aff32dd65f58d1be",
+  "source_commit": "66b4ed320a3cd284436d8a80111247be80ca6670",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-04-29T21:59:00Z"
+  "synced_at": "2026-04-30T09:39:07Z"
 }

--- a/dist/opencode/skills/define/tasks/PROMPTING.md
+++ b/dist/opencode/skills/define/tasks/PROMPTING.md
@@ -21,7 +21,7 @@ When prompt-reviewer is not available, encode these as individual criteria verif
 | No conflicts | No contradictory rules, no priority collisions, edge cases covered |
 | Structure | Critical rules surfaced prominently, clear hierarchy, no unintentional redundancy |
 | Information density | Every word earns its place |
-| No anti-patterns | No prescriptive HOW, arbitrary limits, capability instructions, weak language |
+| No anti-patterns | No prescriptive HOW, arbitrary limits, capability instructions, weak hedging, unjustified absolutes |
 | Invocation fit | Prompt's trigger, caller identity, and output consumer match deployment context |
 | Domain context | Domain terms, conventions, and constraints captured—not guessed |
 | Complexity fit | Prompt complexity matches the task—not over-engineered, not under-specified |
@@ -63,7 +63,8 @@ Before defining a prompt, probe for these—missing context creates ambiguous pr
 | Arbitrary limits | "Max 3 iterations", "2-4 examples" | Principle: "until converged", "as needed" |
 | Capability instructions | "Use grep to search", "Read the file" | Remove—model knows how |
 | Rigid checklists in authored prompts | "Step 1: search. Step 2: read. Step 3: analyze." baked into the prompt | Convert to goal + constraints (discipline patterns like memento are exempt) |
-| Weak language | "Try to", "maybe", "if possible" | Direct: "Do X", "Never Y" |
+| Weak hedging | "Try to", "maybe", "if possible" | Direct imperative: "Do X" |
+| Absolutes for judgment calls | "ALWAYS", "NEVER", "MUST" applied to non-invariants (when to search, ask, iterate, retry) | Decision rules: "When X, do Y; otherwise Z". Reserve absolutes for true invariants — safety rules, required fields, hard constraints |
 | Buried critical info | Important rules in middle | Surface prominently |
 | Over-engineering | 10 phases for a simple task | Match complexity to need |
 

--- a/dist/opencode/skills/tend-pr-tick/SKILL.md
+++ b/dist/opencode/skills/tend-pr-tick/SKILL.md
@@ -26,15 +26,23 @@ Use a lock file at `/tmp/tend-pr-lock-{pr-number}`. Skip this iteration if the l
 
 ## Read State
 
-Read the PR's current state: open/closed/merged/draft, CI status, review status, new comments since last check, merge conflict status, unresolved threads.
+Read the PR's current state: open/closed/merged/draft, CI status, review status, new comments since last check (see Comment Sources below), merge state per §Merge State Health, unresolved threads.
+
+**Comment Sources — three distinct surfaces, ALL required.** Top-level PR comments are routinely missed when only file-level review threads are fetched. Each source is a separate `mcp__github__pull_request_read` method, each is paginated, and each MUST be exhausted (page through `perPage`/`page` or cursor parameters until the response signals no more results). Missing any source means missing real reviewer feedback.
+
+- `mcp__github__pull_request_read` method `get_review_comments` — inline file-level review threads (comments anchored to specific code locations).
+- `mcp__github__pull_request_read` method `get_reviews` — formal review submissions; the review's own `body` (the text the reviewer wrote when submitting Approve / Request Changes / Comment) is a comment surface and counts as a top-level review-body comment.
+- `mcp__github__pull_request_read` method `get_comments` — top-level PR/issue-style comments (the conversation tab below the diff). These are the comments most often missed when only `get_review_comments` is consulted.
+
+**PR summary** — `mcp__github__pull_request_read` method `get` returns `mergeable_state` (the merge-state taxonomy: `clean | dirty | behind | blocked | unstable | unknown | has_hooks | draft`). The value drives §Merge State Health.
 
 **Terminal states** — Merged, Closed, or Draft. Handle per Output Protocol (end the loop).
 
 **First tick** (tend-pr-log has no prior iterations): Everything is unprocessed — run the full pipeline.
 
 **Check categories:**
-- **Every tick:** CI status, merge conflicts, merge readiness — these change independent of comments (base branch updates, CI re-runs, review approvals).
-- **Comment-gated:** Comment classification — only runs when new comments exist since last check.
+- **Every tick:** CI status, merge state health, merge readiness — these change independent of comments (base branch updates, CI re-runs, review approvals).
+- **Comment-gated:** Comment classification — only runs when new comments exist since last check across any of the three sources.
 - **Conditional:** Routing — runs when there are CI failures to handle or when new comments were classified.
 
 ## CI Failure Triage
@@ -47,21 +55,53 @@ Compare against base branch first:
 - **Infrastructure**: Flaky/timeout/runner → retrigger.
 - **Code-caused**: New failure from PR → actionable.
 
-## Merge Conflicts
+## Merge State Health
 
 *Runs every tick.*
 
-Update the PR branch from the base branch. Preserve review comment history — rebase destroys it (see Gotchas). Flag ambiguous conflicts to the user.
+The framing is broader than conflicts alone: GitHub's `mergeable_state` (read from §Read State) reports a taxonomy of values, each blocking merge-readiness in a different way. Reason about every value, not just conflicts.
+
+### Per-value dispositions
+
+- **`clean`** — green. No action.
+- **`dirty` (conflicts)** — actual merge conflicts against base. Update the PR branch by running `git merge origin/<base>`. Prefer `git merge` over `git rebase` — rebase destroys review-comment anchors by rewriting commit history (see Gotchas). Rebase ONLY when a reviewer explicitly requests it AND acknowledges the loss of comment anchoring. Flag ambiguous conflicts (overlapping edits requiring semantic understanding) to the user.
+- **`behind`** — branch protection requires the PR branch to be up-to-date with base, and base has new commits. This is GitHub's signal that the "Update branch" button is required before merge. Update via `git merge origin/<base>` (same path as `dirty`, minus the conflict markers). Preserve review-comment anchors (no rebase). When `mergeable_state` is `clean` even though base has advanced, branch protection does NOT require up-to-date — leave the branch alone.
+- **`blocked`** — non-conflict gate failing (missing required reviews, failing required checks, branch-protection rule beyond up-to-date). Do NOT auto-resolve — these gates require external action. Treat as not-green for §Merge Readiness; CI failures are owned by §CI Failure Triage and review feedback by §Comment Classification + §Routing.
+- **`unstable`** — mergeable, but a non-required check is failing. GitHub's merge button is enabled. Informational only; does NOT block merge-readiness.
+- **`unknown`** — GitHub is still computing the merge state. Wait for the next tick — do not act, do not advance to merge-ready, do not infer green.
+- **`has_hooks`** — mergeable, hooks installed on the repo. Treat as `clean` for merge-state purposes.
+- **`draft`** — handled by §Read State terminal-state rule, not here.
+
+### Fallback rule for unspecified values
+
+If `mergeable_state` returns a value not enumerated above (GitHub may add new states), treat as **`unknown` semantics** — wait for the next tick, do not act, do not advance to merge-ready. Log the encountered value so the user can extend this section if the value persists.
 
 ## Comment Classification
 
-*Runs when new comments exist since last check. Skip when no new comments.*
+*Runs when new comments exist since last check across any of the three sources from §Read State. Skip when no new comments.*
 
 Label source first (bot vs human — read `../tend-pr/references/known-bots.md`), then classify intent (read `../tend-pr/references/classification-examples.md`):
 
 - **Actionable**: Genuine issue to fix.
 - **False positive**: Intentional or not a problem.
 - **Uncertain**: Ambiguous — needs clarification.
+
+The same classification rules apply to all three comment surfaces — a top-level "Could you also handle X?" comment is just as actionable as an inline file-level "this branch is missing the null check" comment.
+
+### Disposition log
+
+Every classified comment emits one disposition log line to `/tmp/tend-pr-log-{pr-number}.md`, prefixed `### Inbox — ` for a stable anchor.
+
+Fields:
+- `thread-id`: GitHub review-thread id (for inline / review-body sources) or comment id (for top-level).
+- `source`: `bot` or `human`.
+- `bot-name`: bot login when `source=bot`; omitted otherwise.
+- `kind`: `inline | top-level | review-body` — which §Read State Comment Source the comment came from. Required so the skill can prove all three sources were consumed and so future ticks can dedup correctly.
+- `classification`: `Actionable` | `FP` | `Uncertain`.
+- `fingerprint`: content hash of the comment body (used for dedup; bots re-scan after every push and emit new comment IDs for the same finding).
+- `tick`: tick number of this classification.
+
+One line per classified comment, across all routing branches.
 
 ## Routing
 
@@ -84,9 +124,14 @@ Label source first (bot vs human — read `../tend-pr/references/known-bots.md`)
 
 ## PR Description Sync
 
-*Runs when this tick produced changes (routing fixes, conflict resolution). Skip when no changes were made.*
+The PR description and title must reflect the PR's current intent, not just its current diff. Two distinct triggers fire this contract:
 
-After changes, rewrite "what changed" sections to reflect the current diff. Preserve manual context (issue references, motivation, deployment notes). Update title if scope changed significantly.
+1. **Commit-producing tick** — routing fixes (/do commits in manifest-aware mode, direct fixes in babysit mode) or merge-state resolution (§Merge State Health). Skipped when nothing changed.
+2. **Intent/Deliverable amendment tick** — manifest-aware mode only. When this tick's amendment (via `/define --amend <manifest-path> --from-do` from §Routing) modified the manifest's **Intent** (Goal, Mental Model) OR added/removed/renamed a **Deliverable**, sync fires even if no /do commit landed this tick. Mid-AC tweaks (e.g., adjusting an AC's verify block, adding a Risk note) do NOT trigger sync — they don't change the PR's described scope. Babysit-mode has no manifest, so this trigger never fires there.
+
+**Combined single sync (same-tick collision)** — when both triggers would fire in the same tick (e.g., an Intent amendment AND a /do commit landed), perform exactly **one** sync at the end of the tick using the merged picture: amended scope + new diff. Avoids two consecutive PR edits per tick.
+
+After determining a trigger fires, rewrite "what changed" sections to reflect the current scope (manifest Intent + diff in commit-producing case; manifest Intent alone when amendment-only). Preserve manual context (issue references, motivation, deployment notes). Update title if scope changed significantly.
 
 The PR description stays summary-only — never embed the manifest. Manifests are internal working documents (also true in multi-repo, where the same canonical manifest is shared across all PRs without surfacing to reviewers).
 
@@ -98,7 +143,9 @@ Append to `/tmp/tend-pr-log-{pr-number}.md`: timestamp, actions taken, skipped i
 
 *Runs every tick.*
 
-When the PR's merge state indicates it is mergeable (all required checks pass, required approvals obtained, no unresolved threads, no pending `/do` runs) — this is a terminal state. Ask the user about merging and end the loop per the Output Protocol.
+When the PR's merge state is green per §Merge State Health (`mergeable_state` ∈ {`clean`, `unstable`, `has_hooks`}), AND all required checks pass, required approvals obtained, no unresolved threads, no pending `/do` runs — this is a terminal state. Ask the user about merging and end the loop per the Output Protocol.
+
+`behind`, `blocked`, `dirty`, and `unknown` are NOT green — they block merge-readiness until §Merge State Health resolves them (auto-update for `behind`/`dirty`; wait for external action on `blocked`; wait next tick for `unknown`).
 
 Unresolved uncertain threads block merge-readiness — they represent unanswered questions that could surface actionable issues.
 
@@ -123,7 +170,7 @@ When any STOP condition is reached: handle the user interaction described below,
 
 ### Continuing states (schedule next iteration)
 
-- **Nothing new** — No changes detected across any dimension (CI, merge conflicts, comments, merge readiness), iteration skipped. Schedule next iteration.
+- **Nothing new** — No changes detected across any dimension (CI, merge state, comments, merge readiness), iteration skipped. Schedule next iteration.
 - **Work done** — Actions taken, more tending needed. Schedule next iteration.
 
 ## Security

--- a/dist/opencode/skills/tend-pr/references/classification-examples.md
+++ b/dist/opencode/skills/tend-pr/references/classification-examples.md
@@ -1,45 +1,54 @@
 # Comment Classification Examples
 
-Use these examples to classify PR comments as actionable, false positive, or uncertain.
+Use these examples to classify PR comments as actionable, false positive, or uncertain. Examples are drawn from all three comment surfaces — **inline** (file-level review threads), **review-body** (text submitted with Approve / Request Changes / Comment), and **top-level** (the conversation tab below the diff). The same classification rules apply across surfaces — a top-level "Could you also handle X?" is just as actionable as an inline "this is missing the null check."
 
 ## Actionable
 
 The comment identifies a genuine issue. Fix it.
 
-| Example | Why Actionable |
-|---------|---------------|
-| "This function doesn't handle the case where `input` is null" | Identifies a missing edge case |
-| "Race condition: `counter` is read and written without synchronization" | Identifies a concurrency bug |
-| "This SQL query is vulnerable to injection — use parameterized queries" | Identifies a security vulnerability |
-| "The return type should be `Option<T>` not `T` — this can panic" | Identifies a type safety issue |
-| "Missing error handling — if the API call fails, the user sees a blank page" | Identifies missing error handling |
-| "This duplicates the logic in `utils.ts:42` — should reuse that" | Identifies a DRY violation worth fixing |
-| "CI: test_auth_flow failed — assertion error on line 87" | New test failure caused by PR changes |
+| Example | Surface | Why Actionable |
+|---------|---------|---------------|
+| "This function doesn't handle the case where `input` is null" | inline | Identifies a missing edge case |
+| "Race condition: `counter` is read and written without synchronization" | inline | Identifies a concurrency bug |
+| "This SQL query is vulnerable to injection — use parameterized queries" | inline | Identifies a security vulnerability |
+| "The return type should be `Option<T>` not `T` — this can panic" | inline | Identifies a type safety issue |
+| "Missing error handling — if the API call fails, the user sees a blank page" | inline | Identifies missing error handling |
+| "This duplicates the logic in `utils.ts:42` — should reuse that" | inline | Identifies a DRY violation worth fixing |
+| "CI: test_auth_flow failed — assertion error on line 87" | top-level | New test failure caused by PR changes |
+| "Could you also handle the case where the user is logged out? It's not covered anywhere in this PR." | top-level | Scope-extension request for a missing case |
+| "Requesting changes — the migration script needs a rollback path before this can land." | review-body | Reviewer blocking on a concrete missing capability |
+| "Please also update the README — the new flag isn't documented anywhere." | top-level | Specific cross-cutting fix tied to this PR |
 
 ## False Positive
 
 The comment flags something intentional or not actually a problem.
 
-| Example | Why False Positive |
-|---------|-------------------|
-| "Consider using `const` instead of `let`" on a variable that IS reassigned later | Reviewer didn't read the full scope |
-| "This file is too long" on a file that was long before the PR | Pre-existing, not introduced by this PR |
-| Bot: "Unused import `os`" when `os` is used via a macro or conditional compilation | Bot can't see macro expansion |
-| "Missing docstring" on an internal helper function in a codebase that doesn't require them | Style preference, not a codebase standard |
-| Bot: "Function complexity too high" on a function that was already complex before the PR | Pre-existing finding, not introduced |
+| Example | Surface | Why False Positive |
+|---------|---------|-------------------|
+| "Consider using `const` instead of `let`" on a variable that IS reassigned later | inline | Reviewer didn't read the full scope |
+| "This file is too long" on a file that was long before the PR | inline | Pre-existing, not introduced by this PR |
+| Bot: "Unused import `os`" when `os` is used via a macro or conditional compilation | inline | Bot can't see macro expansion |
+| "Missing docstring" on an internal helper function in a codebase that doesn't require them | inline | Style preference, not a codebase standard |
+| Bot: "Function complexity too high" on a function that was already complex before the PR | inline | Pre-existing finding, not introduced |
+| "Looks great, ship it 🚀" | top-level | Approval acknowledgement, no change requested |
+| "Approving — nice cleanup." | review-body | Approval, not actionable |
+| "Why are we not just deleting this whole module?" — when the module is actively used by another consumer not visible in the PR diff | top-level | Misunderstanding of broader usage; not a real ask |
 
 ## Uncertain
 
 The comment is ambiguous — you can't tell if it's actionable or a false positive without more context.
 
-| Example | Why Uncertain |
-|---------|--------------|
-| "Is this the right approach?" | Could be rhetorical (approval) or genuine concern |
-| "What about performance?" | Unclear if they've identified a specific issue or asking generally |
-| "Hmm" | No actionable content |
-| "This could be simplified" | Might be a suggestion (low priority) or a blocking concern |
-| "Have you considered using X instead?" | Could be a suggestion or a request for change |
-| "Not sure about this" | Unclear what specifically concerns them |
+| Example | Surface | Why Uncertain |
+|---------|---------|--------------|
+| "Is this the right approach?" | inline | Could be rhetorical (approval) or genuine concern |
+| "What about performance?" | inline | Unclear if they've identified a specific issue or asking generally |
+| "Hmm" | inline | No actionable content |
+| "This could be simplified" | inline | Might be a suggestion (low priority) or a blocking concern |
+| "Have you considered using X instead?" | inline | Could be a suggestion or a request for change |
+| "Not sure about this" | inline | Unclear what specifically concerns them |
+| "Should we revisit the design here?" | top-level | Could mean "block this PR" or "let's chat after merge" |
+| "Have you thought about how this interacts with the new auth system?" | top-level | Could be an informational question or a blocking concern; surface area unspecified |
+| "I'm leaning toward not shipping this until we discuss." | review-body | Direction unclear: pause-pending-discussion vs request-changes — needs reviewer clarification |
 
 ## Classification Decision Tree
 


### PR DESCRIPTION
## Summary

Closes two reported gaps in `/drive` (github adapter) and `/tend-pr-tick`:

- **Top-level PR comments routinely missed.** Skills now enumerate all three `pull_request_read` methods explicitly (`get_review_comments`, `get_reviews`, `get_comments`) with mandated pagination per source. The `get_comments` method (top-level conversation tab) was the one most often skipped.
- **Branch-protection "behind" missed.** `Merge Conflicts` renamed to `Merge State Health`, covering the full `mergeable_state` taxonomy (`clean | dirty | behind | blocked | unstable | unknown | has_hooks | draft`) plus a fallback rule. `behind` triggers an auto `git merge` from base; `blocked` blocks merge-ready; `unknown` waits.

Adjacent fixes serving the same merge-readiness goal:

- **PR Description Sync** now fires on Intent/Deliverable manifest amendment in addition to commit-producing ticks, with combined-single-sync when both apply same tick. On drive, `§PR Description Sync` is hoisted out of `§Write Outputs` into its own contract slot invoked from `drive-tick §P` after Thread Hygiene — required so amendment-only ticks still propagate scope changes to the PR.
- **Disposition log** gains per-comment `kind` tag (`inline | top-level | review-body`) so the skill can prove all three sources were consumed.
- **classification-examples.md** gains diverse top-level + review-body patterns across Actionable / FP / Uncertain.

Plus patch version bumps (`manifest-dev` 0.94.1 → 0.94.2, `manifest-dev-experimental` 0.6.0 → 0.6.1) and dist regen for gemini/opencode/codex (manifest-dev only — manifest-dev-experimental is not in dist by design).

## Notable scope decision

Mid-execution, /verify discovered drive's amendment-only PR Description Sync trigger was unreachable (gated inside `§Write Outputs` which drive-tick skips on no-commit ticks). User picked Option A: relax INV-G4 with one targeted exception — drive-tick `§P` gains one new step "PR Description Sync — runs every tick, after Thread Hygiene; adapter owns trigger logic." `§PR Description Sync` then hoisted into its own contract. Documented in the manifest's Amendments §A1.

## Test plan

- [x] All AC-* verified by automated reviewers (codebase + bash + general-purpose subagent).
- [x] INV-G1 (change-intent-reviewer) PASS — no LOW+ divergence.
- [x] INV-G3 (skill-pair parity) PASS — both files cover all five touched concepts.
- [x] INV-G4 (wrappers) PASS — `tend-pr/SKILL.md` and `drive/SKILL.md` byte-identical to main; `drive-tick/SKILL.md` change confined to `§P` additive scope per §A1.
- [ ] Live verification on a real PR with top-level comments + behind-base state once this merges.

## Out of scope (surfaced by INV-G2 prompt-reviewer)

Pre-existing prose-quality findings in `tend-pr-tick §Routing step 1` (multi-repo procedural prescription) and `github.md §CI Retrigger algorithm` (hardcoded `10`) are real but untouched by this PR. PG-3 scope guard. Worth a follow-up cleanup PR.

https://claude.ai/code/session_01NG5N6obrrWH5bYGPU2prVw

---
_Generated by [Claude Code](https://claude.ai/code/session_01NG5N6obrrWH5bYGPU2prVw)_