### PR TITLE
chore(dist): sync /define SKILL.md tightening (#112) to gemini, opencode, codex

### DIFF
--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "eda68ea64154410f439314dc88df6ed1d028c68d",
+  "source_commit": "c817b391918393b66d88acb6ce7663e2ba75f52c",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-01T16:39:18Z"
+  "synced_at": "2026-05-02T07:44:57Z"
 }

--- a/dist/codex/skills/define/SKILL.md
+++ b/dist/codex/skills/define/SKILL.md
@@ -12,13 +12,13 @@ Build **shared understanding** between you and the user about the work, then enc
 - **How we'll get there** — Approach (initial direction, expect adjustment)
 - **Rules we must follow** — Global Invariants
 
-**Every criterion discovered NOW is one fewer rejection later.** Comprehensive means surfacing latent criteria: requirements the user doesn't know they have until probed. Aim for high coverage; amendments handle what emerges during implementation.
+**Every criterion discovered now is one fewer rejection later.** Comprehensive means surfacing latent criteria: requirements the user doesn't know they have until probed. Coverage converges when the five Coverage Goal tests pass (see Convergence); amendments handle what emerges during implementation.
 
-Output: `/tmp/manifest-{timestamp}.md`
+Output: `/tmp/manifest-{timestamp}.md` where `{timestamp}` is `YYYYMMDD-HHMMSS` in UTC. Use the same `{timestamp}` for the discovery log (`/tmp/define-discovery-{timestamp}.md`) so the two files can be linked as a pair.
 
 ## Prerequisites
 
-If thinking-disciplines is not active, invoke `manifest-dev:thinking-disciplines` before any user-facing question. Apply throughout: every question, assessment, synthesis.
+Invoke `manifest-dev:thinking-disciplines` at the start of /define, before any other action. Apply throughout: every question, assessment, synthesis. (Idempotent — safe if already active.)
 
 ## Input
 
@@ -27,18 +27,19 @@ If thinking-disciplines is not active, invoke `manifest-dev:thinking-disciplines
 | Flag | Values | Default | Behavior |
 |------|--------|---------|----------|
 | `--interview` | `minimal` \| `autonomous` \| `thorough` | `thorough` | Sets interview mode (see Interview Style). Invalid value → halt: "Invalid interview style '<value>'. Valid styles: minimal \| autonomous \| thorough". |
-| `--medium` | `local` (only currently supported) | `local` | Sets communication channel. Other values → halt: "Medium '<value>' not yet supported. Currently supported: local". |
-| `--amend <path>` | manifest path | — | Amend an existing manifest. See `references/AMENDMENT_MODE.md`. |
-| `--from-do` | flag (used with `--amend`) | — | Marks amendment as triggered by `/do`. See `references/AMENDMENT_MODE.md` Three Contexts §2 (From /do). |
-| `--canvas` | flag | — | When present, follow `references/CANVAS_MODE.md`. |
+| `--mode` | `efficient` \| `balanced` \| `thorough` | `thorough` | Sets verification intensity (consumed by /do and the Verification Loop). Recorded in the manifest's `Mode` field. Invalid value → halt: "Invalid mode '<value>'. Valid modes: efficient \| balanced \| thorough". |
+| `--medium` | `local` | `local` | Sets communication channel. Other values → halt: "Medium '<value>' not yet supported. Currently supported: local". |
+| `--amend <path>` | manifest path | — | Amend an existing manifest (see Pre-flight). Missing argument → halt: "Cannot amend: --amend requires a manifest path." Path doesn't exist → halt: "Cannot amend: '<path>' not found." |
+| `--from-do` | boolean flag (used with `--amend`) | — | Marks amendment as triggered by `/do`. Accepts no value. See `references/AMENDMENT_MODE.md` Three Contexts §2 (From /do). |
+| `--canvas` | boolean flag | — | When present, follow `references/CANVAS_MODE.md` (it owns its own activation gate, lifecycle, and run-order placement). Accepts no value. |
 
-Flags can appear anywhere in `$ARGUMENTS`. If no arguments provided, ask: "What would you like to build or change?"
+Flags can appear anywhere in `$ARGUMENTS`. If `$ARGUMENTS` contains no task description (empty, or only flags with no free-form text), ask: "What would you like to build or change?" Exception: skip this prompt when **any** amend trigger applies — `--amend` is set, OR `$ARGUMENTS` contains a `/tmp/manifest-*.md` path (a bare path counts as routing, not as task text). Pre-flight handles amend context: the task description may live in conversation, the prior manifest, or be elaborated during the amendment interview.
 
 ## Pre-flight: Resolve Manifest Context
 
-Pre-flight resolves to **amend** or **fresh**:
+Pre-flight resolves to **amend** or **fresh**. When amend is selected, follow `references/AMENDMENT_MODE.md` for amendment rules.
 
-- `--amend <path>` set, or input plainly references a `/tmp/manifest-*.md` path → **amend** that manifest. Confirm approach with the user only if the referenced manifest's relationship to the new task is unclear.
+- `--amend <path>` set, OR `$ARGUMENTS` contains any `/tmp/manifest-*.md` path → **amend** that manifest. Confirm approach with the user only if the referenced manifest's relationship to the new task is unclear.
 - Transcript contains a prior `Manifest complete: /tmp/manifest-*.md` line, or such a path is mentioned in the conversation → read `references/AMENDMENT_MODE.md` "Session-Default Detection"; that section's branch determines amend or fresh.
 - Else → **fresh**.
 
@@ -48,13 +49,17 @@ Pre-flight resolves to **amend** or **fresh**:
 
 **Why:** Work already on the branch belongs in the manifest (Cumulative Manifest Rule — see `references/AMENDMENT_MODE.md`).
 
-**Base inference** (first hit wins): upstream tracking branch → `origin/main` → `origin/master` → ask the user once. Halt seeding if the user declines.
+**Base inference** (first hit wins): upstream tracking branch → `origin/main` → `origin/master` → ask the user once.
 
-Diff branch against base, read the diff and commit messages. Incorporate the existing changeset into the new manifest's Intent (what's already done) and starting Deliverables (work-in-progress as prior context, with new ACs added on top for completion + the new task). The interview confirms or adjusts what was inferred.
+If the user declines to identify a base, proceed with a **fresh** manifest and log the existing branch commits as a Known Assumption: `[ASM-N] Branch has commits ahead of an unidentified base | Default: treat as out of manifest scope | Impact if wrong: existing work isn't tracked or verified by this manifest.`
+
+When base is identified, diff branch against base, read the diff and commit messages. Incorporate the existing changeset into the new manifest's Intent (what's already done) and starting Deliverables (work-in-progress as prior context, with new ACs added on top for completion + the new task). The interview confirms or adjusts what was inferred.
 
 **Skip cleanly when:** no commits ahead of base, or Pre-flight resolved to amend.
 
 ## Domain Guidance
+
+**Where this fits in the run order:** Pre-flight → Branch-Diff Seeding → Read task files (this section) → Multi-Repo detection → Encode quality gates + Defaults → Load interview mode file → Context Assessment → Interview → Approach Section → manifest write → Verification Loop → Summary → Complete.
 
 Domain-specific guidance lives in `tasks/`:
 
@@ -74,22 +79,21 @@ Domain-specific guidance lives in `tasks/`:
 
 **Exception.** PROMPTING tasks do NOT compose with CODING.md unless the task also changes executable code. PROMPTING.md has its own quality gates. When a task changes both prompts AND code, apply both, scoping each to the relevant files.
 
-**Task file structures are presumed relevant.** They contain quality gates, reviewer agents, risks, scenarios, and trade-offs — domain-specific angles outside your default coverage. Quality gates auto-include; Resolvable structures (risks, scenarios, trade-offs) must be **resolved** per interview mode, or explicitly skipped with logged reasoning (e.g., "CODING.md concurrency risk skipped: single-threaded CLI tool"). Silent drops are the failure mode, not over-asking.
+**Task file structures are presumed relevant.** They contain quality gates (with their reviewer-agent fields), risks, scenarios, and trade-offs — domain-specific angles outside your default coverage. Quality gates auto-include; Resolvable structures (risks, scenarios, trade-offs) must be **resolved** per interview mode, or explicitly skipped with logged reasoning (e.g., "CODING.md concurrency risk skipped: single-threaded CLI tool"). Silent drops are the failure mode, not over-asking.
 
 **Task file content types:**
 - **Quality gates** (`## Quality Gates` section, any structured format with thresholds/criteria) — auto-include as INV-G*. Omit clearly inapplicable with logged reasoning. User reviews manifest.
 - **Resolvable** (tables/checklists: risks, scenarios, trade-offs) — resolve via interview, encode as INV/AC, or explicitly skip.
 - **Compressed awareness** (bold-labeled one-line summaries) — informs probing; no resolution needed.
-- **Process guidance hints** (counter-instinctive practices LLMs would miss). Two modes: **candidates** (presented as a batch after scenarios, resolved per interview mode) and **defaults** (`## Defaults` section, included in manifest without probing, user reviews and removes if not applicable). Both become PG-*.
+- **Process guidance hints** (counter-instinctive practices LLMs would miss). Two modes:
+  - **Defaults** (`## Defaults` section in the task file) — encoded pre-interview alongside Quality Gates; included in manifest without probing; user reviews and removes if not applicable.
+  - **Candidates** — held until Failure Modes scenarios resolve, then presented as a single batch and resolved per interview mode.
+  - Both become PG-*.
 - **Reference files** (`references/*.md`) — lookup data for `/verify` agents. Do not load during interview.
 
 **Encode quality gates and Defaults immediately after reading task files — before the interview.** Log each as `- [x]` RESOLVED.
 
 Task files set the floor, not the ceiling — probe beyond when domain understanding warrants.
-
-## Amendment Mode
-
-When `--amend <path>` is present (explicitly or via Pre-flight default), read `references/AMENDMENT_MODE.md` for amendment rules.
 
 ## Multi-Repo Scope
 
@@ -115,7 +119,7 @@ Five goals that must be met before convergence. Each defines WHAT must be true a
 | Reference Class | Can you name the task type and its common failure modes? |
 | Failure Modes | All scenarios have dispositions (encoded, scoped out, or mitigated)? |
 | Positive Dependencies | Load-bearing assumptions surfaced and each has a disposition? |
