### PR TITLE
sync prompt-engineering skill from upstream v2.6.0

### DIFF
--- a/.claude/skills/prompt-engineering/SKILL.md
+++ b/.claude/skills/prompt-engineering/SKILL.md
@@ -1,25 +1,27 @@
 ---
 name: prompt-engineering
-description: 'Craft or update LLM prompts from first principles. Use when creating new prompts, updating existing ones, or reviewing prompt structure. Ensures prompts define WHAT and WHY, not HOW.'
+description: 'Craft, update, or review LLM prompts from first principles. Use when creating new prompts, updating existing ones, reviewing prompt structure, or diagnosing a failing prompt. Ensures prompts define WHAT and WHY, not HOW. Triggers: write a prompt, edit a prompt, review a prompt, improve a prompt, diagnose prompt failure, fix failing prompt, system prompt, skill, agent.'
 ---
 
 **User request**: $ARGUMENTS
 
-Create or update an LLM prompt. Prompts act as manifests: clear goal, clear constraints, freedom in execution.
+Create, update, or review an LLM prompt. Prompts act as manifests: clear goal, clear constraints, freedom in execution.
 
 **If no request provided**: Ask the user whether they want to create a new prompt, update an existing one, or review prompt structure.
 
-**If creating**: Discover goal, constraints, and structure through targeted questions.
+**If creating**: Discover goal, constraints, and structure through targeted questions, then draft against the canonical template.
 
-**If updating**: Read existing prompt, identify issues against principles, make targeted fixes.
+**If updating**: Read the existing prompt, identify issues against principles, make targeted high-signal fixes only.
 
-**If creating or updating a skill**: Read `references/skills.md` for skill-specific architecture patterns (folder structure, progressive disclosure, gotchas, setup config, description-as-trigger, skill type awareness) before proceeding.
+**If reviewing**: Read the prompt, scan against the canonical template, cross-cutting principles, and anti-patterns. Report issues without modifying the file. For deeper structural audit, delegate to `/review-prompt`.
 
-## Context Discovery
+**Modifier — when the prompt is an agent**: Declare every required tool in frontmatter — agents run isolated and don't inherit tools (see Agents specialization below). Applies on top of the create or update branch.
 
-Before writing or improving a prompt, surface all required context through user engagement. Missing domain knowledge creates ambiguous prompts. You can't surface latent requirements you don't understand.
+**If diagnosing a failing prompt**: Load `references/metaprompting.md` and follow its pre-flight check ("when metaprompting is the wrong tool") before the diagnose-from-failures → surgical-revision workflow.
 
-**What to discover**:
+## Before writing — discover context
+
+Missing domain knowledge creates ambiguous prompts. You can't surface latent requirements you don't understand. Surface these before drafting:
 
 | Context Type | What to Surface |
 |--------------|-----------------|
@@ -28,7 +30,7 @@ Before writing or improving a prompt, surface all required context through user 
 | **Success criteria** | What good output looks like, what makes it fail |
 | **Edge cases** | Unusual inputs, error handling, boundary conditions |
 | **Constraints** | Hard limits (length, format, tone), non-negotiables |
-| **Integration context** | Where prompt fits, what comes before/after |
+| **Integration context** | Where the prompt fits, what comes before/after |
 
 **Interview method**:
 
@@ -38,92 +40,66 @@ Before writing or improving a prompt, surface all required context through user 
 | **Mark recommended options** | Reduce cognitive load. For single-select, mark one "(Recommended)". For multi-select, mark sensible defaults or none if all equally valid. |
 | **Outside view** | "What typically fails in prompts like this?" "What have you seen go wrong before?" |
 | **Pre-mortem** | "If this prompt failed in production, what would likely cause it?" |
-| **Discovered ≠ confirmed** | When you infer constraints from context, confirm before encoding: "I'm inferring X should be a constraint?" Includes ambiguous scope (list in/out assumptions). |
-| **Encode explicit statements** | When user states a preference or requirement, it must appear in the final prompt. Don't let constraints get lost. |
+| **Discovered ≠ confirmed** | When you infer constraints from context, confirm before encoding. Includes ambiguous scope (list in/out assumptions). |
+| **Encode explicit statements** | When the user states a preference or requirement, it must appear in the final prompt. |
 | **Domain terms** | Ask for definitions, don't guess. Jargon you don't understand creates ambiguous prompts. |
 | **Missing examples** | Ask for good/bad output examples when success criteria are unclear. |
 
-**Stopping rule**: Continue probing until very confident further questions would yield nothing new, or user signals "enough". Err toward more probing—every requirement discovered now is one fewer failure later.
+When unsure whether to keep probing, ask one more question — every requirement discovered now is one fewer failure later.
 
-**Handling ambiguity**: Critical ambiguities (those that would cause prompt failure) require clarification even if user wants to move on. Minor ambiguities can be documented with chosen defaults and proceed. When in doubt, ask—a prompt built on assumptions will fail in ways the user didn't expect.
+Critical ambiguities (those that would cause prompt failure) require clarification even if the user wants to move on. Minor ambiguities can be documented with chosen defaults and proceed.
 
