### PR TITLE
feat(define/prompting): sync anti-pattern split from prompt-engineeri…

### DIFF
--- a/.claude/skills/prompt-engineering/SKILL.md
+++ b/.claude/skills/prompt-engineering/SKILL.md
@@ -82,7 +82,8 @@ Before writing or improving a prompt, surface all required context through user 
 | Arbitrary limits | "Max 3 iterations", "2-4 examples" | Principle: "until converged", "as needed" |
 | Capability instructions | "Use grep to search", "Read the file" | Remove - model knows how |
 | Rigid checklists | Step-by-step heuristics tables | Convert to principles |
-| Weak language | "Try to", "maybe", "if possible" | Direct: "Do X", "Never Y" |
+| Weak hedging | "Try to", "maybe", "if possible" | Direct imperative: "Do X" |
+| Absolutes for judgment calls | "ALWAYS", "NEVER", "MUST" applied to non-invariants (when to search, ask, iterate, retry) | Decision rules: "When X, do Y; otherwise Z". Reserve absolutes for true invariants — safety rules, required fields, hard constraints |
 | Buried critical info | Important rules in middle | Surface prominently |
 | Over-engineering | 10 phases for a simple task | Match complexity to need |
 
@@ -161,13 +162,18 @@ description: 'What it does. When to use. Trigger terms.'
 
 ```markdown
 ## Role
-{Identity and purpose - one paragraph}
+{Identity and stance — who the model is and how it behaves}
 
-## Approach
-{Principles for thinking, not procedures}
+## Goal
+{User-visible outcome — what the run produces}
+
+## Success criteria
+{Anything that would cause dissatisfaction with the run:
+ output correctness; validation passing (tests, lint, schema when available);
+ time / iteration bounds; handling of non-success cases — retry, fallback, abstain, ask}
 
 ## Constraints
-{MUST > SHOULD > PREFER priority}
+{MUST > SHOULD > PREFER priority — reserve MUST for true invariants per "Absolutes for judgment calls" anti-pattern}
 
 ## Output
 {Format requirements if needed}

--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.94.1",
+  "version": "0.94.2",
   "description": "Manifest-driven workflows for structured task execution with verification gates. Supports multi-repo changesets via a shared canonical manifest.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/skills/define/tasks/PROMPTING.md
+++ b/claude-plugins/manifest-dev/skills/define/tasks/PROMPTING.md
@@ -21,7 +21,7 @@ When prompt-reviewer is not available, encode these as individual criteria verif
 | No conflicts | No contradictory rules, no priority collisions, edge cases covered |
 | Structure | Critical rules surfaced prominently, clear hierarchy, no unintentional redundancy |
 | Information density | Every word earns its place |
-| No anti-patterns | No prescriptive HOW, arbitrary limits, capability instructions, weak language |
+| No anti-patterns | No prescriptive HOW, arbitrary limits, capability instructions, weak hedging, unjustified absolutes |
 | Invocation fit | Prompt's trigger, caller identity, and output consumer match deployment context |
 | Domain context | Domain terms, conventions, and constraints captured—not guessed |
 | Complexity fit | Prompt complexity matches the task—not over-engineered, not under-specified |
@@ -63,7 +63,8 @@ Before defining a prompt, probe for these—missing context creates ambiguous pr
 | Arbitrary limits | "Max 3 iterations", "2-4 examples" | Principle: "until converged", "as needed" |
 | Capability instructions | "Use grep to search", "Read the file" | Remove—model knows how |
 | Rigid checklists in authored prompts | "Step 1: search. Step 2: read. Step 3: analyze." baked into the prompt | Convert to goal + constraints (discipline patterns like memento are exempt) |
-| Weak language | "Try to", "maybe", "if possible" | Direct: "Do X", "Never Y" |
+| Weak hedging | "Try to", "maybe", "if possible" | Direct imperative: "Do X" |
+| Absolutes for judgment calls | "ALWAYS", "NEVER", "MUST" applied to non-invariants (when to search, ask, iterate, retry) | Decision rules: "When X, do Y; otherwise Z". Reserve absolutes for true invariants — safety rules, required fields, hard constraints |
 | Buried critical info | Important rules in middle | Surface prominently |
 | Over-engineering | 10 phases for a simple task | Match complexity to need |
 


### PR DESCRIPTION
…ng v2.5.1

- .claude/skills/prompt-engineering/SKILL.md: byte-for-byte sync from claude-code-plugins prompt-engineering v2.5.1 (anti-pattern split + System Instructions template restructure: Goal slot, Success criteria slot covering retry/fallback/abstain/ask, Constraints note cross- referencing the new anti-pattern).
- skills/define/tasks/PROMPTING.md: split "Weak language" anti-pattern into "Weak hedging" + "Absolutes for judgment calls" (verbatim from source); update Quality Gates "No anti-patterns" row to reference both.
- bump manifest-dev to 0.94.2.