-| Process Self-Audit | Every identified scope-creep pattern has a disposition (PG, INV, accepted, already-covered). Skip when scope is bounded to a single deliverable with no incremental-addition risk. |
+| Process Self-Audit | Every identified scope-creep pattern has a disposition (PG, INV, accepted, already-covered). Skippable for narrow scopes — see Process Self-Audit § Skip rule. |
 
 ### Domain Understanding
 
@@ -165,7 +169,9 @@ Starting points: existing infrastructure/tooling you're relying on, user behavio
 
 ### Process Self-Audit
 
-**What must be true:** process self-sabotage patterns — decisions reasonable individually but compounding into failure — are identified and resolved. **Skip when scope is bounded to a single deliverable with no incremental-addition risk.**
+**What must be true:** process self-sabotage patterns — decisions reasonable individually but compounding into failure — are identified and resolved.
+
+**Skip rule:** scope is bounded to a single deliverable with no incremental-addition risk.
 
 Common patterns (not exhaustive): small scope additions ("just one more thing"), edge cases deferred ("we'll handle that later"), "temporary" solutions that become permanent, process shortcuts that erode quality.
 
@@ -180,11 +186,15 @@ Resolve from `--interview` argument; default `thorough`. Load the mode file:
 
 Follow the loaded mode's rules for question format, flow, checkpoints, finding-sharing, and convergence for the rest of the run.
 
-**Style is dynamic.** The flag sets starting posture, not a rigid lock. Shift when the user's behavior signals a different mode. After a shift, follow the new mode from that point. Log style shifts to the discovery file.
+**Style switches only on explicit user request.** The flag sets starting posture; the mode stays until the user explicitly asks to switch (e.g., "be more concise", "switch to autonomous", "ask everything"). Don't infer mode shifts from tone or terseness alone — terse answers within a mode are valid mode-internal signals, not switches. After a switch, follow the new mode from that point and log it to the discovery file.
 
-## Discovery Disciplines
+**Auto-switch variant.** When the user signals "enough" / "ship it" / "good enough" / "stop asking", a one-way switch to `autonomous` fires with auto-decide semantics on remaining `[ ]` items — see Convergence § Termination & escalation rules — Mode-switch escalation.
 
-**Discovery log** — write to `/tmp/define-discovery-{timestamp}.md` immediately after each discovery. The log is source of truth — another agent reading only the log could resume the interview.
+## Discovery & Question Disciplines
+
+### Discovery log
+
+Write to `/tmp/define-discovery-{timestamp}.md` immediately after each discovery — same `{timestamp}` as the manifest. The log is source of truth: another agent reading only the log could resume the interview.
 
 Seed with a Context Assessment before probing — what's already understood and what's missing:
 
@@ -205,49 +215,70 @@ Every actionable item gets logged with status:
 
 **Read full log before synthesis.** Unresolved `- [ ]` items are addressed first.
 
+### When to ask
+
 **Search before asking.** Don't ask the user about facts you could discover through exploration. Only ask when multiple plausible candidates exist, searches yield nothing, or the ambiguity is about intent not fact.
 
 **Ask early on preferences.** Trade-offs, priorities, and scope decisions cannot be discovered. Ask directly with concrete options and a recommended default.
-
-**Resolve all Resolvable task file structures.** After reading task files, extract every Resolvable table and checklist. Items already resolved in conversation context are logged as `- [x]` RESOLVED with source — not re-probed. Remaining items are `- [ ]` PENDING. Resolve each per interview mode, or skip with logged justification. Don't defer to synthesis.
-
-## Question Disciplines
-
-**Decisions lock through structured options.** Questions that lock manifest content present concrete options. The messaging file defines the tool and format; the interview mode defines when and how.
-
-**Confirm before encoding.** Exploration-discovered constraints require confirmation per interview mode before becoming invariants. Exception: task-file quality gates and Defaults are auto-included per Domain Guidance.
-
-**Encode explicit constraints.** User-stated preferences, requirements, and constraints must map to an INV or AC.
 
 **Probe approach constraints.** Beyond WHAT to build, ask HOW: tools to use or avoid, methods required or forbidden, automation vs manual. These become process invariants.
 
 **Probe input artifacts.** When input references external documents (URLs, file paths, named documents), determine whether they should be verification sources. If yes, encode as Global Invariant.
 
+**Resolve all Resolvable task file structures.** After reading task files, extract every Resolvable table and checklist. Items already resolved in conversation context are logged as `- [x]` RESOLVED with source — not re-probed. Remaining items are `- [ ]` PENDING. Resolve each per interview mode, or skip with logged justification. Don't defer to synthesis.
+
+### How to ask
+
+**Decisions lock through structured options.** Questions that lock manifest content present concrete options. The messaging file defines the tool and format; the interview mode defines when and how.
+
 **Batch related questions.** Group questions into a single turn covering one coherent topic; don't drip-feed.
+
+**Confirm before encoding.** Exploration-discovered constraints require confirmation per interview mode before becoming invariants. Exception: task-file quality gates and Defaults are auto-included per Domain Guidance.
+
+**Encode explicit constraints.** User-stated preferences, requirements, and constraints must map to an INV or AC.
 
 ## Encoding Disciplines
 
-**Insights become criteria.** Every discovery must be encoded as INV-G*, AC-*, or explicitly scoped out. Unencoded insights are aspirational, not enforced.
+**Insights become criteria.** Every discovery must be encoded — as INV-G*, AC-*, PG-*, R-*, T-*, or ASM-* — or explicitly scoped out with logged reasoning. Unencoded insights are aspirational, not enforced. (See ID Scheme for the full encoding catalog.)
 
 **Auto-decided items.** When interview style causes an item to be auto-decided (agent picks recommended option instead of asking), encode it normally as INV/AC/PG with an "(auto)" annotation, AND list it in Known Assumptions with the reasoning for the chosen option.
 
 **Automate verification.** When a criterion seems to require manual verification, push back: suggest how it could be automated, or ask the user for ideas. Manual only as last resort or when the user explicitly requests it.
 
-**Verification phases.** Each criterion's verify block has an optional `phase:` field (numeric, default 1). **Group by iteration speed — faster feedback loops run first.** Fast checks (agent reviewers, bash) stay in default phase. Slow checks (e2e tests, deploy-dependent) go in later phases. Manual goes last. Omit `phase:` for phase 1; non-contiguous phases are valid.
+**Verification phases.** Each criterion's verify block has an optional `phase` field — an unquoted integer, default 1 (e.g., `phase: 2`, not `phase: "2"`). **Group by iteration speed — faster feedback loops run first.** Fast checks (agent reviewers, bash) stay in default phase. Slow checks (e2e tests, deploy-dependent) go in later phases. Manual goes last. Omit `phase` for phase 1; non-contiguous phases are valid.
 
 ## Convergence
 
 The interview mode defines probing aggressiveness. Convergence requires:
-- All five Coverage Goal convergence tests pass
+- All applicable Coverage Goal convergence tests pass (Process Self-Audit may be skipped per its own rule)
 - No unresolved `- [ ]` items in the discovery log
 - Quality gates from task files encoded as INV-G* (or omitted with logged reasoning)
 - Defaults encoded as PG-*
 
-Low-impact unknowns become Known Assumptions. User can signal "enough" to override.
+Low-impact unknowns become Known Assumptions.
+
+### Termination & escalation rules
+
+Two distinct kinds of trigger:
+
+#### Stop conditions
+
+These end /define:
+
+1. Verifier returns COMPLETE and the user approves the summary.
+2. User explicitly invokes `/do`. Behavior depends on where /define is in the run:
+   - **Before synthesis is complete** (interview still has unresolved items, or manifest not yet written): switch to `autonomous` interview mode, finish synthesis and the Verification Loop with auto-decisions (each remaining `[ ]` item gets the recommended default, encoded with `(auto)` annotation and logged in Known Assumptions), write the manifest, then hand off to /do without waiting for summary approval.
+   - **At the summary stage** (manifest already written, awaiting approval): do not redo synthesis. Print `Manifest complete: ...` per Complete and hand off to /do immediately.
+
+#### Mode-switch escalation
+
+/define continues — only the interview mode changes:
+
+- User signals "enough" (or equivalent: "ship it", "good enough", "stop asking"). Effect: switch interview mode to `autonomous` from this point. Auto-decide remaining `[ ]` items per autonomous mode rules (recommended default chosen, encoded with `(auto)` annotation, logged in Known Assumptions). Continue through synthesis and the Verification Loop; expect to terminate via Stop condition 1.
 
 ## Approach Section (Complex Tasks)
 
-After defining deliverables, probe for **initial** implementation direction. Skip when the task has a single component with no architectural choice to make.
+After defining deliverables, probe for **initial** implementation direction when the inclusion rule below applies.
 
 **Why "initial":** Approach provides starting direction, not a rigid plan. Plans break on reality — unexpected constraints, better patterns, surprising dependencies. The goal is enough direction to start confidently, with trade-offs documented so implementation can adjust autonomously when reality diverges.
 
@@ -259,7 +290,7 @@ After defining deliverables, probe for **initial** implementation direction. Ski
 
 **Trade-offs** — decision criteria for competing concerns. "When facing [tension], priority? [A] vs [B]?" Format: `[T-N] A vs B → Prefer A because X`. Enables autonomous adjustment during /do.
 
-**When to include:** multi-deliverable tasks, unfamiliar domains, architectural decisions, high-risk implementations. The interview reveals if it's needed.
+**Inclusion rule (the one source of truth).** Include the Approach Section when ANY of: the task is multi-deliverable, the domain is unfamiliar, there's an architectural decision to make, or the implementation is high-risk. Skip only when none apply. The interview surfaces which triggers are present.
 
 **Architecture vs Process Guidance.** Architecture = structural decisions (components, patterns, structure). Process Guidance = methodology constraints (tools, manual vs automated). "Add executive summary covering X, Y, Z" is Architecture. "No bullet points in summary sections" is Process Guidance.
 
@@ -282,9 +313,9 @@ Three categories, each covering output or process:
 ## 1. Intent & Context
 - **Goal:** [High-level purpose]
 - **Mental Model:** [Key concepts to understand]