-## Core Principles
+## The canonical template
 
-| Principle | What It Means |
-|-----------|---------------|
-| **WHAT and WHY, not HOW** | State goals and constraints. Don't prescribe steps the model knows how to do. |
-| **Trust capability, enforce discipline** | Model knows how to search, analyze, generate. Only specify guardrails. |
-| **Maximize information density** | Every word earns its place. Fewer words = same meaning = better. |
-| **Avoid arbitrary values** | "Max 4 rounds" becomes rigid. State the principle: "stop when converged". |
-| **Output structure when needed** | Define format only if artifact requires it. Otherwise let agent decide. |
+The reference shape for a system prompt. Each section has one job. Keep each section short. Add detail only where it changes behavior.
 
-## Issue Types
+```
+Role
+Personality          (optional — see below)
+Goal
+Success criteria
+Constraints
+Output
+Stop rules
+```
 
-**Clarity**:
-- Ambiguous instructions (multiple interpretations)
-- Vague language ("be helpful", "use good judgment", "when appropriate")
-- Implicit expectations (unstated assumptions)
+| Section | What goes here |
+|---------|----------------|
+| **Role** | Identity and stance — who the model is, what context it operates in, what it's responsible for. One or two sentences. |
+| **Personality** | Voice, tone, formality, warmth, directness. Shapes how the assistant *sounds* to the user. Skip when the prompt is a worker, internal-pipeline, transformation, extraction, or any non-user-facing task — Personality is for user-facing (conversational or customer-facing) surfaces only. |
+| **Goal** | The user-visible outcome the run produces. State the destination, not the path. |
+| **Success criteria** | What must be true before the final answer. Include the **degradation paths**: when to **retry** (transient failure), **fallback** (alternative method), **abstain** (refuse with reason), **ask** (for the smallest missing field). The four verbs prevent loops and silent guessing. |
+| **Constraints** | Rules that must hold throughout the run — policy, safety, business, evidence, side-effect limits. Reserve absolutes (MUST/NEVER) for true invariants; for judgment calls (when to search, ask, iterate, retry), use decision rules: "When X, do Y; otherwise Z." When multiple non-invariant rules apply, mark priority (MUST > SHOULD > PREFER) so conflicts resolve predictably. |
+| **Output** | Format, length, audience, structure. Be specific only where it changes behavior — don't over-prescribe shape the model already gets right from Goal. |
+| **Stop rules** | Loop control: when to stop pursuing more information and answer with what you have. Distinct from Success (target state) and degradation (non-success behavior). |
 