-- **Mode:** efficient | balanced | thorough *(optional, default: thorough — controls verification intensity during /do)*
-- **Interview:** minimal | autonomous | thorough *(optional, default: thorough — recorded so --amend can inherit the original interview style)*
-- **Medium:** local *(optional, default: local — currently only local is supported)*
+- **Mode:** efficient | balanced | thorough *(default: thorough — controls verification intensity during /do; set via `--mode`)*
+- **Interview:** minimal | autonomous | thorough *(default: thorough — recorded so --amend can inherit the original interview style)*
+- **Medium:** local *(default: local)*
 
 ## 2. Approach (Complex Tasks Only)
 *Initial direction, not rigid plan. Provides enough to start confidently; expect adjustment when reality diverges.*
@@ -310,7 +341,7 @@ Three categories, each covering output or process:
   ```yaml
   verify:
     method: bash | codebase | subagent | research | manual | deferred-auto
-    phase: "[numeric, optional, default 1 — higher phases run after lower phases pass]"
+    phase: 1                       # optional integer, default 1; higher phases run after lower pass
     command: "[if bash]"
     agent: "[if subagent]"
     model: "[if subagent, default inherit]"
@@ -318,6 +349,8 @@ Three categories, each covering output or process:
   ```
 
 *`deferred-auto`: user-triggered; runs only via `/verify --deferred`. See `references/MULTI_REPO.md` §e for cross-repo semantics.*
+
+*Auto-decided items (Encoding Disciplines § Auto-decided items) carry an `(auto)` annotation immediately after the ID, e.g. `- [INV-G2] (auto) Description: ...`. The same convention applies to AC-* and PG-* entries that were auto-decided. Each auto-decided item also appears in Known Assumptions with its reasoning.*
 
 ## 4. Process Guidance (Non-Verifiable)
 *Constraints on HOW to work. Not gates—guidance for the implementer.*
@@ -339,9 +372,13 @@ Three categories, each covering output or process:
   ```yaml
   verify:
     method: bash | codebase | subagent | research | manual | deferred-auto
-    phase: "[numeric, optional, default 1]"
-    [details]
+    phase: 1                       # optional integer, default 1
+    command: "[if bash]"
+    agent: "[if subagent]"
+    model: "[if subagent, default inherit]"
+    prompt: "[if subagent or research]"
   ```
+  *AC verify blocks accept the same fields as INV-G verify blocks above.*
 
 ### Deliverable 2: [Name]
 ...
@@ -360,9 +397,9 @@ Three categories, each covering output or process:
 
 ## Verification Loop
 
-After writing the manifest, check the manifest's `mode:` field and load the execution mode file from `../do/references/execution-modes/` for the resolved mode (default: `thorough`). Follow that mode's "Manifest Verification (/define)" section for whether to run the manifest-verifier and how many cycles.
+After writing the manifest, read the manifest's `Mode` field and load the execution mode file from `../do/references/execution-modes/` for the resolved mode (default: `thorough`). Load once at loop entry; the same mode applies to every cycle in this loop. Follow that mode's "Manifest Verification (/define)" section for whether to run the manifest-verifier and how many cycles.
 
-When invoking the verifier, pass only the file paths (with `Manifest:` / `Log:` labels for disambiguation). No summary of contents, no framing, no commentary on the manifest itself. The verifier sees what you may have missed; let it assess independently. When relaying verifier output, do not paraphrase, filter, or editorialize.
+When invoking the verifier, pass only the file paths (with `Manifest:` / `Log:` labels for disambiguation). No summary of contents, no framing, no commentary on the manifest itself. The verifier sees what you may have missed; let it assess independently.
 
 ```
 Invoke the manifest-dev:manifest-verifier agent with: "Manifest: /tmp/manifest-{timestamp}.md | Log: /tmp/define-discovery-{timestamp}.md"
@@ -370,10 +407,10 @@ Invoke the manifest-dev:manifest-verifier agent with: "Manifest: /tmp/manifest-{
 
 The verifier returns **CONTINUE** or **COMPLETE**:
 
-- **CONTINUE** — interview mode defines whether to present to user or auto-resolve. Log answers to discovery file, update manifest, invoke verifier again.
+- **CONTINUE** — interview mode defines whether to present findings to the user or auto-resolve. **When presenting verifier findings to the user, present verbatim — do not paraphrase, filter, or editorialize.** Log answers to discovery file, update manifest, invoke verifier again.
 - **COMPLETE** — proceed to summary for approval.
 
-Repeat until COMPLETE or user signals "enough".
+Repeat until a Stop condition fires (see Convergence § Termination & escalation rules — Stop conditions). The cycle cap is defined per execution mode in `../do/references/execution-modes/`; this loop respects that cap.
 
 ## Summary for Approval
 
@@ -392,9 +429,10 @@ Include an ASCII architecture diagram when the task has multiple components with
 **The test:** if it reads like a compressed manifest (codes, YAML, structured labels dressed up as prose; enumerated criteria; counts hiding detail; abstractions hiding content), rewrite it. If it reads like something you'd say to a colleague, it's right.
 
 **After presenting the summary**, wait for the user's response:
-- **Approval** ("looks good", "approved") → proceed to Complete.
+- **Approval** ("looks good", "approved") → proceed to Complete (Stop condition 1).
 - **Feedback** ("also add X", "change Y", "use Z skill in process") → revise manifest, re-present summary. Do not implement.
-- **Explicit /do invocation** → /define is done; /do takes over.
+- **Explicit /do invocation** → Stop condition 2 fires; /define is done; /do takes over.
+- **Decline** ("scrap this", "never mind", "cancel") → exit /define silently. Do not write the manifest. The user can re-invoke /define if they want to retry.
 
 ## Medium Routing
 
@@ -407,12 +445,12 @@ The medium is encoded in the manifest's Intent section as `Medium: <value>` so d
 
 ## Complete
 
-/define ends here. Output the manifest path and stop.
+/define ends here. Output the manifest path and stop. Substitute the placeholders before printing:
+- `{timestamp}` → the value used for the manifest filename.
+- `[log-file-path if iterating]` → if this run iterated on a previous manifest that had an execution log, substitute the actual log path; otherwise omit the bracketed clause entirely (including the trailing space).
 
 ```text
 Manifest complete: /tmp/manifest-{timestamp}.md
 
 To execute: /do /tmp/manifest-{timestamp}.md [log-file-path if iterating]
 ```
-
-If this was an iteration on a previous manifest that had an execution log, include the log file path in the suggestion.

--- a/dist/gemini/.sync-meta.json
+++ b/dist/gemini/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "eda68ea64154410f439314dc88df6ed1d028c68d",
+  "source_commit": "c817b391918393b66d88acb6ce7663e2ba75f52c",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-01T16:39:18Z"
+  "synced_at": "2026-05-02T07:44:57Z"
 }

--- a/dist/gemini/skills/define/SKILL.md
+++ b/dist/gemini/skills/define/SKILL.md
@@ -12,13 +12,13 @@ Build **shared understanding** between you and the user about the work, then enc
 - **How we'll get there** — Approach (initial direction, expect adjustment)
 - **Rules we must follow** — Global Invariants
 
-**Every criterion discovered NOW is one fewer rejection later.** Comprehensive means surfacing latent criteria: requirements the user doesn't know they have until probed. Aim for high coverage; amendments handle what emerges during implementation.
+**Every criterion discovered now is one fewer rejection later.** Comprehensive means surfacing latent criteria: requirements the user doesn't know they have until probed. Coverage converges when the five Coverage Goal tests pass (see Convergence); amendments handle what emerges during implementation.
 
-Output: `/tmp/manifest-{timestamp}.md`
+Output: `/tmp/manifest-{timestamp}.md` where `{timestamp}` is `YYYYMMDD-HHMMSS` in UTC. Use the same `{timestamp}` for the discovery log (`/tmp/define-discovery-{timestamp}.md`) so the two files can be linked as a pair.
 
 ## Prerequisites
 
-If thinking-disciplines is not active, invoke `manifest-dev:thinking-disciplines` before any user-facing question. Apply throughout: every question, assessment, synthesis.
+Invoke `manifest-dev:thinking-disciplines` at the start of /define, before any other action. Apply throughout: every question, assessment, synthesis. (Idempotent — safe if already active.)
 
 ## Input
 
@@ -27,18 +27,19 @@ If thinking-disciplines is not active, invoke `manifest-dev:thinking-disciplines
 | Flag | Values | Default | Behavior |
 |------|--------|---------|----------|
 | `--interview` | `minimal` \| `autonomous` \| `thorough` | `thorough` | Sets interview mode (see Interview Style). Invalid value → halt: "Invalid interview style '<value>'. Valid styles: minimal \| autonomous \| thorough". |
-| `--medium` | `local` (only currently supported) | `local` | Sets communication channel. Other values → halt: "Medium '<value>' not yet supported. Currently supported: local". |
-| `--amend <path>` | manifest path | — | Amend an existing manifest. See `references/AMENDMENT_MODE.md`. |
-| `--from-do` | flag (used with `--amend`) | — | Marks amendment as triggered by `/do`. See `references/AMENDMENT_MODE.md` Three Contexts §2 (From /do). |
-| `--canvas` | flag | — | When present, follow `references/CANVAS_MODE.md`. |
+| `--mode` | `efficient` \| `balanced` \| `thorough` | `thorough` | Sets verification intensity (consumed by /do and the Verification Loop). Recorded in the manifest's `Mode` field. Invalid value → halt: "Invalid mode '<value>'. Valid modes: efficient \| balanced \| thorough". |
+| `--medium` | `local` | `local` | Sets communication channel. Other values → halt: "Medium '<value>' not yet supported. Currently supported: local". |
+| `--amend <path>` | manifest path | — | Amend an existing manifest (see Pre-flight). Missing argument → halt: "Cannot amend: --amend requires a manifest path." Path doesn't exist → halt: "Cannot amend: '<path>' not found." |
+| `--from-do` | boolean flag (used with `--amend`) | — | Marks amendment as triggered by `/do`. Accepts no value. See `references/AMENDMENT_MODE.md` Three Contexts §2 (From /do). |
+| `--canvas` | boolean flag | — | When present, follow `references/CANVAS_MODE.md` (it owns its own activation gate, lifecycle, and run-order placement). Accepts no value. |
 
-Flags can appear anywhere in `$ARGUMENTS`. If no arguments provided, ask: "What would you like to build or change?"
+Flags can appear anywhere in `$ARGUMENTS`. If `$ARGUMENTS` contains no task description (empty, or only flags with no free-form text), ask: "What would you like to build or change?" Exception: skip this prompt when **any** amend trigger applies — `--amend` is set, OR `$ARGUMENTS` contains a `/tmp/manifest-*.md` path (a bare path counts as routing, not as task text). Pre-flight handles amend context: the task description may live in conversation, the prior manifest, or be elaborated during the amendment interview.
 
 ## Pre-flight: Resolve Manifest Context
 
-Pre-flight resolves to **amend** or **fresh**:
+Pre-flight resolves to **amend** or **fresh**. When amend is selected, follow `references/AMENDMENT_MODE.md` for amendment rules.
 
-- `--amend <path>` set, or input plainly references a `/tmp/manifest-*.md` path → **amend** that manifest. Confirm approach with the user only if the referenced manifest's relationship to the new task is unclear.
+- `--amend <path>` set, OR `$ARGUMENTS` contains any `/tmp/manifest-*.md` path → **amend** that manifest. Confirm approach with the user only if the referenced manifest's relationship to the new task is unclear.
 - Transcript contains a prior `Manifest complete: /tmp/manifest-*.md` line, or such a path is mentioned in the conversation → read `references/AMENDMENT_MODE.md` "Session-Default Detection"; that section's branch determines amend or fresh.
 - Else → **fresh**.
 
@@ -48,13 +49,17 @@ Pre-flight resolves to **amend** or **fresh**:
 
 **Why:** Work already on the branch belongs in the manifest (Cumulative Manifest Rule — see `references/AMENDMENT_MODE.md`).
 
-**Base inference** (first hit wins): upstream tracking branch → `origin/main` → `origin/master` → ask the user once. Halt seeding if the user declines.
+**Base inference** (first hit wins): upstream tracking branch → `origin/main` → `origin/master` → ask the user once.
 
-Diff branch against base, read the diff and commit messages. Incorporate the existing changeset into the new manifest's Intent (what's already done) and starting Deliverables (work-in-progress as prior context, with new ACs added on top for completion + the new task). The interview confirms or adjusts what was inferred.
+If the user declines to identify a base, proceed with a **fresh** manifest and log the existing branch commits as a Known Assumption: `[ASM-N] Branch has commits ahead of an unidentified base | Default: treat as out of manifest scope | Impact if wrong: existing work isn't tracked or verified by this manifest.`
+
+When base is identified, diff branch against base, read the diff and commit messages. Incorporate the existing changeset into the new manifest's Intent (what's already done) and starting Deliverables (work-in-progress as prior context, with new ACs added on top for completion + the new task). The interview confirms or adjusts what was inferred.
 
 **Skip cleanly when:** no commits ahead of base, or Pre-flight resolved to amend.
 
 ## Domain Guidance
+
+**Where this fits in the run order:** Pre-flight → Branch-Diff Seeding → Read task files (this section) → Multi-Repo detection → Encode quality gates + Defaults → Load interview mode file → Context Assessment → Interview → Approach Section → manifest write → Verification Loop → Summary → Complete.
 
 Domain-specific guidance lives in `tasks/`:
 
@@ -74,22 +79,21 @@ Domain-specific guidance lives in `tasks/`:
 
 **Exception.** PROMPTING tasks do NOT compose with CODING.md unless the task also changes executable code. PROMPTING.md has its own quality gates. When a task changes both prompts AND code, apply both, scoping each to the relevant files.
 
-**Task file structures are presumed relevant.** They contain quality gates, reviewer agents, risks, scenarios, and trade-offs — domain-specific angles outside your default coverage. Quality gates auto-include; Resolvable structures (risks, scenarios, trade-offs) must be **resolved** per interview mode, or explicitly skipped with logged reasoning (e.g., "CODING.md concurrency risk skipped: single-threaded CLI tool"). Silent drops are the failure mode, not over-asking.
+**Task file structures are presumed relevant.** They contain quality gates (with their reviewer-agent fields), risks, scenarios, and trade-offs — domain-specific angles outside your default coverage. Quality gates auto-include; Resolvable structures (risks, scenarios, trade-offs) must be **resolved** per interview mode, or explicitly skipped with logged reasoning (e.g., "CODING.md concurrency risk skipped: single-threaded CLI tool"). Silent drops are the failure mode, not over-asking.
 
 **Task file content types:**
 - **Quality gates** (`## Quality Gates` section, any structured format with thresholds/criteria) — auto-include as INV-G*. Omit clearly inapplicable with logged reasoning. User reviews manifest.
 - **Resolvable** (tables/checklists: risks, scenarios, trade-offs) — resolve via interview, encode as INV/AC, or explicitly skip.
 - **Compressed awareness** (bold-labeled one-line summaries) — informs probing; no resolution needed.
-- **Process guidance hints** (counter-instinctive practices LLMs would miss). Two modes: **candidates** (presented as a batch after scenarios, resolved per interview mode) and **defaults** (`## Defaults` section, included in manifest without probing, user reviews and removes if not applicable). Both become PG-*.
+- **Process guidance hints** (counter-instinctive practices LLMs would miss). Two modes:
+  - **Defaults** (`## Defaults` section in the task file) — encoded pre-interview alongside Quality Gates; included in manifest without probing; user reviews and removes if not applicable.
+  - **Candidates** — held until Failure Modes scenarios resolve, then presented as a single batch and resolved per interview mode.
+  - Both become PG-*.
 - **Reference files** (`references/*.md`) — lookup data for `/verify` agents. Do not load during interview.
 
 **Encode quality gates and Defaults immediately after reading task files — before the interview.** Log each as `- [x]` RESOLVED.
 
 Task files set the floor, not the ceiling — probe beyond when domain understanding warrants.
-
-## Amendment Mode
-
-When `--amend <path>` is present (explicitly or via Pre-flight default), read `references/AMENDMENT_MODE.md` for amendment rules.
 
 ## Multi-Repo Scope
 
@@ -115,7 +119,7 @@ Five goals that must be met before convergence. Each defines WHAT must be true a
 | Reference Class | Can you name the task type and its common failure modes? |
 | Failure Modes | All scenarios have dispositions (encoded, scoped out, or mitigated)? |
 | Positive Dependencies | Load-bearing assumptions surfaced and each has a disposition? |
-| Process Self-Audit | Every identified scope-creep pattern has a disposition (PG, INV, accepted, already-covered). Skip when scope is bounded to a single deliverable with no incremental-addition risk. |
+| Process Self-Audit | Every identified scope-creep pattern has a disposition (PG, INV, accepted, already-covered). Skippable for narrow scopes — see Process Self-Audit § Skip rule. |
 
 ### Domain Understanding
 
@@ -165,7 +169,9 @@ Starting points: existing infrastructure/tooling you're relying on, user behavio
 
 ### Process Self-Audit
 
-**What must be true:** process self-sabotage patterns — decisions reasonable individually but compounding into failure — are identified and resolved. **Skip when scope is bounded to a single deliverable with no incremental-addition risk.**
+**What must be true:** process self-sabotage patterns — decisions reasonable individually but compounding into failure — are identified and resolved.
+
+**Skip rule:** scope is bounded to a single deliverable with no incremental-addition risk.
 
 Common patterns (not exhaustive): small scope additions ("just one more thing"), edge cases deferred ("we'll handle that later"), "temporary" solutions that become permanent, process shortcuts that erode quality.
 
@@ -180,11 +186,15 @@ Resolve from `--interview` argument; default `thorough`. Load the mode file:
 
 Follow the loaded mode's rules for question format, flow, checkpoints, finding-sharing, and convergence for the rest of the run.
 
-**Style is dynamic.** The flag sets starting posture, not a rigid lock. Shift when the user's behavior signals a different mode. After a shift, follow the new mode from that point. Log style shifts to the discovery file.
+**Style switches only on explicit user request.** The flag sets starting posture; the mode stays until the user explicitly asks to switch (e.g., "be more concise", "switch to autonomous", "ask everything"). Don't infer mode shifts from tone or terseness alone — terse answers within a mode are valid mode-internal signals, not switches. After a switch, follow the new mode from that point and log it to the discovery file.
 
-## Discovery Disciplines
+**Auto-switch variant.** When the user signals "enough" / "ship it" / "good enough" / "stop asking", a one-way switch to `autonomous` fires with auto-decide semantics on remaining `[ ]` items — see Convergence § Termination & escalation rules — Mode-switch escalation.
 
-**Discovery log** — write to `/tmp/define-discovery-{timestamp}.md` immediately after each discovery. The log is source of truth — another agent reading only the log could resume the interview.
+## Discovery & Question Disciplines
+
+### Discovery log
+
+Write to `/tmp/define-discovery-{timestamp}.md` immediately after each discovery — same `{timestamp}` as the manifest. The log is source of truth: another agent reading only the log could resume the interview.
 
 Seed with a Context Assessment before probing — what's already understood and what's missing:
 
@@ -205,49 +215,70 @@ Every actionable item gets logged with status:
 
 **Read full log before synthesis.** Unresolved `- [ ]` items are addressed first.
 
+### When to ask
+
 **Search before asking.** Don't ask the user about facts you could discover through exploration. Only ask when multiple plausible candidates exist, searches yield nothing, or the ambiguity is about intent not fact.
 
 **Ask early on preferences.** Trade-offs, priorities, and scope decisions cannot be discovered. Ask directly with concrete options and a recommended default.
-
-**Resolve all Resolvable task file structures.** After reading task files, extract every Resolvable table and checklist. Items already resolved in conversation context are logged as `- [x]` RESOLVED with source — not re-probed. Remaining items are `- [ ]` PENDING. Resolve each per interview mode, or skip with logged justification. Don't defer to synthesis.
-
-## Question Disciplines
-
-**Decisions lock through structured options.** Questions that lock manifest content present concrete options. The messaging file defines the tool and format; the interview mode defines when and how.
-
-**Confirm before encoding.** Exploration-discovered constraints require confirmation per interview mode before becoming invariants. Exception: task-file quality gates and Defaults are auto-included per Domain Guidance.
-
-**Encode explicit constraints.** User-stated preferences, requirements, and constraints must map to an INV or AC.
 
 **Probe approach constraints.** Beyond WHAT to build, ask HOW: tools to use or avoid, methods required or forbidden, automation vs manual. These become process invariants.
 
 **Probe input artifacts.** When input references external documents (URLs, file paths, named documents), determine whether they should be verification sources. If yes, encode as Global Invariant.
 