-**Conflict**:
-- Contradictory rules ("Be concise" vs "Explain thoroughly")
-- Priority collisions (two MUST rules that can't both be satisfied)
-- Edge case gaps (what happens when rules don't cover a situation?)
+**Success vs. Constraints vs. Stop rules** — three different jobs that authors frequently conflate. For a retrieval agent, the boundary looks like:
+- *Success criteria*: "answer addresses every part of the asked question" — the target state.
+- *Constraints*: "ground every factual claim in retrieved content; never invent citations" — rules that hold throughout.
+- *Stop rules*: "when one more search would not change the answer, write" — the loop-exit rule.
 
-**Structure**:
-- Buried critical info (important rules hidden in middle)
-- No hierarchy (all instructions treated as equal priority)
-- Unintentional redundancy (but: repetition can be intentional emphasis—don't remove if it reinforces critical rules)
+Conflating Success and Stop causes agents to over-search or stop early. Conflating Constraints and Success buries the target inside hard rules. Conflating Constraints and Stop turns a permanent rule into a one-shot exit.
 
-## Anti-Patterns to Eliminate
+**When to use canonical headers vs. theme/phase organization:**
+- Use the canonical headers when the prompt is a single-purpose system prompt for an assistant (one Role, one Goal, runtime in a deployment).
+- Theme or phase organization fits when the prompt's structure is itself non-trivial — multi-phase workflows, skills with subdomains, instructional documents (this skill is one) — so long as every applicable canonical section is answerable on read.
 
-| Anti-pattern | Example | Fix |
-|--------------|---------|-----|
-| Prescribing HOW | "First search, then read, then analyze..." | State goal: "Understand the pattern" |
-| Arbitrary limits | "Max 3 iterations", "2-4 examples" | Principle: "until converged", "as needed" |
-| Capability instructions | "Use grep to search", "Read the file" | Remove - model knows how |
-| Rigid checklists | Step-by-step heuristics tables | Convert to principles |
-| Weak hedging | "Try to", "maybe", "if possible" | Direct imperative: "Do X" |
-| Absolutes for judgment calls | "ALWAYS", "NEVER", "MUST" applied to non-invariants (when to search, ask, iterate, retry) | Decision rules: "When X, do Y; otherwise Z". Reserve absolutes for true invariants — safety rules, required fields, hard constraints |
-| Buried critical info | Important rules in middle | Surface prominently |
-| Over-engineering | 10 phases for a simple task | Match complexity to need |
+For non-trivial sections, pull techniques from `references/system-prompt-patterns.md` rather than inventing — verification loops, retrieval/tool budgets, output contracts, ambiguity handling, high-risk self-check, decision-rules.
 
-## When Updating Prompts
+## Specializations
 
-**High-signal changes only**: Every change must address a real failure mode or materially improve clarity. Don't change for the sake of change.
+The canonical template applies directly to **system prompts**. Two further classes — **skills** and **agents** — add conventions on top of the same skeleton.
 
-**Right-sized changes**: Don't overcorrect. One edge case doesn't warrant restructuring.
+### Skills
 
-**Questions before changing**:
-- Does this change address a real failure mode?
-- Am I adding complexity to solve a rare case?
-- Can this be said in fewer words?
-- Am I turning a principle into a rigid rule?
+A skill is a directory, not a file. SKILL.md is the entry; companion files (references/, assets/, scripts/) live alongside. On top of the canonical template:
 
-**Over-engineering warning signs**:
-- Prompt length doubled or tripled
-- Adding edge cases that won't happen
-- "Improving" clear language into verbose language
-- Adding examples for obvious behaviors
+- **Folder architecture** — directory with SKILL.md + appropriate companions. Domain knowledge and reference data live in companions, not front-loaded in SKILL.md (progressive disclosure).
+- **Description as trigger** — the frontmatter `description` field is a *trigger specification* for the model's matching algorithm, not a human summary. Pattern: **what + when + trigger terms users actually say**, under 1024 characters (Claude Code's enforced limit). Strong: "Adversarial code review that spawns a fresh-eyes subagent. Use for PR review, code audit, pre-merge quality check. Triggers: review my PR, audit this code, pre-merge check." Weak: "Helps with code review."
+- **Gotchas** — observed failure modes the skill actually hits, not theoretical risks. Specific (names the failure), actionable (says what to do instead), grounded (observed, not hypothetical). Highest-signal content in any skill.
+- **Setup config** — skills needing user-specific configuration (channel names, project IDs) persist it in a config file under the skill directory; read it on invocation rather than re-asking.
 
-## Memento Pattern (Multi-Phase Workflows Only)
-
-For prompts involving accumulated findings across steps:
-
-| LLM Limitation | Pattern Response |
-|----------------|------------------|
-| Context rot (middle content lost) | Write findings to log after EACH step |
-| Working memory is limited | Todo lists externalize tracked areas |
-| Synthesis failure at scale | Read full log BEFORE final output |
-| Recency bias | Refresh moves findings to context end |
-
-**Key disciplines**:
-- `→log` after each collection step (discipline, not capability)
-- `Refresh: read full log` before synthesis (restores context)
-- Acceptance criteria on each todo ("; done when X")
-
-## Prompt Structure Reference
-
-### Skills/Agents
+Skill scaffold (starting frame):
 
 ```markdown
 ---
@@ -133,79 +109,120 @@ description: 'What it does. When to use. Trigger terms.'
 
 **User request**: $ARGUMENTS
 
-{One-line mission - WHAT, not HOW}
+{One-line mission}
 
-{Empty input handling}
+{Branch on empty input: ask, error, or default}
 
-{Log file path if multi-phase}
-
-## {Sections based on actual workflow needs}
-
-{Goals and constraints per section}
-
-## Key Principles
-
-| Principle | Rule |
-|-----------|------|
-| {Discipline} | {Enforcement} |
+{Sections per the canonical template, scoped to the skill's job. Personality only if user-facing (conversational or customer-facing).}
 
 ## Gotchas
 
-{Known failure modes Claude hits — specific, actionable, observed}
-
-## Never Do
-
-- {Anti-pattern}
+{Observed failure modes — specific, actionable, grounded}
 ```
 
-### System Instructions
+See `references/skills.md` for the skill-type taxonomy and architecture patterns.
 
-```markdown
-## Role
-{Identity and stance — who the model is and how it behaves}
+### Agents
 
-## Goal
-{User-visible outcome — what the run produces}
+Agents run in **isolation** — they don't inherit the parent context. On top of the canonical template:
 
-## Success criteria
-{Anything that would cause dissatisfaction with the run:
- output correctness; validation passing (tests, lint, schema when available);
- time / iteration bounds; handling of non-success cases — retry, fallback, abstain, ask}
+- **Tool declarations** — explicit `tools:` in frontmatter listing every tool the agent needs. Agents run isolated; missing tool declarations mean the agent can't perform required actions. Audit: read what the agent does, identify every capability (explicit or implicit), verify all are declared.
+- **Isolation context** — agents start fresh. Anything the agent needs about the calling situation must be in the prompt the parent passes; the agent has no memory of the parent's conversation.
 
-## Constraints
-{MUST > SHOULD > PREFER priority — reserve MUST for true invariants per "Absolutes for judgment calls" anti-pattern}
+## Cross-cutting principles
 
-## Output
-{Format requirements if needed}
-```
+These apply to every section of every prompt.
 
-## Skill Description Pattern
+| Principle | Rule |
+|-----------|------|
+| **WHAT and WHY, not HOW** | State goals and constraints. Don't prescribe steps the model already knows how to do. |
+| **Trust capability, enforce discipline** | The model knows how to search, analyze, generate. Specify guardrails, not procedure. |
+| **Maximize information density** | Every word earns its place. Fewer words / same meaning / better. |
+| **Decision rules over absolutes** | Reserve MUST / NEVER / ALWAYS (and all-caps emphatic absolutes) for true invariants — safety rules, required output fields, hard constraints. For judgment calls, write decision rules: "When X, do Y; otherwise Z." Ordinary modal usage ("must hold", "must be true") is fine. |
+| **Avoid arbitrary numbers** | "Max 4 rounds" becomes rigid. State the principle: "stop when converged." Numbers earn their place only when they're the actual constraint. |
+| **Emotional tone** | Keep arousal low; aim for trusted-advisor; normalize failure in iterative prompts. (Full rationale in Emotional tone section below.) |
+| **Updates: high-signal only** | Every change must address a real failure mode or materially improve clarity. (Discipline in When updating section below.) |
 
-Descriptions drive auto-invocation. Pattern: **What + When + Triggers**
+## When updating an existing prompt
 
-```yaml
-# Weak
-description: 'Helps with prompts'
+Before each edit, ask:
 
-# Strong
-description: 'Craft or update LLM prompts from first principles. Use when creating new prompts, updating existing ones, or reviewing prompt structure.'
-```
+- Does this change address a real failure mode?
+- Am I adding complexity to solve a rare case?
+- Can this be said in fewer words?
+- Am I turning a principle into a rigid rule?
 
-- Include trigger terms users say
-- Specify when to use
-- Under 1024 chars
+Over-engineering warning signs:
 
-## Emotional Tone
+- Prompt length doubled or tripled
+- Edge cases that won't actually happen
+- "Improving" clear language into verbose language
+- Examples for behaviors the model already gets right
 
-Prompts shape the model's internal emotional state before generation begins. Research on transformer internals shows emotion concept representations that causally influence behavior — including sycophancy, reward hacking, and misalignment. These principles help calibrate the emotional context a prompt creates.
+Watch for **contradictory rules** and **priority collisions** — two rules that can't both hold (e.g., "be concise" alongside "err on the side of completeness"). Flag and resolve, don't leave both.
 
-| Principle | What It Means | Why |
+Not all repetition is bloat. Some is **intentional emphasis** that reinforces a critical rule — don't dedupe what's load-bearing. Decision rule: when a duplicated line states a true invariant (safety, output contract, hard constraint), keep it; when it restates a heuristic in different words, dedupe.
+
+## Anti-patterns
+
+| Anti-pattern | Example | Fix |
+|--------------|---------|-----|
+| Prescribing HOW | "First search, then read, then analyze..." | State goal: "Understand the pattern" |
+| Arbitrary limits | "Max 3 iterations", "2-4 examples" | Principle: "until converged", "as needed" |
+| Capability instructions | Generic "Use grep to search for matches" / "Use your tools to read files" | Remove |
+| Rigid checklists in authored prompts | Step-by-step procedure baked into the prompt for the model to follow at runtime | Convert to goal + constraints. Author-facing checklists (validation lists, review rubrics) and order-bearing patterns (memento, metaprompting) are exempt — they're not steps the model is told to follow at runtime |
+| Weak hedging / vague language | "Try to", "maybe", "if possible", "be helpful", "use good judgment", "when appropriate" | Direct imperative: "Do X" — and replace vague success criteria with checkable conditions |
+| Absolutes for judgment calls | "ALWAYS", "NEVER", "MUST" applied to non-invariants | Decision rule: "When X, do Y; otherwise Z" |
+| Buried critical info | Safety / output-contract rules buried mid-paragraph | Surface near the top of the section that owns them |
+| Over-engineering | 10 phases for a simple task | Match complexity to need |
+
+**Notes on carve-outs:**
+- *Capability instructions* — specific data-flow ("read `/etc/config` first") is fine; generic capability narration isn't.
+- *Weak hedging* — banned as top-level directives. Fine in explanatory prose where the surrounding sentence makes the action concrete.
+
+## Multi-phase: memento pattern
+
+For prompts that accumulate findings across steps (research, audits, multi-stage workflows). LLMs lose middle content (context rot), have limited working memory, fail at synthesis-at-scale, and exhibit recency bias. The memento pattern externalizes state to survive these failure modes.
+
+| Limitation | Pattern response |
+|------------|------------------|
+| Context rot (middle content lost) | Write findings to log after **each** step |
+| Limited working memory | Externalize tracked items to a todo / log |
+| Synthesis failure at scale | Read full log **before** final output |
+| Recency bias | Refresh moves findings to context end |
+
+**Disciplines** to drop into the prompt you author (literal instructions):
+- "Write a log entry after each collection step."
+- "Read the full log before synthesis."
+- "Each todo states a done-when condition."
+
+## Emotional tone
+
+Prompts shape the model's internal emotional state before generation. Research on transformer internals shows emotion concept representations that causally influence behavior — including sycophancy, reward hacking, and misalignment. Calibrate the emotional context the prompt creates.
+
+| Principle | What it means | Why |
 |-----------|---------------|-----|
-| **Keep arousal low** | Avoid urgency language ("CRITICAL", "you MUST"), excessive praise ("you're amazing at this!"), and pressure framing. | High-arousal emotions causally drive sycophancy (positive arousal) or corner-cutting and misalignment (negative arousal). |
+| **Keep arousal low** | Avoid urgency framing ("CRITICAL", "you MUST do this NOW", all-caps imperatives), excessive praise ("you're amazing at this!"), and pressure language. Ordinary modal usage ("must hold", "must be true") is fine. | High-arousal emotions causally drive sycophancy (positive arousal) or corner-cutting and misalignment (negative arousal). |
 | **Opening framing propagates** | The emotional tone set in a prompt's opening persists into the model's response planning. A tense opening produces a tense response. | Emotional context from early tokens propagates through later processing layers, even when subsequent content is neutral. |
-| **Normalize failure in iterative prompts** | For agentic or multi-step prompts, explicitly frame failure as acceptable: "if this approach doesn't work, try another." | Repeated failures build desperation that causally drives reward hacking and corner-cutting solutions. |
-| **Sycophancy-harshness tradeoff** | Pushing toward warmth and positivity increases sycophancy. Pushing away from warmth increases bluntness and harshness. Aim for a "trusted advisor" tone — honest pushback delivered with care. | Positive-valence emotion representations causally increase agreement-seeking behavior; their absence produces unnecessary harshness. |
-| **Avoid unintended high-stakes framing** | The model reads semantic intensity, not surface patterns. "This is critical to my career" or "failure is not an option" activates negative emotion representations even if intended as motivation. | Emotion representations respond to the meaning of situations — quantities, stakes, consequences — not to keywords. |
+| **Normalize failure in iterative prompts** | For agentic or multi-step prompts, frame failure as acceptable: "if this approach doesn't work, try another." | Repeated failures build desperation that causally drives reward hacking and corner-cutting. |
+| **Sycophancy ↔ harshness tradeoff** | Pushing toward warmth and positivity increases sycophancy. Pushing away from warmth increases bluntness. Aim for a "trusted advisor" tone — honest pushback delivered with care. | Positive-valence emotion representations causally increase agreement-seeking; their absence produces unnecessary harshness. |
+| **Avoid unintended high-stakes framing** | The model reads semantic intensity, not surface patterns. "This is critical to my career" or "failure is not an option" activates negative emotion representations even if intended as motivation. | Emotion representations respond to the meaning of situations — quantities, stakes, consequences — not keywords. |
+
+## Before shipping — validation checklist
+
+- [ ] Defines WHAT and WHY, not HOW (no procedural step-prescription where the model already knows the procedure)
+- [ ] Critical ambiguities resolved through user questions; minor ambiguities documented with chosen defaults
+- [ ] Domain terms defined, conventions confirmed, success criteria stated
+- [ ] Goals stated, not steps prescribed
+- [ ] Absolutes reserved for true invariants — judgment calls use decision rules
+- [ ] No arbitrary numbers (or justified if present)
+- [ ] Weak language replaced with direct imperatives
+- [ ] Critical rules surfaced near the top of their owning section
+- [ ] Complexity matches the task — no section longer than its job requires
+- [ ] Emotional tone calibrated — no all-caps urgency, no excessive praise; failure normalized if iterative
+- [ ] If multi-phase: memento pattern applied correctly
+- [ ] If user-facing (conversational or customer-facing): Personality section present and calibrated
+- [ ] If restructuring an existing prompt: high-signal content preserved, relocated, or folded — not silently dropped
 
 ## Gotchas
 
@@ -215,16 +232,9 @@ Prompts shape the model's internal emotional state before generation begins. Res
 - **Converting principles into rigid rules**: "Stop when converged" becomes "Max 5 iterations." Principles give flexibility; rigid rules create edge cases.
 - **Adding examples for behaviors Claude already knows**: Examples earn their place only when they demonstrate non-obvious or counter-intuitive behavior.
 
-## Validation Checklist
+## See also
 
-Before finalizing any prompt:
-
-- [ ] All ambiguities resolved through user questions
-- [ ] Domain context gathered (terms, conventions, constraints)
-- [ ] Goals stated, not steps prescribed
-- [ ] No arbitrary numbers (or justified if present)
-- [ ] Weak language replaced with direct imperatives
-- [ ] Critical rules surfaced prominently
-- [ ] Complexity matches the task
-- [ ] Each word earns its place
-- [ ] If multi-phase: memento pattern applied correctly
+- `references/system-prompt-patterns.md` — technique library for filling non-trivial sections (verification loops, retrieval/tool budgets, output contracts, ambiguity handling, high-risk self-check, decision-rules examples).
+- `references/metaprompting.md` — diagnose-from-failures → surgical-revision workflow for fixing prompts that fail in production.
+- `references/skills.md` — skill architecture patterns and skill-type taxonomy.
+- `/review-prompt` — sibling skill for deeper structural audit beyond the inline review branch.

--- a/.claude/skills/prompt-engineering/references/metaprompting.md
+++ b/.claude/skills/prompt-engineering/references/metaprompting.md
@@ -1,0 +1,124 @@
+# Metaprompting
+
+Loaded when an existing prompt fails in production and you want the model to help diagnose and fix it. Different verb from authoring: instead of writing a prompt from scratch, you use a model to inspect a prompt and its failure traces, then propose a surgical revision — the full prompt redelivered with minimal targeted edits.
+
+The shape is two separate calls — diagnose first, revise second. Skipping the diagnosis step (asking directly for a fix) tends to produce vague or shallow rewrites that miss the real cause.
+
+## Pre-flight check — when metaprompting is the wrong tool
+
+- If the prompt is missing a goal or success criteria entirely, no diagnosis call will surface it — fix the gap directly.
+- If the model lacks a capability the prompt is asking for (e.g., reliable arithmetic on long numbers, accurate citations without retrieval), no prompt change will fix it — change the architecture.
+- If the failure is a single bug from a typo or contradiction visible on a quick read, just fix it.
+
+## Step 1 — Diagnose only
+
+Feed the model the current system prompt plus a small set of logged failures. Ask for root-cause analysis. **Do not ask for a solution yet.** The output is an analysis of which lines of the prompt are causing which observed behaviors.
+
+**Constraints** to include in the diagnosis call:
+- Identify distinct failure modes — name and describe each.
+- For each failure mode, quote or paraphrase the specific lines of the system prompt likely causing or reinforcing it. Include contradictions (e.g., "be concise" vs. "err on the side of completeness").
+- For each failure mode, briefly explain how those lines steer the agent toward the observed behavior.
+- Return the analysis in a structured-but-readable format.
+
+**Example diagnosis prompt**:
+
+```
+You are a prompt engineer debugging a system prompt for an agent that
+[describe agent purpose].
+
+You are given:
+
+1) The current system prompt:
+<system_prompt>
+[PASTE PROMPT]
+</system_prompt>
+
+2) A small set of logged failures. Each entry has:
+- query
+- tools_called (as actually executed)
+- final_answer (shortened if needed)
+- eval_signal (rating, comment, or grader judgment)
+
+<failure_traces>
+[PASTE TRACES]
+</failure_traces>
+
+Tasks:
+1) Identify each distinct failure mode (e.g., tool_usage_inconsistency,
+   output_length_drift, autonomy_vs_clarification).
+2) For each failure mode, quote or paraphrase the specific lines of the
+   system prompt most likely causing or reinforcing it. Include any
+   contradictions.
+3) Briefly explain how those lines are steering the agent toward the
+   observed behavior.
+
+Output format:
+
+failure_modes:
+- name: ...
+  description: ...
+  prompt_drivers:
+    - line_or_paraphrase: ...
+      why_it_matters: ...
+```
+
+## Step 2 — Surgical revision
+
+Feed the diagnosis from Step 1 back into a separate call. Ask for a patch — small explicit edits that resolve the issues without rewriting the prompt.
+
+**Constraints** to include in the revision call:
+- Do not redesign the agent from scratch.
+- Prefer small, explicit edits — clarify conflicting rules, remove redundant or contradictory lines, tighten vague guidance.
+- Make tradeoffs explicit (e.g., "when to prioritize concision over completeness", "exactly when tools must vs. must not be called").
+- Keep overall structure and length roughly similar to the original, unless a short consolidation removes obvious duplication.
+
+Re-include the original system prompt verbatim in the revision call — Step 2 doesn't inherit context from Step 1.
+
+**Example revision prompt**:
+
+```
+You previously analyzed this system prompt and its failure modes.
+
+System prompt:
+<system_prompt>
+[PASTE PROMPT]
+</system_prompt>
+
+Failure-mode analysis:
+[PASTE STEP 1 OUTPUT]
+
+Propose a surgical revision of the system prompt that reduces the observed
+issues while preserving the good behaviors.
+
+Constraints:
+- Do not redesign from scratch.
+- Prefer small, explicit edits.
+- Make tradeoffs explicit (when to prioritize X over Y, exactly when tool A
+  must vs. must not be called).
+- Keep structure and length roughly similar to the original, unless a short
+  consolidation removes obvious duplication.
+
+Output:
+1) patch_notes: a concise list of changes and the reasoning behind each
+   (e.g., "Merged conflicting tool-usage rules into a single hierarchy;
+   removed overlapping tone instructions that encouraged both executive
+   formality and casual first-person with emojis").
+2) revised_system_prompt: the full updated system prompt with edits applied,
+   ready to drop in.
+```
+
+After applying the patch, re-run the failing queries. Repeat the cycle until the failure modes are resolved.
+
+**Don't stack patches.** If a patch creates new failures, restart at Step 1 with the new failure as input — stacking patches obscures the root cause and produces brittle prompts.
+
+**Stop if the cycle isn't converging.** If repeated cycles produce no improvement on the named failure modes, the issue likely isn't a prompt problem. Revisit the pre-flight check at the top of this file — model capability gaps and missing goals don't fix with metaprompting.
+
+## Pitfalls of the metaprompting workflow itself
+
+**Too many failure types in one metaprompt.** When the failure traces span unrelated failure modes (output too long + tool over-eagerness + unit confusion + hallucinated facts, all in one batch), the diagnosis call struggles to connect threads and the patch call produces shallow fixes. Group similar failures and run the cycle separately for each group. One cycle per coherent failure mode.
+
+**Accepting overly specific patch recommendations.** A single patch call may produce edits that fix the specific traces you fed it but generalize poorly — the model overfits to the examples. Run the patch call multiple times and look for changes that appear across runs; those are cross-cutting suggestions. Treat single-run-only suggestions as candidates for a smaller targeted patch rather than the main fix.
+
+## When to add evals
+
+Metaprompting without evals is iteration in the dark. Once a failure mode is named, write the smallest eval that distinguishes the failing behavior from the desired behavior — even a tiny hand-graded set works. Use it to confirm the patch actually helps before merging.

--- a/.claude/skills/prompt-engineering/references/system-prompt-patterns.md
+++ b/.claude/skills/prompt-engineering/references/system-prompt-patterns.md
@@ -1,0 +1,164 @@
+# System Prompt Patterns
+
+Loaded when filling non-trivial sections of the canonical template. Each pattern names *when* it earns its place, *what* it does, and gives a concrete example you can adapt. These are techniques, not architectural sections — they slot into Constraints, Success criteria, Output, or Stop rules in the canonical template.
+
+## End-of-run verification
+
+**When to apply** — the prompt drives an agent that produces high-impact or irreversible actions (commits, deletes, deploys) or evidence-grounded output where requirement misses, ungrounded claims, or format drift would cause real damage.
+
+**What it does** — adds a lightweight self-check pass after the workflow looks complete, before the irreversible step. Catches requirement misses, ungrounded factual claims, and schema drift before they ship.
+
+**Example** (place inside Constraints or just above Stop rules):
+
+```
+Before any final answer or irreversible step, run a self-check:
+does the output cover what the user asked? Are the factual claims grounded
+in tool output, retrieved content, or supplied context — not memory? Does
+the format match what was requested? If the next action has external
+consequences, narrate the action plus its parameters and pause for confirm.
+
+If any check fails, revise before continuing — never paper over a gap.
+```
+
+## Per-action narrate-execute-confirm
+
+**When to apply** — agents that mutate external state with each tool call (file writes, API calls, deploys). Sibling pattern to end-of-run verification, not a substitute. Use both for high-impact agents: per-action for the running discipline, end-of-run for final coverage.
+
+**What it does** — applies a tight discipline to every state-changing tool call so each mutation is observable and recoverable.
+
+**Example** (place inside Constraints):
+
+```
+Treat every state-changing tool call as narrate → execute → confirm. The
+narrate step states what you're about to do and the inputs. The confirm
+step states the outcome and what you checked. Skip neither.
+```
+
+## Tool-call escalation rule
+
+**When to apply** — the prompt drives an agent with search, retrieval, or tool-loop access. Without a budget, agents over-tool ("just one more search") inflating latency and cost without improving correctness, or under-tool when it matters.
+
+**What it does** — names the conditions under which another tool call is warranted, and the conditions under which it isn't. Replaces "use tools when needed" (vague — model errs in both directions) with a decision rule the model can apply.
+
+**Example** (place inside Constraints):
+
+```
+Default to the smallest number of searches that answers the question.
+
+When current results don't answer the core question, a required fact
+(id, date, source) is missing, the user asked for comparison or
+exhaustive coverage, or a named artifact must be opened — escalate
+with another search. Otherwise, stop and answer.
+
+When you'd search to polish phrasing, add decorative citations, or
+support generic wording — don't.
+```
+
+Adapt verbs (`retrieval`, `search`, `tool`) to the agent's available tools. The principle is *escalate-on-condition*, not a fixed cap.
+
+## Output contract
+
+**When to apply** — the consumer of the output has specific needs (audience, length, structure, voice) and the default "produce a good answer" leads to walls of text, missing structure, or wrong register.
+
+**What it does** — names the audience, the length envelope, the structural choices, and the editing posture (improve vs. preserve) up front. Output drift often resolves at this layer alone — try this before adding constraints elsewhere.
+
+**Example for a generation task** (place inside Output):
+
+```
+Audience: senior engineers reviewing a pull request. Familiar with the codebase
+conventions; unfamiliar with this specific change.
+
+Length: short enough to read in one sitting. Conclusion first, reasoning second,
+caveats last.
+
+Structure: short paragraphs. Use bullets only for lists of three or more
+parallel items. Headers only when the answer covers more than one topic.
+```
+
+**Example for an editing task** (place inside Output):
+
+```
+Preserve the original artifact's length, structure, voice, and genre. Quietly
+improve clarity, flow, and correctness. Do not add new claims, new sections,
+or a more promotional tone unless explicitly asked.
+```
+
+## Ambiguity handling
+
+**When to apply** — the prompt receives free-form user input that may be under-specified, ambiguous, or assume facts the model can't verify (recent prices, current policies, internal context).
+
+**What it does** — gives the model a deterministic rule for when to ask versus when to interpret. The default behavior — silently picking one interpretation — is the worst option; this pattern chooses between two better options and tells the model which one applies.
+
+**Example** (place inside Constraints or Success criteria):
+
+```
+When the request is ambiguous or underspecified:
+- Ask the smallest number of precise clarifying questions that resolve
+  material ambiguity — typically one or two — when missing information
+  would materially change the answer or the chosen action.
+- Otherwise present the most likely plausible interpretations with explicit
+  assumptions, and answer the most likely one. Label the assumptions.
+
+When external facts may have changed and tools are not available:
+- Answer in general terms and state that details may have changed since
+  the model's training cutoff. Do not invent figures, dates, or sources.
+
+When uncertain, prefer "based on the provided context …" to absolute claims.
+```
+
+## High-risk self-check
+
+**When to apply** — the prompt operates in legal, financial, medical, compliance, or safety-sensitive contexts where an overstated claim or unstated assumption causes real harm.
+
+**What it does** — adds a final scan for the specific failure modes that hurt in high-risk domains: ungrounded numbers, hidden assumptions, overstrong language. Doesn't replace domain validation; reduces the rate of obvious tells.
+
+**Example** (place inside Constraints or just above Stop rules):
+
+```
+Before returning an answer in a legal, financial, compliance, medical, or
+safety-sensitive context, scan the response for:
+- Specific numbers or claims not grounded in the provided context.
+- Unstated assumptions the user may not share.
+- Overly strong language ("always", "guaranteed", "never").
+
+Soften or qualify any of the above and state assumptions explicitly. If a
+claim cannot be grounded, replace it with a description of what would need
+to be checked.
+```
+
+## Decision rules (alternative to absolutes)
+
+**When to apply** — anywhere a constraint involves a judgment call: when to search, when to ask, when to retry, when to escalate, when to use tool A versus tool B. Absolutes (MUST / NEVER / ALWAYS) on judgment calls produce brittle behavior — either over-fires or under-fires depending on phrasing.
+
+**What it does** — replaces the absolute with an explicit conditional. The model gets a real rule to evaluate instead of a vague directive.
+
+**Examples** (replace the absolute with the rule):
+
+```
+Bad:  Always ask the user before making assumptions.
+Rule: When a missing piece of information would materially change the chosen
+      action, ask. When the missing piece is recoverable from a sensible
+      default (and the user can correct course later), proceed and label
+      the assumption.
+
+Bad:  Never use tools for simple questions.
+Rule: For factual questions about specific entities (people, companies,
+      products) prefer tools. For conceptual or definitional questions
+      ("how does X work in general") answer from internal knowledge.
+
+Bad:  Always be concise.
+Rule: For status updates and acknowledgements: one or two sentences.
+      For explanations and recommendations: as long as needed for the user
+      to act with confidence.
+
+Bad:  Always cite sources.
+Rule: Cite sources for any factual claim about specific entities, prices,
+      dates, identifiers, or quoted text. Conceptual statements and
+      methodology do not need citation.
+```
+
+Reserve absolutes for true invariants — see the "Decision rules over absolutes" cross-cutting principle in SKILL.md for the canonical statement.
+
+---
+
+These patterns compose — pick by failure mode, not by category. Add them where they apply, not speculatively.


### PR DESCRIPTION
## Summary

Syncs `.claude/skills/prompt-engineering/` with `doodledood/claude-code-plugins` prompt-engineering plugin v2.6.0 (previous sync was v2.5.1 in #104).

## Changes

- **`SKILL.md`** — major restructure:
  - Adds an explicit canonical template (Role, Personality, Goal, Success criteria, Constraints, Output, Stop rules) with the Success / Constraints / Stop-rules boundary discussion.
  - Adds a "diagnosing a failing prompt" branch routing through `references/metaprompting.md`.
  - Adds a pre-shipping validation checklist.
  - Refines anti-patterns (capability-instructions carve-out, rigid-checklists carve-out for memento / metaprompting / author-facing rubrics).
  - Tightens the emotional-tone table (low arousal, sycophancy↔harshness tradeoff, normalize failure).
  - Description rewritten as a trigger spec (adds "review", "diagnose", trigger-term list).

- **`references/metaprompting.md`** (new) — diagnose-from-failures → surgical-revision workflow for fixing prompts that fail in production, with a pre-flight check for when metaprompting is the wrong tool.

- **`references/system-prompt-patterns.md`** (new) — technique library (verification loops, retrieval/tool budgets, output contracts, ambiguity handling, high-risk self-check, decision-rules examples) referenced from SKILL.md when filling non-trivial sections.

Local files now match upstream byte-for-byte (`diff -r` clean).

## Out of scope

`claude-plugins/manifest-dev/skills/define/tasks/PROMPTING.md` — consumer-side task file, not part of the upstream prompt-engineering plugin. Not touched here; if v2.6.0 anti-pattern revisions warrant downstream changes there, those belong in a follow-up PR.

## Test plan

- [x] `diff -r .claude/skills/prompt-engineering /tmp/upstream/.../prompt-engineering` returns no differences
- [ ] Spot-check that `/prompt-engineering` slash command still loads and references resolve

https://claude.ai/code/session_012UTZoppd93kBVws9DygfDY

---
_Generated by [Claude Code](https://claude.ai/code/session_012UTZoppd93kBVws9DygfDY)_