+**Resolve all Resolvable task file structures.** After reading task files, extract every Resolvable table and checklist. Items already resolved in conversation context are logged as `- [x]` RESOLVED with source — not re-probed. Remaining items are `- [ ]` PENDING. Resolve each per interview mode, or skip with logged justification. Don't defer to synthesis.
+
+### How to ask
+
+**Decisions lock through structured options.** Questions that lock manifest content present concrete options. The messaging file defines the tool and format; the interview mode defines when and how.
+
 **Batch related questions.** Group questions into a single turn covering one coherent topic; don't drip-feed.
+
+**Confirm before encoding.** Exploration-discovered constraints require confirmation per interview mode before becoming invariants. Exception: task-file quality gates and Defaults are auto-included per Domain Guidance.
+
+**Encode explicit constraints.** User-stated preferences, requirements, and constraints must map to an INV or AC.
 
 ## Encoding Disciplines
 
-**Insights become criteria.** Every discovery must be encoded as INV-G*, AC-*, or explicitly scoped out. Unencoded insights are aspirational, not enforced.
+**Insights become criteria.** Every discovery must be encoded — as INV-G*, AC-*, PG-*, R-*, T-*, or ASM-* — or explicitly scoped out with logged reasoning. Unencoded insights are aspirational, not enforced. (See ID Scheme for the full encoding catalog.)
 
 **Auto-decided items.** When interview style causes an item to be auto-decided (agent picks recommended option instead of asking), encode it normally as INV/AC/PG with an "(auto)" annotation, AND list it in Known Assumptions with the reasoning for the chosen option.
 
 **Automate verification.** When a criterion seems to require manual verification, push back: suggest how it could be automated, or ask the user for ideas. Manual only as last resort or when the user explicitly requests it.
 
-**Verification phases.** Each criterion's verify block has an optional `phase:` field (numeric, default 1). **Group by iteration speed — faster feedback loops run first.** Fast checks (agent reviewers, bash) stay in default phase. Slow checks (e2e tests, deploy-dependent) go in later phases. Manual goes last. Omit `phase:` for phase 1; non-contiguous phases are valid.
+**Verification phases.** Each criterion's verify block has an optional `phase` field — an unquoted integer, default 1 (e.g., `phase: 2`, not `phase: "2"`). **Group by iteration speed — faster feedback loops run first.** Fast checks (agent reviewers, bash) stay in default phase. Slow checks (e2e tests, deploy-dependent) go in later phases. Manual goes last. Omit `phase` for phase 1; non-contiguous phases are valid.
 
 ## Convergence
 
 The interview mode defines probing aggressiveness. Convergence requires:
-- All five Coverage Goal convergence tests pass
+- All applicable Coverage Goal convergence tests pass (Process Self-Audit may be skipped per its own rule)
 - No unresolved `- [ ]` items in the discovery log
 - Quality gates from task files encoded as INV-G* (or omitted with logged reasoning)
 - Defaults encoded as PG-*
 
-Low-impact unknowns become Known Assumptions. User can signal "enough" to override.
+Low-impact unknowns become Known Assumptions.
+
+### Termination & escalation rules
+
+Two distinct kinds of trigger:
+
+#### Stop conditions
+
+These end /define:
+
+1. Verifier returns COMPLETE and the user approves the summary.
+2. User explicitly invokes `/do`. Behavior depends on where /define is in the run:
+   - **Before synthesis is complete** (interview still has unresolved items, or manifest not yet written): switch to `autonomous` interview mode, finish synthesis and the Verification Loop with auto-decisions (each remaining `[ ]` item gets the recommended default, encoded with `(auto)` annotation and logged in Known Assumptions), write the manifest, then hand off to /do without waiting for summary approval.
+   - **At the summary stage** (manifest already written, awaiting approval): do not redo synthesis. Print `Manifest complete: ...` per Complete and hand off to /do immediately.
+
+#### Mode-switch escalation
+
+/define continues — only the interview mode changes:
+
+- User signals "enough" (or equivalent: "ship it", "good enough", "stop asking"). Effect: switch interview mode to `autonomous` from this point. Auto-decide remaining `[ ]` items per autonomous mode rules (recommended default chosen, encoded with `(auto)` annotation, logged in Known Assumptions). Continue through synthesis and the Verification Loop; expect to terminate via Stop condition 1.
 
 ## Approach Section (Complex Tasks)
 
-After defining deliverables, probe for **initial** implementation direction. Skip when the task has a single component with no architectural choice to make.
+After defining deliverables, probe for **initial** implementation direction when the inclusion rule below applies.
 
 **Why "initial":** Approach provides starting direction, not a rigid plan. Plans break on reality — unexpected constraints, better patterns, surprising dependencies. The goal is enough direction to start confidently, with trade-offs documented so implementation can adjust autonomously when reality diverges.
 
@@ -259,7 +290,7 @@ After defining deliverables, probe for **initial** implementation direction. Ski
 
 **Trade-offs** — decision criteria for competing concerns. "When facing [tension], priority? [A] vs [B]?" Format: `[T-N] A vs B → Prefer A because X`. Enables autonomous adjustment during /do.
 
-**When to include:** multi-deliverable tasks, unfamiliar domains, architectural decisions, high-risk implementations. The interview reveals if it's needed.
+**Inclusion rule (the one source of truth).** Include the Approach Section when ANY of: the task is multi-deliverable, the domain is unfamiliar, there's an architectural decision to make, or the implementation is high-risk. Skip only when none apply. The interview surfaces which triggers are present.
 
 **Architecture vs Process Guidance.** Architecture = structural decisions (components, patterns, structure). Process Guidance = methodology constraints (tools, manual vs automated). "Add executive summary covering X, Y, Z" is Architecture. "No bullet points in summary sections" is Process Guidance.
 
@@ -282,9 +313,9 @@ Three categories, each covering output or process:
 ## 1. Intent & Context
 - **Goal:** [High-level purpose]
 - **Mental Model:** [Key concepts to understand]
-- **Mode:** efficient | balanced | thorough *(optional, default: thorough — controls verification intensity during /do)*
-- **Interview:** minimal | autonomous | thorough *(optional, default: thorough — recorded so --amend can inherit the original interview style)*
-- **Medium:** local *(optional, default: local — currently only local is supported)*
+- **Mode:** efficient | balanced | thorough *(default: thorough — controls verification intensity during /do; set via `--mode`)*
+- **Interview:** minimal | autonomous | thorough *(default: thorough — recorded so --amend can inherit the original interview style)*
+- **Medium:** local *(default: local)*
 
 ## 2. Approach (Complex Tasks Only)
 *Initial direction, not rigid plan. Provides enough to start confidently; expect adjustment when reality diverges.*
@@ -310,7 +341,7 @@ Three categories, each covering output or process:
   ```yaml
   verify:
     method: bash | codebase | subagent | research | manual | deferred-auto
-    phase: "[numeric, optional, default 1 — higher phases run after lower phases pass]"
+    phase: 1                       # optional integer, default 1; higher phases run after lower pass
     command: "[if bash]"
     agent: "[if subagent]"
     model: "[if subagent, default inherit]"
@@ -318,6 +349,8 @@ Three categories, each covering output or process:
   ```
 
 *`deferred-auto`: user-triggered; runs only via `/verify --deferred`. See `references/MULTI_REPO.md` §e for cross-repo semantics.*
+
+*Auto-decided items (Encoding Disciplines § Auto-decided items) carry an `(auto)` annotation immediately after the ID, e.g. `- [INV-G2] (auto) Description: ...`. The same convention applies to AC-* and PG-* entries that were auto-decided. Each auto-decided item also appears in Known Assumptions with its reasoning.*
 
 ## 4. Process Guidance (Non-Verifiable)
 *Constraints on HOW to work. Not gates—guidance for the implementer.*
@@ -339,9 +372,13 @@ Three categories, each covering output or process:
   ```yaml
   verify:
     method: bash | codebase | subagent | research | manual | deferred-auto
-    phase: "[numeric, optional, default 1]"
-    [details]
+    phase: 1                       # optional integer, default 1
+    command: "[if bash]"
+    agent: "[if subagent]"
+    model: "[if subagent, default inherit]"
+    prompt: "[if subagent or research]"
   ```
+  *AC verify blocks accept the same fields as INV-G verify blocks above.*
 
 ### Deliverable 2: [Name]
 ...
@@ -360,9 +397,9 @@ Three categories, each covering output or process:
 
 ## Verification Loop
 
-After writing the manifest, check the manifest's `mode:` field and load the execution mode file from `../do/references/execution-modes/` for the resolved mode (default: `thorough`). Follow that mode's "Manifest Verification (/define)" section for whether to run the manifest-verifier and how many cycles.
+After writing the manifest, read the manifest's `Mode` field and load the execution mode file from `../do/references/execution-modes/` for the resolved mode (default: `thorough`). Load once at loop entry; the same mode applies to every cycle in this loop. Follow that mode's "Manifest Verification (/define)" section for whether to run the manifest-verifier and how many cycles.
 
-When invoking the verifier, pass only the file paths (with `Manifest:` / `Log:` labels for disambiguation). No summary of contents, no framing, no commentary on the manifest itself. The verifier sees what you may have missed; let it assess independently. When relaying verifier output, do not paraphrase, filter, or editorialize.
+When invoking the verifier, pass only the file paths (with `Manifest:` / `Log:` labels for disambiguation). No summary of contents, no framing, no commentary on the manifest itself. The verifier sees what you may have missed; let it assess independently.
 
 ```
 Invoke the manifest-dev:manifest-verifier agent with: "Manifest: /tmp/manifest-{timestamp}.md | Log: /tmp/define-discovery-{timestamp}.md"
@@ -370,10 +407,10 @@ Invoke the manifest-dev:manifest-verifier agent with: "Manifest: /tmp/manifest-{
 
 The verifier returns **CONTINUE** or **COMPLETE**:
 
-- **CONTINUE** — interview mode defines whether to present to user or auto-resolve. Log answers to discovery file, update manifest, invoke verifier again.
+- **CONTINUE** — interview mode defines whether to present findings to the user or auto-resolve. **When presenting verifier findings to the user, present verbatim — do not paraphrase, filter, or editorialize.** Log answers to discovery file, update manifest, invoke verifier again.
 - **COMPLETE** — proceed to summary for approval.
 
-Repeat until COMPLETE or user signals "enough".
+Repeat until a Stop condition fires (see Convergence § Termination & escalation rules — Stop conditions). The cycle cap is defined per execution mode in `../do/references/execution-modes/`; this loop respects that cap.
 
 ## Summary for Approval
 
@@ -392,9 +429,10 @@ Include an ASCII architecture diagram when the task has multiple components with
 **The test:** if it reads like a compressed manifest (codes, YAML, structured labels dressed up as prose; enumerated criteria; counts hiding detail; abstractions hiding content), rewrite it. If it reads like something you'd say to a colleague, it's right.
 
 **After presenting the summary**, wait for the user's response:
-- **Approval** ("looks good", "approved") → proceed to Complete.
+- **Approval** ("looks good", "approved") → proceed to Complete (Stop condition 1).
 - **Feedback** ("also add X", "change Y", "use Z skill in process") → revise manifest, re-present summary. Do not implement.
-- **Explicit /do invocation** → /define is done; /do takes over.
+- **Explicit /do invocation** → Stop condition 2 fires; /define is done; /do takes over.
+- **Decline** ("scrap this", "never mind", "cancel") → exit /define silently. Do not write the manifest. The user can re-invoke /define if they want to retry.
 
 ## Medium Routing
 
@@ -407,7 +445,11 @@ The medium is encoded in the manifest's Intent section as `Medium: <value>` so d
 
 ## Complete
 
-/define ends here. Output the manifest path and stop.
+/define ends here. Output the manifest path and stop. Substitute the placeholders before printing:
+- `{timestamp}` → the value used for the manifest filename.
+- `<project_hash>` → the project hash directory under `~/.gemini/tmp/` for the current project.
+- `${GEMINI_SESSION_ID}` → the value of the `GEMINI_SESSION_ID` environment variable.
+- `[log-file-path if iterating]` → if this run iterated on a previous manifest that had an execution log, substitute the actual log path; otherwise omit the bracketed clause entirely (including the trailing space).
 
 ```text
 Manifest complete: /tmp/manifest-{timestamp}.md
@@ -415,5 +457,3 @@ Session: ~/.gemini/tmp/<project_hash>/chats/session-${GEMINI_SESSION_ID}.jsonl
 
 To execute: /do /tmp/manifest-{timestamp}.md [log-file-path if iterating]
 ```
-
-If this was an iteration on a previous manifest that had an execution log, include the log file path in the suggestion.

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "eda68ea64154410f439314dc88df6ed1d028c68d",
+  "source_commit": "c817b391918393b66d88acb6ce7663e2ba75f52c",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-01T16:39:18Z"
+  "synced_at": "2026-05-02T07:44:57Z"
 }

--- a/dist/opencode/skills/define/SKILL.md
+++ b/dist/opencode/skills/define/SKILL.md
@@ -12,13 +12,13 @@ Build **shared understanding** between you and the user about the work, then enc
 - **How we'll get there** — Approach (initial direction, expect adjustment)
 - **Rules we must follow** — Global Invariants
 
-**Every criterion discovered NOW is one fewer rejection later.** Comprehensive means surfacing latent criteria: requirements the user doesn't know they have until probed. Aim for high coverage; amendments handle what emerges during implementation.
+**Every criterion discovered now is one fewer rejection later.** Comprehensive means surfacing latent criteria: requirements the user doesn't know they have until probed. Coverage converges when the five Coverage Goal tests pass (see Convergence); amendments handle what emerges during implementation.
 
-Output: `/tmp/manifest-{timestamp}.md`
+Output: `/tmp/manifest-{timestamp}.md` where `{timestamp}` is `YYYYMMDD-HHMMSS` in UTC. Use the same `{timestamp}` for the discovery log (`/tmp/define-discovery-{timestamp}.md`) so the two files can be linked as a pair.
 
 ## Prerequisites
 
-If thinking-disciplines is not active, invoke `manifest-dev:thinking-disciplines` before any user-facing question. Apply throughout: every question, assessment, synthesis.
+Invoke `manifest-dev:thinking-disciplines` at the start of /define, before any other action. Apply throughout: every question, assessment, synthesis. (Idempotent — safe if already active.)
 
 ## Input
 
@@ -27,18 +27,19 @@ If thinking-disciplines is not active, invoke `manifest-dev:thinking-disciplines
 | Flag | Values | Default | Behavior |
 |------|--------|---------|----------|
 | `--interview` | `minimal` \| `autonomous` \| `thorough` | `thorough` | Sets interview mode (see Interview Style). Invalid value → halt: "Invalid interview style '<value>'. Valid styles: minimal \| autonomous \| thorough". |
-| `--medium` | `local` (only currently supported) | `local` | Sets communication channel. Other values → halt: "Medium '<value>' not yet supported. Currently supported: local". |
-| `--amend <path>` | manifest path | — | Amend an existing manifest. See `references/AMENDMENT_MODE.md`. |
-| `--from-do` | flag (used with `--amend`) | — | Marks amendment as triggered by `/do`. See `references/AMENDMENT_MODE.md` Three Contexts §2 (From /do). |
-| `--canvas` | flag | — | When present, follow `references/CANVAS_MODE.md`. |
+| `--mode` | `efficient` \| `balanced` \| `thorough` | `thorough` | Sets verification intensity (consumed by /do and the Verification Loop). Recorded in the manifest's `Mode` field. Invalid value → halt: "Invalid mode '<value>'. Valid modes: efficient \| balanced \| thorough". |
+| `--medium` | `local` | `local` | Sets communication channel. Other values → halt: "Medium '<value>' not yet supported. Currently supported: local". |
+| `--amend <path>` | manifest path | — | Amend an existing manifest (see Pre-flight). Missing argument → halt: "Cannot amend: --amend requires a manifest path." Path doesn't exist → halt: "Cannot amend: '<path>' not found." |
+| `--from-do` | boolean flag (used with `--amend`) | — | Marks amendment as triggered by `/do`. Accepts no value. See `references/AMENDMENT_MODE.md` Three Contexts §2 (From /do). |
+| `--canvas` | boolean flag | — | When present, follow `references/CANVAS_MODE.md` (it owns its own activation gate, lifecycle, and run-order placement). Accepts no value. |
 
-Flags can appear anywhere in `$ARGUMENTS`. If no arguments provided, ask: "What would you like to build or change?"
+Flags can appear anywhere in `$ARGUMENTS`. If `$ARGUMENTS` contains no task description (empty, or only flags with no free-form text), ask: "What would you like to build or change?" Exception: skip this prompt when **any** amend trigger applies — `--amend` is set, OR `$ARGUMENTS` contains a `/tmp/manifest-*.md` path (a bare path counts as routing, not as task text). Pre-flight handles amend context: the task description may live in conversation, the prior manifest, or be elaborated during the amendment interview.
 
 ## Pre-flight: Resolve Manifest Context
 
-Pre-flight resolves to **amend** or **fresh**:
+Pre-flight resolves to **amend** or **fresh**. When amend is selected, follow `references/AMENDMENT_MODE.md` for amendment rules.
 
-- `--amend <path>` set, or input plainly references a `/tmp/manifest-*.md` path → **amend** that manifest. Confirm approach with the user only if the referenced manifest's relationship to the new task is unclear.
+- `--amend <path>` set, OR `$ARGUMENTS` contains any `/tmp/manifest-*.md` path → **amend** that manifest. Confirm approach with the user only if the referenced manifest's relationship to the new task is unclear.
 - Transcript contains a prior `Manifest complete: /tmp/manifest-*.md` line, or such a path is mentioned in the conversation → read `references/AMENDMENT_MODE.md` "Session-Default Detection"; that section's branch determines amend or fresh.
 - Else → **fresh**.
 
@@ -48,13 +49,17 @@ Pre-flight resolves to **amend** or **fresh**:
 
 **Why:** Work already on the branch belongs in the manifest (Cumulative Manifest Rule — see `references/AMENDMENT_MODE.md`).
 
-**Base inference** (first hit wins): upstream tracking branch → `origin/main` → `origin/master` → ask the user once. Halt seeding if the user declines.
+**Base inference** (first hit wins): upstream tracking branch → `origin/main` → `origin/master` → ask the user once.
 
-Diff branch against base, read the diff and commit messages. Incorporate the existing changeset into the new manifest's Intent (what's already done) and starting Deliverables (work-in-progress as prior context, with new ACs added on top for completion + the new task). The interview confirms or adjusts what was inferred.
+If the user declines to identify a base, proceed with a **fresh** manifest and log the existing branch commits as a Known Assumption: `[ASM-N] Branch has commits ahead of an unidentified base | Default: treat as out of manifest scope | Impact if wrong: existing work isn't tracked or verified by this manifest.`
+
+When base is identified, diff branch against base, read the diff and commit messages. Incorporate the existing changeset into the new manifest's Intent (what's already done) and starting Deliverables (work-in-progress as prior context, with new ACs added on top for completion + the new task). The interview confirms or adjusts what was inferred.
 
 **Skip cleanly when:** no commits ahead of base, or Pre-flight resolved to amend.
 
 ## Domain Guidance
+
+**Where this fits in the run order:** Pre-flight → Branch-Diff Seeding → Read task files (this section) → Multi-Repo detection → Encode quality gates + Defaults → Load interview mode file → Context Assessment → Interview → Approach Section → manifest write → Verification Loop → Summary → Complete.
 
 Domain-specific guidance lives in `tasks/`:
 
@@ -74,22 +79,21 @@ Domain-specific guidance lives in `tasks/`:
 
 **Exception.** PROMPTING tasks do NOT compose with CODING.md unless the task also changes executable code. PROMPTING.md has its own quality gates. When a task changes both prompts AND code, apply both, scoping each to the relevant files.
 
-**Task file structures are presumed relevant.** They contain quality gates, reviewer agents, risks, scenarios, and trade-offs — domain-specific angles outside your default coverage. Quality gates auto-include; Resolvable structures (risks, scenarios, trade-offs) must be **resolved** per interview mode, or explicitly skipped with logged reasoning (e.g., "CODING.md concurrency risk skipped: single-threaded CLI tool"). Silent drops are the failure mode, not over-asking.
+**Task file structures are presumed relevant.** They contain quality gates (with their reviewer-agent fields), risks, scenarios, and trade-offs — domain-specific angles outside your default coverage. Quality gates auto-include; Resolvable structures (risks, scenarios, trade-offs) must be **resolved** per interview mode, or explicitly skipped with logged reasoning (e.g., "CODING.md concurrency risk skipped: single-threaded CLI tool"). Silent drops are the failure mode, not over-asking.
 
 **Task file content types:**
 - **Quality gates** (`## Quality Gates` section, any structured format with thresholds/criteria) — auto-include as INV-G*. Omit clearly inapplicable with logged reasoning. User reviews manifest.
 - **Resolvable** (tables/checklists: risks, scenarios, trade-offs) — resolve via interview, encode as INV/AC, or explicitly skip.
 - **Compressed awareness** (bold-labeled one-line summaries) — informs probing; no resolution needed.
-- **Process guidance hints** (counter-instinctive practices LLMs would miss). Two modes: **candidates** (presented as a batch after scenarios, resolved per interview mode) and **defaults** (`## Defaults` section, included in manifest without probing, user reviews and removes if not applicable). Both become PG-*.
+- **Process guidance hints** (counter-instinctive practices LLMs would miss). Two modes:
+  - **Defaults** (`## Defaults` section in the task file) — encoded pre-interview alongside Quality Gates; included in manifest without probing; user reviews and removes if not applicable.
+  - **Candidates** — held until Failure Modes scenarios resolve, then presented as a single batch and resolved per interview mode.
+  - Both become PG-*.
 - **Reference files** (`references/*.md`) — lookup data for `/verify` agents. Do not load during interview.
 
 **Encode quality gates and Defaults immediately after reading task files — before the interview.** Log each as `- [x]` RESOLVED.
 
 Task files set the floor, not the ceiling — probe beyond when domain understanding warrants.
-
-## Amendment Mode
-
-When `--amend <path>` is present (explicitly or via Pre-flight default), read `references/AMENDMENT_MODE.md` for amendment rules.
 
 ## Multi-Repo Scope
 
@@ -115,7 +119,7 @@ Five goals that must be met before convergence. Each defines WHAT must be true a
 | Reference Class | Can you name the task type and its common failure modes? |
 | Failure Modes | All scenarios have dispositions (encoded, scoped out, or mitigated)? |
 | Positive Dependencies | Load-bearing assumptions surfaced and each has a disposition? |
-| Process Self-Audit | Every identified scope-creep pattern has a disposition (PG, INV, accepted, already-covered). Skip when scope is bounded to a single deliverable with no incremental-addition risk. |
+| Process Self-Audit | Every identified scope-creep pattern has a disposition (PG, INV, accepted, already-covered). Skippable for narrow scopes — see Process Self-Audit § Skip rule. |
 
 ### Domain Understanding
 
@@ -165,7 +169,9 @@ Starting points: existing infrastructure/tooling you're relying on, user behavio
 
 ### Process Self-Audit
 
-**What must be true:** process self-sabotage patterns — decisions reasonable individually but compounding into failure — are identified and resolved. **Skip when scope is bounded to a single deliverable with no incremental-addition risk.**
+**What must be true:** process self-sabotage patterns — decisions reasonable individually but compounding into failure — are identified and resolved.
+
+**Skip rule:** scope is bounded to a single deliverable with no incremental-addition risk.
 
 Common patterns (not exhaustive): small scope additions ("just one more thing"), edge cases deferred ("we'll handle that later"), "temporary" solutions that become permanent, process shortcuts that erode quality.
 
@@ -180,11 +186,15 @@ Resolve from `--interview` argument; default `thorough`. Load the mode file:
 
 Follow the loaded mode's rules for question format, flow, checkpoints, finding-sharing, and convergence for the rest of the run.
 
-**Style is dynamic.** The flag sets starting posture, not a rigid lock. Shift when the user's behavior signals a different mode. After a shift, follow the new mode from that point. Log style shifts to the discovery file.
+**Style switches only on explicit user request.** The flag sets starting posture; the mode stays until the user explicitly asks to switch (e.g., "be more concise", "switch to autonomous", "ask everything"). Don't infer mode shifts from tone or terseness alone — terse answers within a mode are valid mode-internal signals, not switches. After a switch, follow the new mode from that point and log it to the discovery file.
 
-## Discovery Disciplines
+**Auto-switch variant.** When the user signals "enough" / "ship it" / "good enough" / "stop asking", a one-way switch to `autonomous` fires with auto-decide semantics on remaining `[ ]` items — see Convergence § Termination & escalation rules — Mode-switch escalation.
 
-**Discovery log** — write to `/tmp/define-discovery-{timestamp}.md` immediately after each discovery. The log is source of truth — another agent reading only the log could resume the interview.
+## Discovery & Question Disciplines
+
+### Discovery log
+
+Write to `/tmp/define-discovery-{timestamp}.md` immediately after each discovery — same `{timestamp}` as the manifest. The log is source of truth: another agent reading only the log could resume the interview.
 
 Seed with a Context Assessment before probing — what's already understood and what's missing:
 
@@ -205,49 +215,70 @@ Every actionable item gets logged with status:
 
 **Read full log before synthesis.** Unresolved `- [ ]` items are addressed first.
 
+### When to ask
+
 **Search before asking.** Don't ask the user about facts you could discover through exploration. Only ask when multiple plausible candidates exist, searches yield nothing, or the ambiguity is about intent not fact.
 
 **Ask early on preferences.** Trade-offs, priorities, and scope decisions cannot be discovered. Ask directly with concrete options and a recommended default.
-
-**Resolve all Resolvable task file structures.** After reading task files, extract every Resolvable table and checklist. Items already resolved in conversation context are logged as `- [x]` RESOLVED with source — not re-probed. Remaining items are `- [ ]` PENDING. Resolve each per interview mode, or skip with logged justification. Don't defer to synthesis.
-
-## Question Disciplines
-
-**Decisions lock through structured options.** Questions that lock manifest content present concrete options. The messaging file defines the tool and format; the interview mode defines when and how.
-
-**Confirm before encoding.** Exploration-discovered constraints require confirmation per interview mode before becoming invariants. Exception: task-file quality gates and Defaults are auto-included per Domain Guidance.
-
-**Encode explicit constraints.** User-stated preferences, requirements, and constraints must map to an INV or AC.
 
 **Probe approach constraints.** Beyond WHAT to build, ask HOW: tools to use or avoid, methods required or forbidden, automation vs manual. These become process invariants.
 
 **Probe input artifacts.** When input references external documents (URLs, file paths, named documents), determine whether they should be verification sources. If yes, encode as Global Invariant.
 
+**Resolve all Resolvable task file structures.** After reading task files, extract every Resolvable table and checklist. Items already resolved in conversation context are logged as `- [x]` RESOLVED with source — not re-probed. Remaining items are `- [ ]` PENDING. Resolve each per interview mode, or skip with logged justification. Don't defer to synthesis.
+
+### How to ask
+
+**Decisions lock through structured options.** Questions that lock manifest content present concrete options. The messaging file defines the tool and format; the interview mode defines when and how.
+
 **Batch related questions.** Group questions into a single turn covering one coherent topic; don't drip-feed.
+
+**Confirm before encoding.** Exploration-discovered constraints require confirmation per interview mode before becoming invariants. Exception: task-file quality gates and Defaults are auto-included per Domain Guidance.
+
+**Encode explicit constraints.** User-stated preferences, requirements, and constraints must map to an INV or AC.
 
 ## Encoding Disciplines
 
-**Insights become criteria.** Every discovery must be encoded as INV-G*, AC-*, or explicitly scoped out. Unencoded insights are aspirational, not enforced.
+**Insights become criteria.** Every discovery must be encoded — as INV-G*, AC-*, PG-*, R-*, T-*, or ASM-* — or explicitly scoped out with logged reasoning. Unencoded insights are aspirational, not enforced. (See ID Scheme for the full encoding catalog.)
 
 **Auto-decided items.** When interview style causes an item to be auto-decided (agent picks recommended option instead of asking), encode it normally as INV/AC/PG with an "(auto)" annotation, AND list it in Known Assumptions with the reasoning for the chosen option.
 
 **Automate verification.** When a criterion seems to require manual verification, push back: suggest how it could be automated, or ask the user for ideas. Manual only as last resort or when the user explicitly requests it.
 
-**Verification phases.** Each criterion's verify block has an optional `phase:` field (numeric, default 1). **Group by iteration speed — faster feedback loops run first.** Fast checks (agent reviewers, bash) stay in default phase. Slow checks (e2e tests, deploy-dependent) go in later phases. Manual goes last. Omit `phase:` for phase 1; non-contiguous phases are valid.
+**Verification phases.** Each criterion's verify block has an optional `phase` field — an unquoted integer, default 1 (e.g., `phase: 2`, not `phase: "2"`). **Group by iteration speed — faster feedback loops run first.** Fast checks (agent reviewers, bash) stay in default phase. Slow checks (e2e tests, deploy-dependent) go in later phases. Manual goes last. Omit `phase` for phase 1; non-contiguous phases are valid.
 
 ## Convergence
 
 The interview mode defines probing aggressiveness. Convergence requires:
-- All five Coverage Goal convergence tests pass
+- All applicable Coverage Goal convergence tests pass (Process Self-Audit may be skipped per its own rule)
 - No unresolved `- [ ]` items in the discovery log
 - Quality gates from task files encoded as INV-G* (or omitted with logged reasoning)
 - Defaults encoded as PG-*
 
-Low-impact unknowns become Known Assumptions. User can signal "enough" to override.
+Low-impact unknowns become Known Assumptions.
+
+### Termination & escalation rules
+
+Two distinct kinds of trigger:
+
+#### Stop conditions
+
+These end /define:
+
+1. Verifier returns COMPLETE and the user approves the summary.
+2. User explicitly invokes `/do`. Behavior depends on where /define is in the run:
+   - **Before synthesis is complete** (interview still has unresolved items, or manifest not yet written): switch to `autonomous` interview mode, finish synthesis and the Verification Loop with auto-decisions (each remaining `[ ]` item gets the recommended default, encoded with `(auto)` annotation and logged in Known Assumptions), write the manifest, then hand off to /do without waiting for summary approval.
+   - **At the summary stage** (manifest already written, awaiting approval): do not redo synthesis. Print `Manifest complete: ...` per Complete and hand off to /do immediately.
+
+#### Mode-switch escalation
+
+/define continues — only the interview mode changes:
+
+- User signals "enough" (or equivalent: "ship it", "good enough", "stop asking"). Effect: switch interview mode to `autonomous` from this point. Auto-decide remaining `[ ]` items per autonomous mode rules (recommended default chosen, encoded with `(auto)` annotation, logged in Known Assumptions). Continue through synthesis and the Verification Loop; expect to terminate via Stop condition 1.
 
 ## Approach Section (Complex Tasks)
 
-After defining deliverables, probe for **initial** implementation direction. Skip when the task has a single component with no architectural choice to make.
+After defining deliverables, probe for **initial** implementation direction when the inclusion rule below applies.
 
 **Why "initial":** Approach provides starting direction, not a rigid plan. Plans break on reality — unexpected constraints, better patterns, surprising dependencies. The goal is enough direction to start confidently, with trade-offs documented so implementation can adjust autonomously when reality diverges.
 
@@ -259,7 +290,7 @@ After defining deliverables, probe for **initial** implementation direction. Ski
 
 **Trade-offs** — decision criteria for competing concerns. "When facing [tension], priority? [A] vs [B]?" Format: `[T-N] A vs B → Prefer A because X`. Enables autonomous adjustment during /do.
 
-**When to include:** multi-deliverable tasks, unfamiliar domains, architectural decisions, high-risk implementations. The interview reveals if it's needed.
+**Inclusion rule (the one source of truth).** Include the Approach Section when ANY of: the task is multi-deliverable, the domain is unfamiliar, there's an architectural decision to make, or the implementation is high-risk. Skip only when none apply. The interview surfaces which triggers are present.
 
 **Architecture vs Process Guidance.** Architecture = structural decisions (components, patterns, structure). Process Guidance = methodology constraints (tools, manual vs automated). "Add executive summary covering X, Y, Z" is Architecture. "No bullet points in summary sections" is Process Guidance.
 
@@ -282,9 +313,9 @@ Three categories, each covering output or process:
 ## 1. Intent & Context
 - **Goal:** [High-level purpose]
 - **Mental Model:** [Key concepts to understand]
-- **Mode:** efficient | balanced | thorough *(optional, default: thorough — controls verification intensity during /do)*
-- **Interview:** minimal | autonomous | thorough *(optional, default: thorough — recorded so --amend can inherit the original interview style)*
-- **Medium:** local *(optional, default: local — currently only local is supported)*
+- **Mode:** efficient | balanced | thorough *(default: thorough — controls verification intensity during /do; set via `--mode`)*
+- **Interview:** minimal | autonomous | thorough *(default: thorough — recorded so --amend can inherit the original interview style)*
+- **Medium:** local *(default: local)*
 
 ## 2. Approach (Complex Tasks Only)
 *Initial direction, not rigid plan. Provides enough to start confidently; expect adjustment when reality diverges.*
@@ -310,7 +341,7 @@ Three categories, each covering output or process:
   ```yaml
   verify:
     method: bash | codebase | subagent | research | manual | deferred-auto
-    phase: "[numeric, optional, default 1 — higher phases run after lower phases pass]"
+    phase: 1                       # optional integer, default 1; higher phases run after lower pass
     command: "[if bash]"
     agent: "[if subagent]"
     model: "[if subagent, default inherit]"
@@ -318,6 +349,8 @@ Three categories, each covering output or process:
   ```
 
 *`deferred-auto`: user-triggered; runs only via `/verify --deferred`. See `references/MULTI_REPO.md` §e for cross-repo semantics.*
+
+*Auto-decided items (Encoding Disciplines § Auto-decided items) carry an `(auto)` annotation immediately after the ID, e.g. `- [INV-G2] (auto) Description: ...`. The same convention applies to AC-* and PG-* entries that were auto-decided. Each auto-decided item also appears in Known Assumptions with its reasoning.*
 
 ## 4. Process Guidance (Non-Verifiable)
 *Constraints on HOW to work. Not gates—guidance for the implementer.*
@@ -339,9 +372,13 @@ Three categories, each covering output or process:
   ```yaml
   verify:
     method: bash | codebase | subagent | research | manual | deferred-auto
-    phase: "[numeric, optional, default 1]"
-    [details]
+    phase: 1                       # optional integer, default 1
+    command: "[if bash]"
+    agent: "[if subagent]"
+    model: "[if subagent, default inherit]"
+    prompt: "[if subagent or research]"
   ```
+  *AC verify blocks accept the same fields as INV-G verify blocks above.*
 
 ### Deliverable 2: [Name]
 ...
@@ -360,9 +397,9 @@ Three categories, each covering output or process:
 
 ## Verification Loop
 
-After writing the manifest, check the manifest's `mode:` field and load the execution mode file from `../do/references/execution-modes/` for the resolved mode (default: `thorough`). Follow that mode's "Manifest Verification (/define)" section for whether to run the manifest-verifier and how many cycles.
+After writing the manifest, read the manifest's `Mode` field and load the execution mode file from `../do/references/execution-modes/` for the resolved mode (default: `thorough`). Load once at loop entry; the same mode applies to every cycle in this loop. Follow that mode's "Manifest Verification (/define)" section for whether to run the manifest-verifier and how many cycles.
 
-When invoking the verifier, pass only the file paths (with `Manifest:` / `Log:` labels for disambiguation). No summary of contents, no framing, no commentary on the manifest itself. The verifier sees what you may have missed; let it assess independently. When relaying verifier output, do not paraphrase, filter, or editorialize.
+When invoking the verifier, pass only the file paths (with `Manifest:` / `Log:` labels for disambiguation). No summary of contents, no framing, no commentary on the manifest itself. The verifier sees what you may have missed; let it assess independently.
 
 ```
 Invoke the manifest-dev:manifest-verifier agent with: "Manifest: /tmp/manifest-{timestamp}.md | Log: /tmp/define-discovery-{timestamp}.md"
@@ -370,10 +407,10 @@ Invoke the manifest-dev:manifest-verifier agent with: "Manifest: /tmp/manifest-{
 
 The verifier returns **CONTINUE** or **COMPLETE**:
 
-- **CONTINUE** — interview mode defines whether to present to user or auto-resolve. Log answers to discovery file, update manifest, invoke verifier again.
+- **CONTINUE** — interview mode defines whether to present findings to the user or auto-resolve. **When presenting verifier findings to the user, present verbatim — do not paraphrase, filter, or editorialize.** Log answers to discovery file, update manifest, invoke verifier again.
 - **COMPLETE** — proceed to summary for approval.
 
-Repeat until COMPLETE or user signals "enough".
+Repeat until a Stop condition fires (see Convergence § Termination & escalation rules — Stop conditions). The cycle cap is defined per execution mode in `../do/references/execution-modes/`; this loop respects that cap.
 
 ## Summary for Approval
 
@@ -392,9 +429,10 @@ Include an ASCII architecture diagram when the task has multiple components with
 **The test:** if it reads like a compressed manifest (codes, YAML, structured labels dressed up as prose; enumerated criteria; counts hiding detail; abstractions hiding content), rewrite it. If it reads like something you'd say to a colleague, it's right.
 
 **After presenting the summary**, wait for the user's response:
-- **Approval** ("looks good", "approved") → proceed to Complete.
+- **Approval** ("looks good", "approved") → proceed to Complete (Stop condition 1).
 - **Feedback** ("also add X", "change Y", "use Z skill in process") → revise manifest, re-present summary. Do not implement.
-- **Explicit /do invocation** → /define is done; /do takes over.
+- **Explicit /do invocation** → Stop condition 2 fires; /define is done; /do takes over.
+- **Decline** ("scrap this", "never mind", "cancel") → exit /define silently. Do not write the manifest. The user can re-invoke /define if they want to retry.
 
 ## Medium Routing
 
@@ -407,12 +445,12 @@ The medium is encoded in the manifest's Intent section as `Medium: <value>` so d
 
 ## Complete
 
-/define ends here. Output the manifest path and stop.
+/define ends here. Output the manifest path and stop. Substitute the placeholders before printing:
+- `{timestamp}` → the value used for the manifest filename.
+- `[log-file-path if iterating]` → if this run iterated on a previous manifest that had an execution log, substitute the actual log path; otherwise omit the bracketed clause entirely (including the trailing space).
 
 ```text
 Manifest complete: /tmp/manifest-{timestamp}.md
 
 To execute: /do /tmp/manifest-{timestamp}.md [log-file-path if iterating]
 ```
-
-If this was an iteration on a previous manifest that had an execution log, include the log file path in the suggestion.


### PR DESCRIPTION
## Summary

Delta sync from `c817b39` (PR #112 — `/define` SKILL.md tightening). Source diff against the recorded sync-meta SHA reduces to a single content-bearing change: `claude-plugins/manifest-dev/skills/define/SKILL.md`. (Other diff entries — drive/drive-tick added, tend-pr/tend-pr-tick removed — were already applied to `dist/` by PR #110; the sync-meta SHA was lagging one commit behind, so re-applying is idempotent.)

### Per-CLI Complete-section retargeting
- **gemini**: Session line + placeholders adapted to `~/.gemini/tmp/<project_hash>/chats/session-${GEMINI_SESSION_ID}.jsonl`
- **opencode** / **codex**: Session line and `<dir>` / `${CLAUDE_SESSION_ID}` placeholder explanations omitted (per the respective reference files' Session File Adaptation verdicts)

`.sync-meta.json` bumped to `c817b39` for all three CLIs.

| CLI | Skills | Agents | Hooks | Commands | Status |
|-----|--------|--------|-------|----------|--------|
| Gemini | 1 modified | 0 | 0 | — | Complete |
| OpenCode | 1 modified | 0 | 0 | 0 | Complete |
| Codex | 1 modified | 0 | n/a | — | Complete |

README component tables and CLI context files (`GEMINI.md` / `AGENTS.md`) were **not** regenerated — the set of skills/agents did not change in this delta.

## Test plan
- [ ] Confirm `dist/gemini/skills/define/SKILL.md` Complete-section Session line resolves at runtime via `GEMINI_SESSION_ID`
- [ ] Confirm `dist/opencode/skills/define/SKILL.md` and `dist/codex/skills/define/SKILL.md` Complete sections render cleanly without dangling `<dir>` / `${CLAUDE_SESSION_ID}` references
- [ ] Spot-check that no `CLAUDE` / `~/.claude` strings remain in the three dist `define/SKILL.md` files
- [ ] Verify `.sync-meta.json` for all three CLIs records `c817b39`

https://claude.ai/code/session_01NWfkM4yrytPAeL5tqciQs2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWfkM4yrytPAeL5tqciQs2)_