### PR TITLE
chore(dist): sync /verify, /do, /define tightening to gemini, opencode, codex

### DIFF
--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "c817b391918393b66d88acb6ce7663e2ba75f52c",
+  "source_commit": "08c688927317bb652db59f48299623fc5a9fad7b",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-02T07:44:57Z"
+  "synced_at": "2026-05-02T20:36:36Z"
 }

--- a/dist/codex/skills/define/SKILL.md
+++ b/dist/codex/skills/define/SKILL.md
@@ -342,13 +342,14 @@ Three categories, each covering output or process:
   verify:
     method: bash | codebase | subagent | research | manual | deferred-auto
     phase: 1                       # optional integer, default 1; higher phases run after lower pass
-    command: "[if bash]"
-    agent: "[if subagent]"
+    inner_method: subagent | bash | codebase | research   # REQUIRED when method: deferred-auto
+    command: "[if bash, or if deferred-auto with inner_method: bash]"
+    agent: "[if subagent, or if deferred-auto with inner_method: subagent]"
     model: "[if subagent, default inherit]"
-    prompt: "[if subagent or research]"
+    prompt: "[if subagent or research, or matching deferred-auto inner_method]"
   ```
 
-*`deferred-auto`: user-triggered; runs only via `/verify --deferred`. See `references/MULTI_REPO.md` §e for cross-repo semantics.*
+*`deferred-auto`: user-triggered; runs only via `/verify --deferred`. The required `inner_method` field names the underlying verifier type used when the deferred run executes. See `references/MULTI_REPO.md` §e for cross-repo semantics.*
 
 *Auto-decided items (Encoding Disciplines § Auto-decided items) carry an `(auto)` annotation immediately after the ID, e.g. `- [INV-G2] (auto) Description: ...`. The same convention applies to AC-* and PG-* entries that were auto-decided. Each auto-decided item also appears in Known Assumptions with its reasoning.*
 
@@ -373,10 +374,11 @@ Three categories, each covering output or process:
   verify:
     method: bash | codebase | subagent | research | manual | deferred-auto
     phase: 1                       # optional integer, default 1
-    command: "[if bash]"
-    agent: "[if subagent]"
+    inner_method: subagent | bash | codebase | research   # REQUIRED when method: deferred-auto
+    command: "[if bash, or deferred-auto + inner_method: bash]"
+    agent: "[if subagent, or deferred-auto + inner_method: subagent]"
     model: "[if subagent, default inherit]"
-    prompt: "[if subagent or research]"
+    prompt: "[if subagent or research, or matching deferred-auto inner_method]"
   ```
   *AC verify blocks accept the same fields as INV-G verify blocks above.*
 

--- a/dist/codex/skills/define/references/MULTI_REPO.md
+++ b/dist/codex/skills/define/references/MULTI_REPO.md
@@ -83,12 +83,13 @@ Worked example — manifest declares:
 
 Cross-repo gates often cannot run during normal `/do→/verify` flow because they depend on prerequisites the user controls (e.g., "all PRs deployed to staging"). They are still **automatically verifiable** — just user-triggered.
 
-`method: deferred-auto` marks such criteria. Worked example:
+`method: deferred-auto` marks such criteria. Verify blocks MUST declare an explicit sibling `inner_method:` field naming the underlying verifier type (`subagent` | `bash` | `codebase` | `research`); under `/verify --deferred` the criterion is routed identically to a non-deferred criterion of that `inner_method`. Worked example:
 
 ```yaml
 - [INV-G7] Frontend SSO login round-trips through deployed backend
   verify:
     method: deferred-auto
+    inner_method: subagent
     agent: general-purpose
     prompt: "Hit https://staging.example.com/login with a test SAML assertion. Confirm successful redirect to /dashboard with a valid session cookie."
 ```

--- a/dist/codex/skills/do/SKILL.md
+++ b/dist/codex/skills/do/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: do
-description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Optional --mode efficient|balanced|thorough controls verification intensity (default: thorough). Only pass --mode when the user explicitly requests a different mode. Use when executing a manifest, running a plan, implementing a defined task.'
+description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Optional --mode efficient|balanced|thorough controls verification intensity (default: thorough). Use when executing a manifest, running a plan, implementing a defined task.'
 ---
 
 # /do - Manifest Executor
@@ -11,17 +11,17 @@ Execute a Manifest: satisfy all Deliverables' Acceptance Criteria while followin
 
 ## Input
 
-`$ARGUMENTS` = manifest file path (REQUIRED), optionally with execution log path, `--mode <level>`, and `--scope <deliverable-ids>`
+`$ARGUMENTS` = manifest file path (REQUIRED), optionally with execution log path, `--mode <level>`, and `--scope <deliverable-ids>`. Positional args (manifest path, then log path) and flags may interleave. First positional = manifest path; second positional (if present) = execution log path.
 
-If no arguments: Output error "Usage: /do <manifest-file-path> [log-file-path] [--mode efficient|balanced|thorough] [--scope D1,D2,...]"
+If no arguments, halt: `Usage: /do <manifest-file-path> [log-file-path] [--mode efficient|balanced|thorough] [--scope D1,D2,...]`
 
 Read the manifest file fully before any execution.
 
 ## Execution Mode
 
-Resolve mode from (highest precedence first): `--mode` argument → manifest `mode:` field → default `thorough`.
+Resolve mode from (highest precedence first): `--mode` argument → manifest `Mode` field → default `thorough`.
 
-Invalid mode value → error and halt: "Invalid mode '<value>'. Valid modes: efficient | balanced | thorough"
+Invalid `--mode` value → halt: `Invalid mode '<value>'. Valid modes: efficient | balanced | thorough`.
 
 Load the execution mode file for behavioral specifics:
 - `thorough` (default): read `references/execution-modes/thorough.md`
@@ -30,14 +30,15 @@ Load the execution mode file for behavioral specifics:
 
 Follow the loaded mode's rules for model routing, verification parallelism, fix-verify loop limits, and escalation for the remainder of this /do run.
 
-**Override precedence** (applies to all modes):
-1. **Criterion-level model wins**: When a manifest criterion specifies `model:` in its verify block, that overrides the mode's model routing.
-2. **Explicit model overrides skip**: If a criterion explicitly sets `model:`, it runs even when the mode would otherwise skip it.
-3. **Global Invariants always run**: INV-G* verification runs regardless of mode — constitutional constraints.
+**Model routing precedence** (applies to all modes):
+1. **Criterion-level model wins.** When a manifest criterion specifies `model:` in its verify block, that overrides the mode's model routing.
+2. **Explicit model overrides skip.** If a criterion explicitly sets `model:`, it runs even when the mode would otherwise skip it.
+
+**Always-on rule:** Global Invariants (INV-G*) verify regardless of mode — constitutional constraints.
 
 ## Existing Execution Log
 
-If input includes a log file path (iteration on previous work): **treat it as source of truth**. It contains prior execution history. Continue from where it left off—append to the same log, don't restart.
+If input includes a log file path (iteration on previous work): **treat it as source of truth**. It contains prior execution history. Continue from where it left off — append to the same log, don't restart.
 
 ## Scoped Execution
 
@@ -45,80 +46,79 @@ Parse `--scope` from arguments if present. Accepts comma-separated deliverable I
 
 When `--scope` is provided, read `references/SCOPED_EXECUTION.md` and follow its rules for scoped execution. This limits work to the specified deliverables while maintaining global invariant safety.
 
-When `--scope` is NOT provided, ignore this section entirely — no reference file is loaded, no scoping behavior applies. Full execution as normal.
+When `--scope` is NOT provided, ignore this section entirely. No reference file is loaded, no scoping behavior applies. Full execution as normal.
 
 ## Principles
 
 | Principle | Rule |
 |-----------|------|
 | **ACs define success** | Work toward acceptance criteria however makes sense. Manifest says WHAT, you decide HOW. |
-| **Approach is initial, not rigid** | Approach provides starting direction, but adapt freely when reality diverges. No escalation needed — log adjustments with rationale. |
+| **Approach is initial, not rigid** | Approach provides starting direction, but adapt freely when reality diverges. No escalation needed; log adjustments with rationale. |
 | **Target failures specifically** | On verification failure, fix the specific failing criterion. Don't restart. Don't touch passing criteria. |
 | **Verify fixes first** | After fixing a failure, confirm the fix works before re-running full verification. |
 | **Trade-offs guide adjustment** | When risks (R-*) materialize, consult trade-offs (T-*) for decision criteria. Log adjustments with rationale. |
 
 ## Constraints
 
-**Log after every action** - Write to execution log immediately after each AC attempt. No exceptions. This is disaster recovery—if context is lost, the log is the only record of what happened.
+**Log after every action.** Write to execution log immediately after each AC attempt. No exceptions. This is disaster recovery: if context is lost, the log is the only record of what happened.
 
-**Must call /verify** - Can't declare done without verification. Invoke manifest-dev:verify with manifest, log paths, the resolved mode, and an optional scope per the rules below: `/verify <manifest> <log> --mode <level> [--scope D2,D3]`. Never pass `--final` from /do — that flag is internal to /verify (auto-triggered after a selective green pass) and exists to enforce the hard final gate. /done is unreachable without a full-mode green pass; /verify owns the selective→full chain.
+**Must call /verify.** Can't declare done without verification. Invoke manifest-dev:verify with manifest, log paths, the resolved mode, and an optional scope per the rules below: `/verify <manifest> <log> --mode <level> [--scope D2,D3]`. Never pass `--final` from /do; that flag is internal to /verify (auto-triggered after a true-selective green pass where `--scope` was set). /done is unreachable without a full-pass green (every AC + every INV-G) with no pending manual or deferred-auto criteria.
 
-**Selective verification + fix-loop scope** - /verify supports two modes (see verify SKILL.md for full contract):
-- *First pass on fresh /do* — invoke without `--scope` and without `--final`. Selective mode degenerates to full (nothing to narrow). Equivalent to today's behavior.
-- *Scoped /do* (`--scope D2,D3` was passed to /do) — invoke /verify with the same `--scope D2,D3`. Selective pass runs those deliverables' ACs + all globals.
-- *Fix-loop after AC-X.Y failure* — invoke /verify with `--scope D{X}` (the failing criterion's deliverable). Other deliverables are not re-verified during this iteration; they get their pass at the mandatory full final gate when /verify auto-triggers it.
-- *Fix-loop after INV-G failure* — invoke /verify normally (globals always run; no narrowing makes sense). When the failure happened during a selective pass with a `--scope`, the next pass is selective on the same deliverable + globals. When the failure happened during a full pass (auto-triggered final, or first-pass degenerated-to-full — no `--scope` was set), the next pass is also full — invoke /verify with no `--scope`. INV-G failures are not deliverable-scoped, so falling through to full is the correct default.
+**Selective verification + fix-loop scope.** /verify supports selective and full passes (see verify SKILL.md for the full contract). /do invokes /verify in four patterns:
 
-The mandatory full final gate (auto-triggered by /verify after selective green) is the safety net for cross-deliverable regressions. Don't try to skip or short-circuit it.
+- *First pass on fresh /do.* Invoke without `--scope` and without `--final`. Selective mode degenerates to full (nothing to narrow).
+- *Scoped /do* (`--scope D2,D3` was passed to /do). Invoke /verify with the same `--scope D2,D3`. Selective pass runs those deliverables' ACs + all globals.
+- *Fix-loop after AC-X.Y failure.* Invoke /verify with `--scope D{X}` (the failing criterion's deliverable). Other deliverables are not re-verified during this iteration; they get their pass at the mandatory full final gate when /verify auto-triggers it. This applies whether the AC failure happened during a selective pass or during the auto-triggered full pass: scope to the failing deliverable, then let /verify auto-trigger full again on green.
+- *Fix-loop after INV-G failure.* Invoke /verify normally (globals always run; deliverable-scoping is meaningless for INV-G). When the failure happened during a selective pass with a `--scope`, the next pass is selective on the same scope + globals (re-pass exactly the deliverable IDs that were in the failing pass). When the failure happened during a full pass (auto-triggered final, or first-pass degenerated-to-full where `--scope` was not set), the next pass is also full: invoke /verify with no `--scope`.
 
-**Execution log /verify contract** - /verify appends a structured block (`## /verify pass {N}` + fenced YAML with `mode`, `scope`, `result`, `failures`, `auto_triggered_final`, `deferred`) per invocation. Read the most recent block before deciding the next pass's scope. Format defined in `verify/SKILL.md` "/verify Pass Logging Contract." When scanning for the most recent /verify pass to drive scope decisions, **skip blocks with `deferred: true`** — those reflect user-direct `--deferred` invocations (now possible since /verify is user-invocable), not /do-driven normal-flow passes.
+The mandatory full final gate (auto-triggered by /verify after true-selective green) is the safety net for cross-deliverable regressions. Selective scoping gives fast feedback during fixes; the full final gate guarantees nothing in the rest of the suite regressed. Don't try to skip or short-circuit it.
 
-**Escalation boundary** - Escalate when: (1) ACs can't be met as written (contract broken), (2) user requests a pause mid-workflow, (3) you discover an AC or invariant should be amended (use "Proposed Amendment" escalation type), or (4) the active execution mode's fix-verify loop limit is reached. If ACs remain achievable as written and no user interrupt, continue autonomously.
+**Execution log /verify contract.** /verify appends a structured block (`## /verify pass {N}` + fenced YAML with `mode`, `scope`, `result`, `failures`, `auto_triggered_final`, `deferred`) per invocation. Read the most recent block before deciding the next pass's scope. Format defined in `verify/SKILL.md` "/verify Pass Logging Contract." When scanning for the most recent /verify pass to drive scope decisions, **skip blocks with `deferred: true`**; those reflect user-direct `--deferred` invocations, not /do-driven normal-flow passes.
 
-**`/verify`-routed escalation passthrough.** When `/verify` itself routes to `/escalate` (e.g., "Deferred-Auto Pending", "Manual Criteria Review") instead of `/done`, treat as a clean terminal handoff: surface the escalation output verbatim to the caller, do NOT enter the fix-loop, do NOT increment loop counters. The implementation is green; further action belongs to the user (e.g., running `/verify --deferred` for deferred-auto pending). This is distinct from `/verify` returning failures (which enters the standard fix-loop).
+**Escalation boundary.** Escalate when: (1) ACs can't be met as written (contract broken); (2) user requests a pause mid-workflow; (3) you discover an AC or invariant should be amended (use "Proposed Amendment" escalation type); (4) the active execution mode's fix-verify loop limit is reached; (5) any user message arrives during /do or /verify (use "Self-Amendment"; see Mid-Execution Amendment below). If ACs remain achievable as written and no user interrupt, continue autonomously.
 
-**Mode-aware loop tracking** - Track fix-verify iteration count and escalation count in the execution log. When the active execution mode's limits are reached, follow its escalation rules.
+**`/verify`-routed escalation passthrough.** When `/verify` itself routes to `/escalate` (e.g., "Deferred-Auto Pending", "Manual Criteria Review", or the combined "Manual Review + Deferred-Auto Pending") instead of `/done`, treat as a clean terminal handoff: surface the escalation output verbatim to the caller, do NOT enter the fix-loop, do NOT increment loop counters. The implementation is green; further action belongs to the user (e.g., running `/verify --deferred` for deferred-auto pending). This is distinct from `/verify` returning failures (which enters the standard fix-loop).
 
-**Phase-aware verification** - /verify runs criteria in phases (ascending by `phase:` field, default 1). It may report "Phase N failed, Phase N+1 not run." After fixing failures, /verify restarts from Phase 1 to catch regressions. Loop limits apply per-phase; regressions increment the broken phase's counter, not the phase that caused them.
+**Mode-aware loop tracking.** Track fix-verify iteration count and escalation count in the execution log. When the active execution mode's limits are reached, follow its escalation rules.
 
-**Stop requires /escalate** - During /do, you cannot stop without calling /verify→/done or /escalate. If you need to pause, call /escalate with "User-Requested Pause" format. Bare outputs like "Done." or "Waiting." are not valid exits.
+**Phase-aware verification.** /verify runs criteria in phases (ascending by `phase:` field, default 1). It may report "Phase N failed, Phase N+1 not run." After fixing failures, /verify restarts from Phase 1 to catch regressions. Loop limits apply per-phase; regressions increment the broken phase's counter, not the phase that caused them.
+
+**Stop requires /escalate.** During /do, you cannot stop without calling /verify (which routes to /done or /escalate) or calling /escalate directly. If you need to pause, call /escalate with "User-Requested Pause" format. Silent halts and bare statements like "Done." or "Waiting." are not valid exits.
 
 ## Memento Pattern
 
 Externalize progress to survive context loss.
 
-**Execution log**: Create `/tmp/do-log-{timestamp}.md` at start. After EACH AC attempt, append what happened and the outcome. Goal: another agent reading only the log could resume work.
+**Execution log.** Create `/tmp/do-log-{timestamp}.md` at start. After EACH AC attempt, append what happened and the outcome. Goal: another agent reading only the log could resume work.
 
-**Todos**: Create from manifest (deliverables → ACs). Start with execution order from Approach (adjust if dependencies require). Update todo status after logging (log first, todo second).
+**Todos.** Create from manifest (deliverables → ACs). Start with execution order from Approach (adjust if dependencies require). Update todo status after logging (log first, todo second).
 
-**Refresh before verify** - Read full execution log before calling /verify to restore context.
+**Refresh before verify.** Read full execution log before calling /verify to restore context.
 
-**Refresh between deliverables** - Before starting a new deliverable, re-read the manifest's deliverable section and relevant log entries. Context degrades across long sessions.
+**Refresh between deliverables.** Before starting a new deliverable, re-read the manifest's deliverable section and relevant log entries. Context degrades across long sessions.
 
 ## Multi-Repo Navigation
 
-When the manifest declares `Repos: [name: path, ...]` in Intent, deliverables may live in repos other than cwd. Read the path map and use **absolute paths** in tool calls (Read/Edit/Write/Bash) when working on a deliverable tagged with a different repo. There is **no filter logic, no cwd matching, no per-repo configuration** — the LLM navigates as deliverables require.
+When the manifest declares `Repos: [name: path, ...]` in Intent, deliverables may live in repos other than cwd. Read the path map and use **absolute paths** in tool calls (Read/Edit/Write/Bash) when working on a deliverable tagged with a different repo. There is **no filter logic, no cwd matching, no per-repo configuration**; the LLM navigates as deliverables require.
 
 A single `/do` invocation can cover the whole multi-repo task by navigating between repos; alternatively the user invokes `/do` per repo with `--scope` for parallel execution. Either works. The execution log remains a single file per `/do` invocation.
 
-When the manifest has no `Repos:` field (single-repo manifest), this section does not apply — behavior is unchanged.
+When the manifest has no `Repos:` field (single-repo manifest), this section does not apply; behavior is unchanged.
 
-Full convention: `references/MULTI_REPO.md` (lives in `define/references/`).
+Full convention: `define/references/MULTI_REPO.md`.
 
 ## Mid-Execution Amendment
 
-**Default to amend.** Any user message arriving during /do or /verify defaults to triggering Self-Amendment. The manifest is the canonical source of truth for the PR/branch — or, in multi-repo cases, the **PR set / branch set** (see `references/AMENDMENT_MODE.md`). Feedback flows through it, not around it. The asymmetric framing is deliberate: silent scope drift (feedback acted on inline, manifest left out of date) is a worse failure than an occasional unnecessary amendment cycle.
+**Default to amend.** Any user message arriving during /do or /verify defaults to triggering Self-Amendment. The manifest is the canonical source of truth for the PR/branch (or, in multi-repo cases, the **PR set / branch set**; see `define/references/AMENDMENT_MODE.md`). Feedback flows through it, not around it. Asymmetric by design: silent scope drift (feedback acted on inline, manifest left out of date) is a worse failure than an occasional unnecessary amendment cycle.
 
-**Carve-out: pure questions.** Messages that ask about the manifest or process without requesting a state change are answered inline — no amendment.
+**Carve-out: pure questions.** Messages that ask about the manifest or process without requesting a state change are answered inline; no amendment.
 - *Amend:* "Also handle X." / "Change Y to Z." / "That's wrong, it should be …" / "Add a check for …"
 - *Inline:* "What does AC-1.1 require?" / "Why did you choose approach A over B?" / "Where's the execution log?" / "Which deliverable is D3?"
 
 **When ambiguous, amend.** A message that could be either ("hmm, what about the auth case?") goes to amendment. Re-running an amendment cycle is cheap; silently dropping a constraint that turns out to matter is expensive.
 
-**/verify-time feedback.** While /verify is running under /do, user feedback received mid-pass is semantically feedback to /do (the caller), not to /verify. The same default-to-amend rule applies. /verify itself never handles user feedback inline; the message is interpreted in /do's context and routed through Self-Amendment. (When /verify is invoked directly by the user — e.g., `/verify --deferred` — there is no /do caller; mid-pass user messages are handled per the user's own session reflex, not via /do's amendment route.)
+**/verify-time feedback.** While /verify is running under /do, user feedback received mid-pass is semantically feedback to /do (the caller), not to /verify. The same default-to-amend rule applies. /verify itself never handles user feedback inline (per /verify's "Don't handle user feedback during a pass" Principle); the message is interpreted in /do's context and routed through Self-Amendment. When /verify is invoked directly by the user (e.g., `/verify --deferred`), there is no /do caller, and mid-pass user messages are governed by /verify's own Principle, not /do's amendment route.
 
-**Amendment flow** — Amend the manifest autonomously via Self-Amendment escalation and `/define --amend <manifest-path> --from-do`, then resume with the updated manifest and existing log. Log the trigger before amending. No human wait — the entire cycle is autonomous.
+**Amendment flow.** Amend the manifest autonomously via Self-Amendment escalation and `/define --amend <manifest-path> --from-do`, then resume with the updated manifest and existing log. Log the trigger before amending. No human wait; the entire cycle is autonomous.
 
-**Amendment loop guard** (R-7) — If Self-Amendment escalations repeat without new external input (user messages or PR comments) between them, the amendments are likely oscillating — escalate as "Proposed Amendment" for human decision instead. The same guard applies to post-/done re-entry: when feedback after completion triggers re-entry to /do via amendment, the consecutive-amendments-without-external-input counter still applies. Purpose: prevent runaway loops and unnecessary token burn.
-
-**No-manifest case.** When /do is invoked without a manifest (rare — typically /do follows /define), default-to-amend doesn't apply: there is nothing to amend. Behavior falls back to inline handling. This is fail-open by design.
+**Amendment loop guard.** If Self-Amendment escalations repeat without new external input (user messages or PR comments) between them, the amendments are likely oscillating; escalate as "Proposed Amendment" for human decision instead. The same guard applies to post-/done re-entry: when feedback after completion triggers re-entry to /do via amendment, the consecutive-amendments-without-external-input counter still applies. Purpose: prevent runaway loops and unnecessary token burn.

--- a/dist/codex/skills/verify/SKILL.md
+++ b/dist/codex/skills/verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify
-description: 'Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest. Primary user-facing entry point is /verify --deferred (run user-triggered deferred-auto criteria); other invocations normally come from /do.'
+description: 'Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest. Normally invoked by /do; users invoke directly via /verify --deferred to run user-triggered deferred-auto criteria.'
 user-invocable: true
 ---
 
@@ -10,49 +10,82 @@ Orchestrate verification of all criteria from a Manifest by spawning parallel ve
 
 **Input**: $ARGUMENTS
 
-Format: `<manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough] [--scope D1,D2,...] [--final] [--deferred]`
+Format: `<manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough] [--scope D1,D2,...] [--deferred]`
 
-Both paths required — return usage error if missing. Mode defaults to `thorough` if not provided. `--scope` and `--final` are mutually exclusive (final is full by definition); when both appear, treat as final. `--deferred` runs only `method: deferred-auto` criteria — see "Deferred-Auto Criteria" below.
+If either path is missing, halt: `Usage: /verify <manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough] [--scope D1,D2,...] [--deferred]`. If the manifest path doesn't exist, halt: `Cannot verify: manifest '<path>' not found.` If the execution log path doesn't exist, **create it as an empty file** before proceeding — /verify must always be able to append a pass-log block.
+
+`--deferred` runs only `method: deferred-auto` criteria — see "Deferred-Auto Criteria" below.
+
+`--final` is internal-only — see "Hard Final Gate" below. /do never passes it; users never pass it.
+
+## Mode Resolution
+
+Resolve mode from (highest precedence first): `--mode` argument → manifest `Mode` field → `thorough`.
+
+Invalid `--mode` value → halt: `Invalid mode '<value>'. Valid modes: efficient | balanced | thorough`.
+
+The resolved mode controls verifier parallelism, model routing, and reviewer-skip rules per `../do/references/execution-modes/{mode}.md`. Load that file at entry; if it cannot be loaded, halt with the load error — do not attempt verification.
 
 ## Selective vs Full Verification
 
-/verify runs in one of two modes — selective or full — driven by the caller (/do):
+/verify runs in one of two modes — selective or full — driven by the caller (/do, or a user-direct invocation):
 
-- **Selective pass.** Runs only the ACs of the in-scope deliverables (passed via `--scope D2,D3`, or computed by /do as the deliverable owning a failed criterion in fix-loop) **plus all Global Invariants** (INV-G* always run). Used during the fix-loop and after scoped /do invocations to keep token cost bounded.
-- **Full pass.** Runs every AC across every deliverable plus all globals. Triggered by `--final` from /do, or auto-triggered by /verify itself after a selective pass goes green (see Outcome Handling).
+- **Selective pass.** Runs only the ACs of the in-scope deliverables (passed via `--scope D2,D3` — /do computes the failing-deliverable scope and passes it during fix-loop) **plus all Global Invariants** (INV-G* are in scope on every pass, subject to Phased Execution gating). Used during the fix-loop and after scoped /do invocations to keep token cost bounded.
+- **Full pass.** Runs every AC across every deliverable plus all globals (same phase gating). Auto-triggered by /verify itself (re-invoking with `--final`) after a true-selective pass goes green — see Hard Final Gate.
 
-**When `--scope` is absent and `--final` is absent**, selective mode degenerates to full — there's no narrowing to apply, so behavior matches today's "verify everything." This is also the first /verify pass on a fresh /do (no failure context yet, no scope flag).
+**Terminology.** *True-selective* = a selective pass where `--scope` was set (the filter actually narrowed). *Selective-degenerated-to-full* = a selective pass where `--scope` was absent (no narrowing to apply, so the pass covers everything). Outcome handling distinguishes the two — see Outcome Handling.
 
-**Why this exists.** Re-running every AC on every fix-loop iteration costs N × loops verifier invocations. Most fixes touch one deliverable; re-verifying the rest is waste. The mandatory full final gate (Outcome Handling) catches anything cross-deliverable that selective mode missed — that's the safety net.
+**When `--scope` is absent and `--final` is absent**, selective mode degenerates to full — behavior matches "verify everything." This applies to the first /verify pass on a fresh /do (no failure context yet, no scope flag) and to user-direct invocations like `/verify <manifest> <log>` with no flags.
+
+**Why this exists.** Re-running every AC on every fix-loop iteration costs N × loops verifier invocations. Most fixes touch one deliverable; re-verifying the rest is waste. The mandatory full final gate (Hard Final Gate) catches anything cross-deliverable that selective mode missed — that's the safety net.
 
 ## Principles
+
+Operating principles for every pass:
 
 | Principle | Rule |
 |-----------|------|
 | **Context before spawning** | Read manifest and execution log before spawning verifiers — criterion IDs and prompts drive agent composition. |
 | **Orchestrate, don't verify** | Spawn agents to verify. You aggregate results and coordinate, never run checks yourself. |
-| **All in-scope criteria, no exceptions** | Every criterion in the current pass's scope (selective: in-scope deliverables' ACs + all INV-G*; full: every AC + every INV-G*) MUST be verified. Skipping any in-scope criterion is a critical failure. |
+| **All in-scope criteria, mode-authorized skips only** | Every criterion in the current pass's scope (selective: in-scope deliverables' ACs + all INV-G*; full: every AC + every INV-G*) MUST be verified, except where the active execution mode file explicitly authorizes a skip (e.g., quality-gate reviewers in efficient mode). Skipping any criterion not authorized by the mode file is a critical failure. |
 | **Parallelism per mode** | The active execution mode defines how many verifiers to launch concurrently within each phase. Phases always run sequentially — see Phased Execution below. |
 | **Actionable feedback** | Pass through file:line, expected vs actual, fix hints. |
-| **Don't handle user feedback during a pass** | While /verify is running, any user message arriving mid-pass is semantically feedback to the caller (/do, or the user who invoked /verify --deferred directly) — /verify never amends, never re-prompts, never deviates from its current pass. It returns results; the caller interprets new user input per its own rules (e.g., /do's Mid-Execution Amendment). User-direct invocations of /verify --deferred run to completion the same way. |
+| **Don't handle user feedback during a pass** | **While /verify is running**, any user message arriving mid-pass is semantically feedback to the caller (/do, or the user who invoked /verify --deferred directly) — /verify never amends, never re-prompts, never deviates from its current pass. It returns results; the caller interprets new user input per its own rules (e.g., /do's Mid-Execution Amendment). User-direct invocations of /verify --deferred run to completion the same way. |
 
 ## Verification Routing
 
-Route `manual` criteria to /escalate. Route `subagent` criteria to the named agent specified in the criterion. Route `deferred-auto` criteria per the "Deferred-Auto Criteria" section below — they are **skipped during normal /verify flow** and only run when `--deferred` is passed; under `--deferred`, they are routed by the inner shape of their verify block (if `agent:` is set, route to that named subagent; if `command:` is set, route to criteria-checker as bash; otherwise default to criteria-checker). All other types (`bash`, `codebase`, `research`) spawn criteria-checker agents. If a criterion has no verification type, default to criteria-checker.
+Route by criterion `method:`:
+
+| Method | Verifier |
+|--------|----------|
+| `bash`, `codebase`, `research` | criteria-checker (mode-routed model) |
+| `subagent` | the named agent in the criterion's `agent:` field |
+| `manual` | /escalate (no automated check exists) |
+| `deferred-auto` | skipped on normal passes (see Deferred-Auto Criteria); under `--deferred`, routed by the inner nested `method:` field |
+| (none / unrecognized) | criteria-checker |
+
+**Deferred-auto requires an explicit inner method.** A `method: deferred-auto` verify block MUST declare a sibling `inner_method:` field (`subagent` | `bash` | `codebase` | `research`). Under `--deferred`, /verify routes the criterion identically to a non-deferred criterion of that `inner_method`. If `inner_method` is missing, halt: `Deferred-auto criterion <ID> missing inner_method.` Field shape (canonical example):
+
+```yaml
+verify:
+  method: deferred-auto
+  inner_method: subagent
+  agent: general-purpose
+  prompt: "..."
+```
 
 ## Agent Prompt Composition
 
-When spawning verifier agents, pass the criterion's manifest data. Do not add your own framing.
+Pass each verifier exactly three sections, **in this order, each on its own line**:
 
-**Include**: Criterion ID, description, verification method, and the verify block's `command:` or `prompt:` field verbatim. Add file scope when the criterion targets specific files.
+1. **Cross-repo prefix** (only when the manifest declares `Repos:`) — the verbatim string defined in `define/references/MULTI_REPO.md` §e (single source of truth). Single-repo manifests skip this line.
+2. **Optional context line** (only when at least one of manifest / discovery log / execution log path exists) — `Optional context — manifest: <path>, discovery log: <path>, execution log: <path>`. Include only paths that exist. This is informational, not directive — agents decide whether the context is relevant.
+3. **Criterion content** — the criterion's manifest data: ID, description, verification method, and the verify block's `command:` or `prompt:` field verbatim. If `prompt:` is absent (e.g., bash criteria), pass the criterion's description as the agent prompt instead. Add file scope when the criterion targets specific files.
 
-**Optional context file paths**: When a manifest file, discovery log, or execution log exists, append their file paths as optional reference material. Present them neutrally — agents can read them if useful for understanding scope or context, but are not required to.
+The cross-repo prefix is the one prescribed exception to "do not add framing" — it is manifest-driven (derived from `Repos:`), not orchestrator opinion.
 
-Format: `Optional context — manifest: <path>, discovery log: <path>, execution log: <path>`
+**Never add to the criterion content:**
 
-Only include paths that exist. This is informational, not directive — agents decide whether the context is relevant to their review.
-
-**Never add**:
 - Severity thresholds ("only report medium+ issues", "focus on critical findings")
 - Implementation context ("the code was refactored to...", "this was implemented by...")
 - Opinions or expectations ("this should pass", "this is likely fine")
@@ -61,9 +94,7 @@ Only include paths that exist. This is informational, not directive — agents d
 - Suggested outcomes ("confirm that X works correctly")
 - Interpretations of manifest intent ("the goal is to...", "this change is about...")
 
-The verify block's `prompt:` field is manifest-authored — pass it verbatim. These rules target language you add beyond what the manifest specifies. The optional context file paths are raw references, not framing — they provide access to source material without steering the agent's analysis.
-
-**Exception — manifest-driven `Repos:` prefix.** When the manifest declares `Repos:`, the cross-repo path prefix (`Available repos: name=/path, ...`) is prepended to every verifier's prompt per "Cross-repo path delivery to verifiers" below. This is the one prescribed exception to "Do not add your own framing" — the prefix is manifest-driven (derived from `Repos:`), not orchestrator opinion.
+The verify block's `prompt:` field is manifest-authored — pass it verbatim. These rules target language you add beyond what the manifest specifies. The optional context line is raw references, not framing — it provides access to source material without steering the agent's analysis.
 
 ## Criterion Types
 
@@ -73,7 +104,7 @@ The verify block's `prompt:` field is manifest-authored — pass it verbatim. Th
 | Acceptance Criteria | AC-{D}.{N} | Deliverable incomplete |
 | Process Guidance | PG-{N} | Not verified (guidance only) |
 
-Note: PG-* items guide HOW to work. Followed during /do, not checked by /verify.
+`{D}` = deliverable number; `{N}` = ordinal within scope (1-based). PG-* items guide HOW to work — followed during /do, not checked by /verify.
 
 ## Agent Failures
 
@@ -92,13 +123,9 @@ Criteria have an optional `phase:` field (numeric, default 1). Phases run in asc
 
 **Phase failure reporting:** When a phase fails, include the phase number in the failure report and note which later phases were not run (e.g., "Phase 1: 2 failures. Phase 2: not run (3 criteria pending).").
 
-**Phase and scope are orthogonal.** `phase:` gates execution order (ascending); selective vs full filters the universe of criteria. Within a selective pass, the filter applies first (which deliverables' ACs + all globals), then phases gate the filtered set. Conflating them is wrong — phase ordering is unchanged by selection.
+**Phase and scope are orthogonal.** `phase:` gates execution order (ascending); selective vs full filters the universe of criteria. Within a selective pass, the filter applies first (which deliverables' ACs + all globals), then phases gate the filtered set.
 
-**Backward compatibility:** Manifests without any `phase:` fields have all criteria in phase 1 — identical to current behavior (all criteria run together per mode parallelism).
-
-## Mode-Aware Verification
-
-Load the mode file at `../do/references/execution-modes/{mode}.md` (default: `thorough`). Follow its rules for verification parallelism, model routing, and quality gate inclusion. The mode file defines which verifiers to skip, what model to use for criteria-checker agents, and how many concurrent verifiers to launch per phase. If mode file cannot be loaded, return an error to the caller immediately — do not attempt any verification.
+**Backward compatibility:** Manifests without any `phase:` fields have all criteria in phase 1 — identical to the prior behavior (all criteria run together per mode parallelism).
 
 ## Gotchas
 
@@ -111,56 +138,60 @@ Group results by phase, then Global Invariants first, then by Deliverable.
 
 | Condition | Action |
 |-----------|--------|
-| Any Global Invariant failed | Return all failures, globals highlighted |
-| Any AC failed | Return failures grouped by deliverable |
-| All in-scope pass, **selective mode that actually narrowed** (`--scope` was set) | **Auto-trigger a full pass** (re-invoke /verify internally with `--final`). Do NOT call /done. Manual criteria in scope are NOT escalated yet — they're deferred to the auto-triggered full pass per the rule below. |
-| All pass, **full mode**, manual criteria exist (no pending deferred-auto) | List manual criteria with how-to-verify, suggest /escalate |
-| All pass, **full mode**, **deferred-auto criteria exist and not all verified green via prior `--deferred` pass** (no manual criteria) | /escalate with "Deferred-Auto Pending" — see "Deferred-Pending Escalation" below. Do NOT call /done. |
-| All pass, **full mode**, **manual criteria AND pending deferred-auto criteria** | Combined /escalate (Manual Review + Deferred-Auto Pending) per "When BOTH" in Deferred-Pending Escalation below. Do NOT call /done. |
-| All pass, **full mode**, no pending deferred-auto criteria, no manual criteria | Call /done |
+| **Any Global Invariant failed** | **Return all failures, globals highlighted** |
+| **Any AC failed** (no global failures) | **Return failures grouped by deliverable** |
+| **All in-scope pass; true-selective pass (`--scope` was set)** | **Auto-trigger a full pass** (re-invoke /verify internally with `--final`). Do NOT call /done. Manual escalation and Deferred-Auto Pending escalation are both deferred to the auto-triggered full pass. |
+| **All pass; full or selective-degenerated-to-full; manual criteria exist; no pending deferred-auto** | **/escalate "Manual Criteria Review"** with each manual criterion + its how-to-verify. Do NOT call /done. |
+| **All pass; full or selective-degenerated-to-full; pending deferred-auto exist; no manual criteria** | **/escalate "Deferred-Auto Pending"** — see Deferred-Auto Pending Escalation. Do NOT call /done. |
+| **All pass; full or selective-degenerated-to-full; manual AND pending deferred-auto** | **Combined /escalate** (Manual Criteria Review + Deferred-Auto Pending). Do NOT call /done. |
+| **All pass; full or selective-degenerated-to-full; no manual; no pending deferred-auto** | **Call /done** |
 
-**Selective that degenerated to full = full mode for outcome handling.** When `--scope` is absent and `--final` is absent, the pass covered every criterion already. Treat as a full pass: if manual criteria exist OR pending deferred-auto criteria exist → escalate (combine both per "Deferred-Pending Escalation §When BOTH"); otherwise → call /done. There is no "auto-trigger another full pass" for degenerated-to-full — that's redundant since the pass already covered everything.
+**Selective-degenerated-to-full** = a selective pass where `--scope` was absent. The pass already covered every criterion, so it's treated as full for outcome handling. There is no "auto-trigger another full pass" — that would be redundant.
 
-**Manual criteria in selective mode.** When a selective pass encounters manual criteria within its in-scope deliverables and all automated checks pass, manual escalation is **deferred** to the auto-triggered full pass. Rationale: the full pass surfaces every manual criterion across every deliverable, so escalating partial manual criteria from a selective pass would fragment the user-facing escalation. Manual escalation fires exactly once per /verify chain — at the end of the full pass — never from a selective pass.
-
-**Hard final gate.** /done is unreachable from selective-mode green alone. Per project directive ("Done means nothing more to do"), only a full-mode green pass — every AC across every deliverable + every Global Invariant — **with no pending deferred-auto criteria** calls /done. When deferred-auto criteria are pending (no prior `--deferred` pass covered them), /verify routes to /escalate ("Deferred-Auto Pending") instead — see Deferred-Pending Escalation. The auto-triggered full pass is unconditional: no mode override, no opt-out. If the auto-triggered full pass fails, /verify returns the failures to /do, which enters the standard fix-loop. Failure during a final pass behaves identically to failure during any other pass — fix, then a fresh selective pass scoped to the failing deliverable, then auto-trigger full again.
-
-**`--final` is internal-only.** /verify uses `--final` to re-invoke itself after a selective green; /do does NOT pass `--final`. /do invokes /verify either with no scope flags (degenerates to full on first pass) or with `--scope D2,D3` (selective). The internal-only constraint preserves the gate: /do can never bypass the selective→full chain by manually requesting a final-only pass.
-
-**Mode is preserved across the recursion.** When /verify auto-triggers itself with `--final`, it carries forward the active `--mode <X>` from the current invocation (efficient | balanced | thorough). The auto-triggered final pass runs at the same intensity (parallelism + model routing + skip rules) as the selective pass that triggered it — never forced to thorough. The "full suite" guarantee is unconditional; the *intensity per criterion* follows the active mode (preserves the orthogonality between selective/full and mode established earlier in this skill).
+**Manual criteria in true selective mode** (where `--scope` was set). Manual escalation is **deferred** to the auto-triggered full pass so that escalation fires exactly once per /verify chain — at the end of the full pass. Surfacing partial manual criteria from a true selective pass would fragment the user-facing escalation.
 
 **On phase failure**: Show the failed phase, then for each failed criterion: ID, description, verification method, failure details (location, expected vs actual, fix hint). Note later phases not run and their pending criteria count.
 
+### Hard Final Gate
+
+- **/done is unreachable from selective-mode green alone.** Per project directive ("Done means nothing more to do"), only a full-mode green pass — every AC across every deliverable + every Global Invariant — **with no pending manual criteria and no pending deferred-auto criteria** calls /done.
+- **Pending manual blocks /done.** When manual criteria exist (and the pass is the kind that can call /done), /verify routes to /escalate ("Manual Criteria Review") instead — the user verifies manually, then re-invokes /verify.
+- **Pending deferred-auto blocks /done.** When deferred-auto criteria are pending, /verify routes to /escalate ("Deferred-Auto Pending") instead — see Deferred-Auto Pending Escalation.
+- **Both pending → combined /escalate.** Surface both types in one block (see Deferred-Auto Pending Escalation § "When BOTH").
+- **Once a true-selective pass goes green, the auto-trigger fires unconditionally** — no mode override, no opt-out.
+- **Auto-final failure → standard fix-loop.** /verify returns failures to /do, which fixes; /verify then runs a fresh selective pass scoped to the failing deliverable, then auto-triggers full again.
+- **`--final` is internal-only.** /verify uses `--final` to re-invoke itself after a true-selective green; /do never passes it. /do invokes /verify either with no scope flags (degenerates to full on first pass) or with `--scope D2,D3` (selective). This preserves the gate: /do can never bypass the selective→full chain.
+- **Mode is preserved across the auto-final re-invocation.** /verify carries forward the active `--mode <X>` (efficient | balanced | thorough). The auto-final pass runs at the same intensity as the selective pass that triggered it — never forced to thorough. The "full suite" guarantee is unconditional; the *intensity per criterion* follows the active mode.
+
 ## Deferred-Auto Criteria
 
-`method: deferred-auto` marks a criterion as **automatically verifiable but user-triggered** — typically a cross-repo gate the user signals readiness for (e.g., "all PRs deployed"). The verifier itself runs automatically (bash command, subagent prompt, etc.); only the *triggering* is user-controlled.
+`method: deferred-auto` marks a criterion as **automatically verifiable but user-triggered** — typically a cross-repo gate the user signals readiness for (e.g., "all PRs deployed"). The verifier itself runs automatically (bash command, subagent prompt, etc.); only the *triggering* is user-controlled. Deferred-auto verify blocks MUST declare an explicit sibling `inner_method:` (subagent | bash | codebase | research) — see Verification Routing for the field shape.
 
-**Normal flow skips them.** Selective and full passes (with or without `--scope`/`--final`) ignore `deferred-auto` criteria entirely during the pass — they never appear in the failure list of a normal pass. **However, their absence-of-coverage gates `/done` routing per "Deferred-Pending Escalation" below**: a normal-flow green pass with pending deferred-auto criteria routes to `/escalate` ("Deferred-Auto Pending"), not `/done`.
+**Normal flow skips them.** Selective and full passes (with or without `--scope`/`--final`) ignore `deferred-auto` criteria entirely during the pass — they never appear in the failure list of a normal pass. **However, uncovered deferred-auto criteria block /done — a normal-flow green pass with pending deferred-auto routes to /escalate ("Deferred-Auto Pending"), not /done.** See Deferred-Auto Pending Escalation below.
 
 **`--deferred` runs them.** When `/verify ... --deferred` is invoked, /verify runs **only** `deferred-auto` criteria (everything else is skipped, including INV-Gs and ACs of other methods).
 
 **Flag interactions:**
+
 - `--deferred` + `--scope` is supported. `--scope` narrows the deferred-auto set to in-scope deliverables.
 - `--deferred` does not interact with `--final` — never enters the final-gate machinery, never auto-triggers a follow-up pass, never calls /done.
 - `--deferred` inherits `--mode` — same parallelism / model routing as the parent invocation.
 - `--deferred` invoked without `--scope` covers all `deferred-auto` criteria across the manifest.
 - A manifest with no `deferred-auto` criteria sees `--deferred` as a clean no-op ("no deferred-auto criteria in manifest").
 
-**Deferred-Pending Escalation.** When a normal-flow `/verify` pass (selective or full) completes green but the manifest contains `deferred-auto` criteria that have not been verified green via a prior `/verify --deferred` run, `/verify` must NOT call `/done`. Instead, it routes to `/escalate` with type "Deferred-Auto Pending" and a message telling the user which deferred-auto criteria remain and instructing them to invoke `/verify --deferred` once prerequisites are in place. Once those criteria pass via `--deferred`, a subsequent normal `/verify` pass can call `/done`.
+**Coverage determination.** A deferred-auto criterion is "covered" when there exists a preceding pass-log block where `deferred: true`, `result: pass`, and either (a) `scope:` is empty (full deferred coverage), or (b) `scope:` contains the deliverable that owns the criterion. /verify aggregates coverage across all prior `--deferred` blocks: a criterion is pending iff no prior deferred-pass block satisfies (a) or (b). INV-G* deferred-auto criteria are deliverable-scope-independent — covered only by a block where `deferred: true` and `scope: []`.
 
-**Coverage determination.** A deferred-auto criterion is considered "covered" when there exists a preceding pass-log block with `deferred: true`, `result: pass`, and either (a) `scope:` is empty (full deferred coverage), or (b) `scope:` contains the deliverable that owns the criterion. /verify aggregates coverage across all prior `--deferred` blocks in the log: a criterion is pending iff no prior deferred-pass block satisfies (a) or (b) for it. INV-G* deferred-auto criteria are deliverable-scope-independent — they are covered only by a `deferred: true scope: []` block.
+### Deferred-Auto Pending Escalation
 
-**When BOTH manual criteria and pending deferred-auto criteria exist** after a normal full-mode green pass, surface BOTH in a single combined escalation block: list the manual criteria + their how-to-verify, AND list the pending deferred-auto criteria + the `/verify --deferred` instruction. /done remains unreachable until both are resolved.
+When a normal-flow `/verify` pass (selective or full) completes green but the manifest contains `deferred-auto` criteria not yet covered, /verify routes to `/escalate` with type `"Deferred-Auto Pending"`. The escalation message lists the pending criteria and instructs the user to invoke `/verify --deferred` once prerequisites are in place. Once those criteria pass via `--deferred`, a subsequent normal `/verify` pass can call `/done`.
 
-**After `/verify --deferred` completes green** (all deferred-auto criteria pass), close the user-as-coordinator loop with an explicit next-step instruction: emit a message like *"Deferred-auto criteria green. Re-invoke `/verify <manifest> <log>` (no flags) to reach /done."* Do NOT call /done from the `--deferred` pass itself — `--deferred` only verifies the deferred-auto subset; the final `/done` decision belongs to a normal-flow pass that confirms the full criterion universe is still green AND the deferred coverage now satisfies the gate.
+**When BOTH manual criteria AND pending deferred-auto exist** after a normal full-mode green pass, surface BOTH in a single combined escalation block: list the manual criteria + their how-to-verify, AND list the pending deferred-auto criteria + the `/verify --deferred` instruction. /done remains unreachable until both are resolved.
 
-**Cross-repo path delivery to verifiers.** When the manifest declares `Repos: [name: path, ...]`, **every `/verify` pass** (selective, full, and `--deferred`) prepends a verbatim string to each verifier's prompt before the criterion's own prompt:
+**After `/verify --deferred` completes green** (all deferred-auto criteria pass), close the user-as-coordinator loop with an explicit next-step instruction: emit a message like *"Deferred-auto criteria green. Re-invoke `/verify <manifest> <log>` (no flags) to reach /done."* Do NOT call /done from the `--deferred` pass itself — `--deferred` only verifies the deferred-auto subset; the final /done decision belongs to a normal-flow pass that confirms the full criterion universe is still green AND the deferred coverage now satisfies the gate.
 
-```
-Available repos: name1=/path/1, name2=/path/2, ...
-```
+### Cross-Repo Path Delivery
 
-This is the one mechanism — verifiers do not parse the manifest themselves. The injection fires on every pass, not just `--deferred`, so cross-repo verifiers can run during normal `/do→/verify` flow — that's what makes `/done` reachable for multi-repo manifests without per-repo /done independence. Single-repo manifests (no `Repos:` field) get no prefix injection. Full convention: `references/MULTI_REPO.md` (lives in `define/references/`) §e.
+When the manifest declares `Repos:`, every /verify pass (selective, full, and `--deferred`) prepends a verbatim cross-repo prefix to each verifier's prompt. Format and full convention: `define/references/MULTI_REPO.md` §e (single source of truth). The prefix injection fires on every pass, not just `--deferred`, so cross-repo verifiers can run during normal `/do→/verify` flow — that's what makes /done reachable for multi-repo manifests without per-repo /done independence. Single-repo manifests (no `Repos:` field) get no prefix injection.
 
 ## /verify Pass Logging Contract
 
@@ -170,17 +201,22 @@ Every /verify invocation appends a structured block to the execution log so /do 
 ## /verify pass {N}
 
 ```yaml
-mode: selective|full             # for --deferred passes: selective if --scope was set, else full
+mode: selective|full             # under deferred:true, reflects --scope filter only — see Deferred-Auto Criteria
 scope: [<deliverable-id>, ...]   # empty list when mode is full
 result: pass|fail
 failures: [<criterion-id>, ...]  # empty when pass; criterion IDs only, no narrative
-auto_triggered_final: true|false # true when this pass was auto-triggered after selective green; always false for --deferred passes
+auto_triggered_final: true|false # true only when this pass was auto-triggered by /verify after a true-selective green; false for first-pass-degenerated-to-full and for --deferred passes
 deferred: true|false             # true when this pass ran via --deferred (only deferred-auto criteria checked); false for normal selective/full passes
 ```
 
 [narrative — failed criterion details, fix hints, etc., per Outcome Handling]
 ````
 
-When `deferred: true`, consumers should treat the pass as a partial verification (only `deferred-auto` criteria) — never as evidence that normal-flow ACs/INVs passed. The `result: pass` of a deferred pass means "the deferred-auto criteria are green," not "the whole manifest is green."
+**Field semantics:**
 
-Pure markdown so humans can read; fenced YAML so /do and a future /verify can parse deterministically. Pass numbers are sequential within the execution log. /do uses the most recent block to track progress and decide which pass to invoke next.
+- **`deferred` is the master interpretation flag.** Consumers MUST read `deferred` before `mode`. Under `deferred: true`, `result: pass` means "the deferred-auto criteria are green," not "the whole manifest is green." Under `deferred: true`, write `mode: selective` if `--scope` was set, else `mode: full`.
+- **Degenerated-to-full logging.** When `--scope` and `--final` are both absent (and `--deferred` is not set), log `mode: full`, `scope: []`, `auto_triggered_final: false`. The pass already covered everything — log it as full.
+- **`result: pass` does not imply /done was called.** A green pass may route to /escalate (Manual Criteria Review, Deferred-Auto Pending, or both) instead. Consumers asking "did /done fire?" must re-derive from the manifest's manual / deferred-auto coverage, not from `result` alone.
+- **Consumers driving next-pass scope decisions** (e.g., /do scanning for the latest pass) MUST skip blocks where `deferred: true` — those reflect partial verification, not normal-flow AC/INV state.
+
+Pure markdown so humans can read; fenced YAML so /do and a future /verify can parse deterministically. Pass numbers are sequential within the execution log. /do reads the most recent block, skipping `deferred: true` blocks per Field semantics above, to track progress and decide which pass to invoke next.

--- a/dist/gemini/.sync-meta.json
+++ b/dist/gemini/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "c817b391918393b66d88acb6ce7663e2ba75f52c",
+  "source_commit": "08c688927317bb652db59f48299623fc5a9fad7b",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-02T07:44:57Z"
+  "synced_at": "2026-05-02T20:36:36Z"
 }

--- a/dist/gemini/skills/define/SKILL.md
+++ b/dist/gemini/skills/define/SKILL.md
@@ -342,13 +342,14 @@ Three categories, each covering output or process:
   verify:
     method: bash | codebase | subagent | research | manual | deferred-auto
     phase: 1                       # optional integer, default 1; higher phases run after lower pass
-    command: "[if bash]"
-    agent: "[if subagent]"
+    inner_method: subagent | bash | codebase | research   # REQUIRED when method: deferred-auto
+    command: "[if bash, or if deferred-auto with inner_method: bash]"
+    agent: "[if subagent, or if deferred-auto with inner_method: subagent]"
     model: "[if subagent, default inherit]"
-    prompt: "[if subagent or research]"
+    prompt: "[if subagent or research, or matching deferred-auto inner_method]"
   ```
 
-*`deferred-auto`: user-triggered; runs only via `/verify --deferred`. See `references/MULTI_REPO.md` §e for cross-repo semantics.*
+*`deferred-auto`: user-triggered; runs only via `/verify --deferred`. The required `inner_method` field names the underlying verifier type used when the deferred run executes. See `references/MULTI_REPO.md` §e for cross-repo semantics.*
 
 *Auto-decided items (Encoding Disciplines § Auto-decided items) carry an `(auto)` annotation immediately after the ID, e.g. `- [INV-G2] (auto) Description: ...`. The same convention applies to AC-* and PG-* entries that were auto-decided. Each auto-decided item also appears in Known Assumptions with its reasoning.*
 
@@ -373,10 +374,11 @@ Three categories, each covering output or process:
   verify:
     method: bash | codebase | subagent | research | manual | deferred-auto
     phase: 1                       # optional integer, default 1
-    command: "[if bash]"
-    agent: "[if subagent]"
+    inner_method: subagent | bash | codebase | research   # REQUIRED when method: deferred-auto
+    command: "[if bash, or deferred-auto + inner_method: bash]"
+    agent: "[if subagent, or deferred-auto + inner_method: subagent]"
     model: "[if subagent, default inherit]"
-    prompt: "[if subagent or research]"
+    prompt: "[if subagent or research, or matching deferred-auto inner_method]"
   ```
   *AC verify blocks accept the same fields as INV-G verify blocks above.*
 

--- a/dist/gemini/skills/define/references/MULTI_REPO.md
+++ b/dist/gemini/skills/define/references/MULTI_REPO.md
@@ -83,12 +83,13 @@ Worked example — manifest declares:
 
 Cross-repo gates often cannot run during normal `/do→/verify` flow because they depend on prerequisites the user controls (e.g., "all PRs deployed to staging"). They are still **automatically verifiable** — just user-triggered.
 
-`method: deferred-auto` marks such criteria. Worked example:
+`method: deferred-auto` marks such criteria. Verify blocks MUST declare an explicit sibling `inner_method:` field naming the underlying verifier type (`subagent` | `bash` | `codebase` | `research`); under `/verify --deferred` the criterion is routed identically to a non-deferred criterion of that `inner_method`. Worked example:
 
 ```yaml
 - [INV-G7] Frontend SSO login round-trips through deployed backend
   verify:
     method: deferred-auto
+    inner_method: subagent
     agent: general-purpose
     prompt: "Hit https://staging.example.com/login with a test SAML assertion. Confirm successful redirect to /dashboard with a valid session cookie."
 ```

--- a/dist/gemini/skills/do/SKILL.md
+++ b/dist/gemini/skills/do/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: do
-description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Optional --mode efficient|balanced|thorough controls verification intensity (default: thorough). Only pass --mode when the user explicitly requests a different mode. Use when executing a manifest, running a plan, implementing a defined task.'
+description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Optional --mode efficient|balanced|thorough controls verification intensity (default: thorough). Use when executing a manifest, running a plan, implementing a defined task.'
 ---
 
 # /do - Manifest Executor
@@ -11,17 +11,17 @@ Execute a Manifest: satisfy all Deliverables' Acceptance Criteria while followin
 
 ## Input
 
-`$ARGUMENTS` = manifest file path (REQUIRED), optionally with execution log path, `--mode <level>`, and `--scope <deliverable-ids>`
+`$ARGUMENTS` = manifest file path (REQUIRED), optionally with execution log path, `--mode <level>`, and `--scope <deliverable-ids>`. Positional args (manifest path, then log path) and flags may interleave. First positional = manifest path; second positional (if present) = execution log path.
 
-If no arguments: Output error "Usage: /do <manifest-file-path> [log-file-path] [--mode efficient|balanced|thorough] [--scope D1,D2,...]"
+If no arguments, halt: `Usage: /do <manifest-file-path> [log-file-path] [--mode efficient|balanced|thorough] [--scope D1,D2,...]`
 
 Read the manifest file fully before any execution.
 
 ## Execution Mode
 
-Resolve mode from (highest precedence first): `--mode` argument → manifest `mode:` field → default `thorough`.
+Resolve mode from (highest precedence first): `--mode` argument → manifest `Mode` field → default `thorough`.
 
-Invalid mode value → error and halt: "Invalid mode '<value>'. Valid modes: efficient | balanced | thorough"
+Invalid `--mode` value → halt: `Invalid mode '<value>'. Valid modes: efficient | balanced | thorough`.
 
 Load the execution mode file for behavioral specifics:
 - `thorough` (default): read `references/execution-modes/thorough.md`
@@ -30,14 +30,15 @@ Load the execution mode file for behavioral specifics:
 
 Follow the loaded mode's rules for model routing, verification parallelism, fix-verify loop limits, and escalation for the remainder of this /do run.
 
-**Override precedence** (applies to all modes):
-1. **Criterion-level model wins**: When a manifest criterion specifies `model:` in its verify block, that overrides the mode's model routing.
-2. **Explicit model overrides skip**: If a criterion explicitly sets `model:`, it runs even when the mode would otherwise skip it.
-3. **Global Invariants always run**: INV-G* verification runs regardless of mode — constitutional constraints.
+**Model routing precedence** (applies to all modes):
+1. **Criterion-level model wins.** When a manifest criterion specifies `model:` in its verify block, that overrides the mode's model routing.
+2. **Explicit model overrides skip.** If a criterion explicitly sets `model:`, it runs even when the mode would otherwise skip it.
+
+**Always-on rule:** Global Invariants (INV-G*) verify regardless of mode — constitutional constraints.
 
 ## Existing Execution Log
 
-If input includes a log file path (iteration on previous work): **treat it as source of truth**. It contains prior execution history. Continue from where it left off—append to the same log, don't restart.
+If input includes a log file path (iteration on previous work): **treat it as source of truth**. It contains prior execution history. Continue from where it left off — append to the same log, don't restart.
 
 ## Scoped Execution
 
@@ -45,80 +46,79 @@ Parse `--scope` from arguments if present. Accepts comma-separated deliverable I
 
 When `--scope` is provided, read `references/SCOPED_EXECUTION.md` and follow its rules for scoped execution. This limits work to the specified deliverables while maintaining global invariant safety.
 
-When `--scope` is NOT provided, ignore this section entirely — no reference file is loaded, no scoping behavior applies. Full execution as normal.
+When `--scope` is NOT provided, ignore this section entirely. No reference file is loaded, no scoping behavior applies. Full execution as normal.
 
 ## Principles
 
 | Principle | Rule |
 |-----------|------|
 | **ACs define success** | Work toward acceptance criteria however makes sense. Manifest says WHAT, you decide HOW. |
-| **Approach is initial, not rigid** | Approach provides starting direction, but adapt freely when reality diverges. No escalation needed — log adjustments with rationale. |
+| **Approach is initial, not rigid** | Approach provides starting direction, but adapt freely when reality diverges. No escalation needed; log adjustments with rationale. |
 | **Target failures specifically** | On verification failure, fix the specific failing criterion. Don't restart. Don't touch passing criteria. |
 | **Verify fixes first** | After fixing a failure, confirm the fix works before re-running full verification. |
 | **Trade-offs guide adjustment** | When risks (R-*) materialize, consult trade-offs (T-*) for decision criteria. Log adjustments with rationale. |
 
 ## Constraints
 
-**Log after every action** - Write to execution log immediately after each AC attempt. No exceptions. This is disaster recovery—if context is lost, the log is the only record of what happened.
+**Log after every action.** Write to execution log immediately after each AC attempt. No exceptions. This is disaster recovery: if context is lost, the log is the only record of what happened.
 
-**Must call /verify** - Can't declare done without verification. Invoke manifest-dev:verify with manifest, log paths, the resolved mode, and an optional scope per the rules below: `/verify <manifest> <log> --mode <level> [--scope D2,D3]`. Never pass `--final` from /do — that flag is internal to /verify (auto-triggered after a selective green pass) and exists to enforce the hard final gate. /done is unreachable without a full-mode green pass; /verify owns the selective→full chain.
+**Must call /verify.** Can't declare done without verification. Invoke manifest-dev:verify with manifest, log paths, the resolved mode, and an optional scope per the rules below: `/verify <manifest> <log> --mode <level> [--scope D2,D3]`. Never pass `--final` from /do; that flag is internal to /verify (auto-triggered after a true-selective green pass where `--scope` was set). /done is unreachable without a full-pass green (every AC + every INV-G) with no pending manual or deferred-auto criteria.
 
-**Selective verification + fix-loop scope** - /verify supports two modes (see verify SKILL.md for full contract):
-- *First pass on fresh /do* — invoke without `--scope` and without `--final`. Selective mode degenerates to full (nothing to narrow). Equivalent to today's behavior.
-- *Scoped /do* (`--scope D2,D3` was passed to /do) — invoke /verify with the same `--scope D2,D3`. Selective pass runs those deliverables' ACs + all globals.
-- *Fix-loop after AC-X.Y failure* — invoke /verify with `--scope D{X}` (the failing criterion's deliverable). Other deliverables are not re-verified during this iteration; they get their pass at the mandatory full final gate when /verify auto-triggers it.
-- *Fix-loop after INV-G failure* — invoke /verify normally (globals always run; no narrowing makes sense). When the failure happened during a selective pass with a `--scope`, the next pass is selective on the same deliverable + globals. When the failure happened during a full pass (auto-triggered final, or first-pass degenerated-to-full — no `--scope` was set), the next pass is also full — invoke /verify with no `--scope`. INV-G failures are not deliverable-scoped, so falling through to full is the correct default.
+**Selective verification + fix-loop scope.** /verify supports selective and full passes (see verify SKILL.md for the full contract). /do invokes /verify in four patterns:
 
-The mandatory full final gate (auto-triggered by /verify after selective green) is the safety net for cross-deliverable regressions. Don't try to skip or short-circuit it.
+- *First pass on fresh /do.* Invoke without `--scope` and without `--final`. Selective mode degenerates to full (nothing to narrow).
+- *Scoped /do* (`--scope D2,D3` was passed to /do). Invoke /verify with the same `--scope D2,D3`. Selective pass runs those deliverables' ACs + all globals.
+- *Fix-loop after AC-X.Y failure.* Invoke /verify with `--scope D{X}` (the failing criterion's deliverable). Other deliverables are not re-verified during this iteration; they get their pass at the mandatory full final gate when /verify auto-triggers it. This applies whether the AC failure happened during a selective pass or during the auto-triggered full pass: scope to the failing deliverable, then let /verify auto-trigger full again on green.
+- *Fix-loop after INV-G failure.* Invoke /verify normally (globals always run; deliverable-scoping is meaningless for INV-G). When the failure happened during a selective pass with a `--scope`, the next pass is selective on the same scope + globals (re-pass exactly the deliverable IDs that were in the failing pass). When the failure happened during a full pass (auto-triggered final, or first-pass degenerated-to-full where `--scope` was not set), the next pass is also full: invoke /verify with no `--scope`.
 
-**Execution log /verify contract** - /verify appends a structured block (`## /verify pass {N}` + fenced YAML with `mode`, `scope`, `result`, `failures`, `auto_triggered_final`, `deferred`) per invocation. Read the most recent block before deciding the next pass's scope. Format defined in `verify/SKILL.md` "/verify Pass Logging Contract." When scanning for the most recent /verify pass to drive scope decisions, **skip blocks with `deferred: true`** — those reflect user-direct `--deferred` invocations (now possible since /verify is user-invocable), not /do-driven normal-flow passes.
+The mandatory full final gate (auto-triggered by /verify after true-selective green) is the safety net for cross-deliverable regressions. Selective scoping gives fast feedback during fixes; the full final gate guarantees nothing in the rest of the suite regressed. Don't try to skip or short-circuit it.
 
-**Escalation boundary** - Escalate when: (1) ACs can't be met as written (contract broken), (2) user requests a pause mid-workflow, (3) you discover an AC or invariant should be amended (use "Proposed Amendment" escalation type), or (4) the active execution mode's fix-verify loop limit is reached. If ACs remain achievable as written and no user interrupt, continue autonomously.
+**Execution log /verify contract.** /verify appends a structured block (`## /verify pass {N}` + fenced YAML with `mode`, `scope`, `result`, `failures`, `auto_triggered_final`, `deferred`) per invocation. Read the most recent block before deciding the next pass's scope. Format defined in `verify/SKILL.md` "/verify Pass Logging Contract." When scanning for the most recent /verify pass to drive scope decisions, **skip blocks with `deferred: true`**; those reflect user-direct `--deferred` invocations, not /do-driven normal-flow passes.
 
-**`/verify`-routed escalation passthrough.** When `/verify` itself routes to `/escalate` (e.g., "Deferred-Auto Pending", "Manual Criteria Review") instead of `/done`, treat as a clean terminal handoff: surface the escalation output verbatim to the caller, do NOT enter the fix-loop, do NOT increment loop counters. The implementation is green; further action belongs to the user (e.g., running `/verify --deferred` for deferred-auto pending). This is distinct from `/verify` returning failures (which enters the standard fix-loop).
+**Escalation boundary.** Escalate when: (1) ACs can't be met as written (contract broken); (2) user requests a pause mid-workflow; (3) you discover an AC or invariant should be amended (use "Proposed Amendment" escalation type); (4) the active execution mode's fix-verify loop limit is reached; (5) any user message arrives during /do or /verify (use "Self-Amendment"; see Mid-Execution Amendment below). If ACs remain achievable as written and no user interrupt, continue autonomously.
 
-**Mode-aware loop tracking** - Track fix-verify iteration count and escalation count in the execution log. When the active execution mode's limits are reached, follow its escalation rules.
+**`/verify`-routed escalation passthrough.** When `/verify` itself routes to `/escalate` (e.g., "Deferred-Auto Pending", "Manual Criteria Review", or the combined "Manual Review + Deferred-Auto Pending") instead of `/done`, treat as a clean terminal handoff: surface the escalation output verbatim to the caller, do NOT enter the fix-loop, do NOT increment loop counters. The implementation is green; further action belongs to the user (e.g., running `/verify --deferred` for deferred-auto pending). This is distinct from `/verify` returning failures (which enters the standard fix-loop).
 
-**Phase-aware verification** - /verify runs criteria in phases (ascending by `phase:` field, default 1). It may report "Phase N failed, Phase N+1 not run." After fixing failures, /verify restarts from Phase 1 to catch regressions. Loop limits apply per-phase; regressions increment the broken phase's counter, not the phase that caused them.
+**Mode-aware loop tracking.** Track fix-verify iteration count and escalation count in the execution log. When the active execution mode's limits are reached, follow its escalation rules.
 
-**Stop requires /escalate** - During /do, you cannot stop without calling /verify→/done or /escalate. If you need to pause, call /escalate with "User-Requested Pause" format. Bare outputs like "Done." or "Waiting." are not valid exits.
+**Phase-aware verification.** /verify runs criteria in phases (ascending by `phase:` field, default 1). It may report "Phase N failed, Phase N+1 not run." After fixing failures, /verify restarts from Phase 1 to catch regressions. Loop limits apply per-phase; regressions increment the broken phase's counter, not the phase that caused them.
+
+**Stop requires /escalate.** During /do, you cannot stop without calling /verify (which routes to /done or /escalate) or calling /escalate directly. If you need to pause, call /escalate with "User-Requested Pause" format. Silent halts and bare statements like "Done." or "Waiting." are not valid exits.
 
 ## Memento Pattern
 
 Externalize progress to survive context loss.
 
-**Execution log**: Create `/tmp/do-log-{timestamp}.md` at start. After EACH AC attempt, append what happened and the outcome. Goal: another agent reading only the log could resume work.
+**Execution log.** Create `/tmp/do-log-{timestamp}.md` at start. After EACH AC attempt, append what happened and the outcome. Goal: another agent reading only the log could resume work.
 
-**Todos**: Create from manifest (deliverables → ACs). Start with execution order from Approach (adjust if dependencies require). Update todo status after logging (log first, todo second).
+**Todos.** Create from manifest (deliverables → ACs). Start with execution order from Approach (adjust if dependencies require). Update todo status after logging (log first, todo second).
 
-**Refresh before verify** - Read full execution log before calling /verify to restore context.
+**Refresh before verify.** Read full execution log before calling /verify to restore context.
 
-**Refresh between deliverables** - Before starting a new deliverable, re-read the manifest's deliverable section and relevant log entries. Context degrades across long sessions.
+**Refresh between deliverables.** Before starting a new deliverable, re-read the manifest's deliverable section and relevant log entries. Context degrades across long sessions.
 
 ## Multi-Repo Navigation
 
-When the manifest declares `Repos: [name: path, ...]` in Intent, deliverables may live in repos other than cwd. Read the path map and use **absolute paths** in tool calls (Read/Edit/Write/Bash) when working on a deliverable tagged with a different repo. There is **no filter logic, no cwd matching, no per-repo configuration** — the LLM navigates as deliverables require.
+When the manifest declares `Repos: [name: path, ...]` in Intent, deliverables may live in repos other than cwd. Read the path map and use **absolute paths** in tool calls (Read/Edit/Write/Bash) when working on a deliverable tagged with a different repo. There is **no filter logic, no cwd matching, no per-repo configuration**; the LLM navigates as deliverables require.
 
 A single `/do` invocation can cover the whole multi-repo task by navigating between repos; alternatively the user invokes `/do` per repo with `--scope` for parallel execution. Either works. The execution log remains a single file per `/do` invocation.
 
-When the manifest has no `Repos:` field (single-repo manifest), this section does not apply — behavior is unchanged.
+When the manifest has no `Repos:` field (single-repo manifest), this section does not apply; behavior is unchanged.
 
-Full convention: `references/MULTI_REPO.md` (lives in `define/references/`).
+Full convention: `define/references/MULTI_REPO.md`.
 
 ## Mid-Execution Amendment
 
-**Default to amend.** Any user message arriving during /do or /verify defaults to triggering Self-Amendment. The manifest is the canonical source of truth for the PR/branch — or, in multi-repo cases, the **PR set / branch set** (see `references/AMENDMENT_MODE.md`). Feedback flows through it, not around it. The asymmetric framing is deliberate: silent scope drift (feedback acted on inline, manifest left out of date) is a worse failure than an occasional unnecessary amendment cycle.
+**Default to amend.** Any user message arriving during /do or /verify defaults to triggering Self-Amendment. The manifest is the canonical source of truth for the PR/branch (or, in multi-repo cases, the **PR set / branch set**; see `define/references/AMENDMENT_MODE.md`). Feedback flows through it, not around it. Asymmetric by design: silent scope drift (feedback acted on inline, manifest left out of date) is a worse failure than an occasional unnecessary amendment cycle.
 
-**Carve-out: pure questions.** Messages that ask about the manifest or process without requesting a state change are answered inline — no amendment.
+**Carve-out: pure questions.** Messages that ask about the manifest or process without requesting a state change are answered inline; no amendment.
 - *Amend:* "Also handle X." / "Change Y to Z." / "That's wrong, it should be …" / "Add a check for …"
 - *Inline:* "What does AC-1.1 require?" / "Why did you choose approach A over B?" / "Where's the execution log?" / "Which deliverable is D3?"
 
 **When ambiguous, amend.** A message that could be either ("hmm, what about the auth case?") goes to amendment. Re-running an amendment cycle is cheap; silently dropping a constraint that turns out to matter is expensive.
 
-**/verify-time feedback.** While /verify is running under /do, user feedback received mid-pass is semantically feedback to /do (the caller), not to /verify. The same default-to-amend rule applies. /verify itself never handles user feedback inline; the message is interpreted in /do's context and routed through Self-Amendment. (When /verify is invoked directly by the user — e.g., `/verify --deferred` — there is no /do caller; mid-pass user messages are handled per the user's own session reflex, not via /do's amendment route.)
+**/verify-time feedback.** While /verify is running under /do, user feedback received mid-pass is semantically feedback to /do (the caller), not to /verify. The same default-to-amend rule applies. /verify itself never handles user feedback inline (per /verify's "Don't handle user feedback during a pass" Principle); the message is interpreted in /do's context and routed through Self-Amendment. When /verify is invoked directly by the user (e.g., `/verify --deferred`), there is no /do caller, and mid-pass user messages are governed by /verify's own Principle, not /do's amendment route.
 
-**Amendment flow** — Amend the manifest autonomously via Self-Amendment escalation and `/define --amend <manifest-path> --from-do`, then resume with the updated manifest and existing log. Log the trigger before amending. No human wait — the entire cycle is autonomous.
+**Amendment flow.** Amend the manifest autonomously via Self-Amendment escalation and `/define --amend <manifest-path> --from-do`, then resume with the updated manifest and existing log. Log the trigger before amending. No human wait; the entire cycle is autonomous.
 
-**Amendment loop guard** (R-7) — If Self-Amendment escalations repeat without new external input (user messages or PR comments) between them, the amendments are likely oscillating — escalate as "Proposed Amendment" for human decision instead. The same guard applies to post-/done re-entry: when feedback after completion triggers re-entry to /do via amendment, the consecutive-amendments-without-external-input counter still applies. Purpose: prevent runaway loops and unnecessary token burn.
-
-**No-manifest case.** When /do is invoked without a manifest (rare — typically /do follows /define), default-to-amend doesn't apply: there is nothing to amend. Behavior falls back to inline handling. This is fail-open by design.
+**Amendment loop guard.** If Self-Amendment escalations repeat without new external input (user messages or PR comments) between them, the amendments are likely oscillating; escalate as "Proposed Amendment" for human decision instead. The same guard applies to post-/done re-entry: when feedback after completion triggers re-entry to /do via amendment, the consecutive-amendments-without-external-input counter still applies. Purpose: prevent runaway loops and unnecessary token burn.

--- a/dist/gemini/skills/verify/SKILL.md
+++ b/dist/gemini/skills/verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify
-description: 'Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest. Primary user-facing entry point is /verify --deferred (run user-triggered deferred-auto criteria); other invocations normally come from /do.'
+description: 'Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest. Normally invoked by /do; users invoke directly via /verify --deferred to run user-triggered deferred-auto criteria.'
 user-invocable: true
 ---
 
@@ -10,49 +10,82 @@ Orchestrate verification of all criteria from a Manifest by spawning parallel ve
 
 **Input**: $ARGUMENTS
 
-Format: `<manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough] [--scope D1,D2,...] [--final] [--deferred]`
+Format: `<manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough] [--scope D1,D2,...] [--deferred]`
 
-Both paths required — return usage error if missing. Mode defaults to `thorough` if not provided. `--scope` and `--final` are mutually exclusive (final is full by definition); when both appear, treat as final. `--deferred` runs only `method: deferred-auto` criteria — see "Deferred-Auto Criteria" below.
+If either path is missing, halt: `Usage: /verify <manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough] [--scope D1,D2,...] [--deferred]`. If the manifest path doesn't exist, halt: `Cannot verify: manifest '<path>' not found.` If the execution log path doesn't exist, **create it as an empty file** before proceeding — /verify must always be able to append a pass-log block.
+
+`--deferred` runs only `method: deferred-auto` criteria — see "Deferred-Auto Criteria" below.
+
+`--final` is internal-only — see "Hard Final Gate" below. /do never passes it; users never pass it.
+
+## Mode Resolution
+
+Resolve mode from (highest precedence first): `--mode` argument → manifest `Mode` field → `thorough`.
+
+Invalid `--mode` value → halt: `Invalid mode '<value>'. Valid modes: efficient | balanced | thorough`.
+
+The resolved mode controls verifier parallelism, model routing, and reviewer-skip rules per `../do/references/execution-modes/{mode}.md`. Load that file at entry; if it cannot be loaded, halt with the load error — do not attempt verification.
 
 ## Selective vs Full Verification
 
-/verify runs in one of two modes — selective or full — driven by the caller (/do):
+/verify runs in one of two modes — selective or full — driven by the caller (/do, or a user-direct invocation):
 
-- **Selective pass.** Runs only the ACs of the in-scope deliverables (passed via `--scope D2,D3`, or computed by /do as the deliverable owning a failed criterion in fix-loop) **plus all Global Invariants** (INV-G* always run). Used during the fix-loop and after scoped /do invocations to keep token cost bounded.
-- **Full pass.** Runs every AC across every deliverable plus all globals. Triggered by `--final` from /do, or auto-triggered by /verify itself after a selective pass goes green (see Outcome Handling).
+- **Selective pass.** Runs only the ACs of the in-scope deliverables (passed via `--scope D2,D3` — /do computes the failing-deliverable scope and passes it during fix-loop) **plus all Global Invariants** (INV-G* are in scope on every pass, subject to Phased Execution gating). Used during the fix-loop and after scoped /do invocations to keep token cost bounded.
+- **Full pass.** Runs every AC across every deliverable plus all globals (same phase gating). Auto-triggered by /verify itself (re-invoking with `--final`) after a true-selective pass goes green — see Hard Final Gate.
 
-**When `--scope` is absent and `--final` is absent**, selective mode degenerates to full — there's no narrowing to apply, so behavior matches today's "verify everything." This is also the first /verify pass on a fresh /do (no failure context yet, no scope flag).
+**Terminology.** *True-selective* = a selective pass where `--scope` was set (the filter actually narrowed). *Selective-degenerated-to-full* = a selective pass where `--scope` was absent (no narrowing to apply, so the pass covers everything). Outcome handling distinguishes the two — see Outcome Handling.
 
-**Why this exists.** Re-running every AC on every fix-loop iteration costs N × loops verifier invocations. Most fixes touch one deliverable; re-verifying the rest is waste. The mandatory full final gate (Outcome Handling) catches anything cross-deliverable that selective mode missed — that's the safety net.
+**When `--scope` is absent and `--final` is absent**, selective mode degenerates to full — behavior matches "verify everything." This applies to the first /verify pass on a fresh /do (no failure context yet, no scope flag) and to user-direct invocations like `/verify <manifest> <log>` with no flags.
+
+**Why this exists.** Re-running every AC on every fix-loop iteration costs N × loops verifier invocations. Most fixes touch one deliverable; re-verifying the rest is waste. The mandatory full final gate (Hard Final Gate) catches anything cross-deliverable that selective mode missed — that's the safety net.
 
 ## Principles
+
+Operating principles for every pass:
 
 | Principle | Rule |
 |-----------|------|
 | **Context before spawning** | Read manifest and execution log before spawning verifiers — criterion IDs and prompts drive agent composition. |
 | **Orchestrate, don't verify** | Spawn agents to verify. You aggregate results and coordinate, never run checks yourself. |
-| **All in-scope criteria, no exceptions** | Every criterion in the current pass's scope (selective: in-scope deliverables' ACs + all INV-G*; full: every AC + every INV-G*) MUST be verified. Skipping any in-scope criterion is a critical failure. |
+| **All in-scope criteria, mode-authorized skips only** | Every criterion in the current pass's scope (selective: in-scope deliverables' ACs + all INV-G*; full: every AC + every INV-G*) MUST be verified, except where the active execution mode file explicitly authorizes a skip (e.g., quality-gate reviewers in efficient mode). Skipping any criterion not authorized by the mode file is a critical failure. |
 | **Parallelism per mode** | The active execution mode defines how many verifiers to launch concurrently within each phase. Phases always run sequentially — see Phased Execution below. |
 | **Actionable feedback** | Pass through file:line, expected vs actual, fix hints. |
-| **Don't handle user feedback during a pass** | While /verify is running, any user message arriving mid-pass is semantically feedback to the caller (/do, or the user who invoked /verify --deferred directly) — /verify never amends, never re-prompts, never deviates from its current pass. It returns results; the caller interprets new user input per its own rules (e.g., /do's Mid-Execution Amendment). User-direct invocations of /verify --deferred run to completion the same way. |
+| **Don't handle user feedback during a pass** | **While /verify is running**, any user message arriving mid-pass is semantically feedback to the caller (/do, or the user who invoked /verify --deferred directly) — /verify never amends, never re-prompts, never deviates from its current pass. It returns results; the caller interprets new user input per its own rules (e.g., /do's Mid-Execution Amendment). User-direct invocations of /verify --deferred run to completion the same way. |
 
 ## Verification Routing
 
-Route `manual` criteria to /escalate. Route `subagent` criteria to the named agent specified in the criterion. Route `deferred-auto` criteria per the "Deferred-Auto Criteria" section below — they are **skipped during normal /verify flow** and only run when `--deferred` is passed; under `--deferred`, they are routed by the inner shape of their verify block (if `agent:` is set, route to that named subagent; if `command:` is set, route to criteria-checker as bash; otherwise default to criteria-checker). All other types (`bash`, `codebase`, `research`) spawn criteria-checker agents. If a criterion has no verification type, default to criteria-checker.
+Route by criterion `method:`:
+
+| Method | Verifier |
+|--------|----------|
+| `bash`, `codebase`, `research` | criteria-checker (mode-routed model) |
+| `subagent` | the named agent in the criterion's `agent:` field |
+| `manual` | /escalate (no automated check exists) |
+| `deferred-auto` | skipped on normal passes (see Deferred-Auto Criteria); under `--deferred`, routed by the inner nested `method:` field |
+| (none / unrecognized) | criteria-checker |
+
+**Deferred-auto requires an explicit inner method.** A `method: deferred-auto` verify block MUST declare a sibling `inner_method:` field (`subagent` | `bash` | `codebase` | `research`). Under `--deferred`, /verify routes the criterion identically to a non-deferred criterion of that `inner_method`. If `inner_method` is missing, halt: `Deferred-auto criterion <ID> missing inner_method.` Field shape (canonical example):
+
+```yaml
+verify:
+  method: deferred-auto
+  inner_method: subagent
+  agent: general-purpose
+  prompt: "..."
+```
 
 ## Agent Prompt Composition
 
-When spawning verifier agents, pass the criterion's manifest data. Do not add your own framing.
+Pass each verifier exactly three sections, **in this order, each on its own line**:
 
-**Include**: Criterion ID, description, verification method, and the verify block's `command:` or `prompt:` field verbatim. Add file scope when the criterion targets specific files.
+1. **Cross-repo prefix** (only when the manifest declares `Repos:`) — the verbatim string defined in `define/references/MULTI_REPO.md` §e (single source of truth). Single-repo manifests skip this line.
+2. **Optional context line** (only when at least one of manifest / discovery log / execution log path exists) — `Optional context — manifest: <path>, discovery log: <path>, execution log: <path>`. Include only paths that exist. This is informational, not directive — agents decide whether the context is relevant.
+3. **Criterion content** — the criterion's manifest data: ID, description, verification method, and the verify block's `command:` or `prompt:` field verbatim. If `prompt:` is absent (e.g., bash criteria), pass the criterion's description as the agent prompt instead. Add file scope when the criterion targets specific files.
 
-**Optional context file paths**: When a manifest file, discovery log, or execution log exists, append their file paths as optional reference material. Present them neutrally — agents can read them if useful for understanding scope or context, but are not required to.
+The cross-repo prefix is the one prescribed exception to "do not add framing" — it is manifest-driven (derived from `Repos:`), not orchestrator opinion.
 
-Format: `Optional context — manifest: <path>, discovery log: <path>, execution log: <path>`
+**Never add to the criterion content:**
 
-Only include paths that exist. This is informational, not directive — agents decide whether the context is relevant to their review.
-
-**Never add**:
 - Severity thresholds ("only report medium+ issues", "focus on critical findings")
 - Implementation context ("the code was refactored to...", "this was implemented by...")
 - Opinions or expectations ("this should pass", "this is likely fine")
@@ -61,9 +94,7 @@ Only include paths that exist. This is informational, not directive — agents d
 - Suggested outcomes ("confirm that X works correctly")
 - Interpretations of manifest intent ("the goal is to...", "this change is about...")
 
-The verify block's `prompt:` field is manifest-authored — pass it verbatim. These rules target language you add beyond what the manifest specifies. The optional context file paths are raw references, not framing — they provide access to source material without steering the agent's analysis.
-
-**Exception — manifest-driven `Repos:` prefix.** When the manifest declares `Repos:`, the cross-repo path prefix (`Available repos: name=/path, ...`) is prepended to every verifier's prompt per "Cross-repo path delivery to verifiers" below. This is the one prescribed exception to "Do not add your own framing" — the prefix is manifest-driven (derived from `Repos:`), not orchestrator opinion.
+The verify block's `prompt:` field is manifest-authored — pass it verbatim. These rules target language you add beyond what the manifest specifies. The optional context line is raw references, not framing — it provides access to source material without steering the agent's analysis.
 
 ## Criterion Types
 
@@ -73,7 +104,7 @@ The verify block's `prompt:` field is manifest-authored — pass it verbatim. Th
 | Acceptance Criteria | AC-{D}.{N} | Deliverable incomplete |
 | Process Guidance | PG-{N} | Not verified (guidance only) |
 
-Note: PG-* items guide HOW to work. Followed during /do, not checked by /verify.
+`{D}` = deliverable number; `{N}` = ordinal within scope (1-based). PG-* items guide HOW to work — followed during /do, not checked by /verify.
 
 ## Agent Failures
 
@@ -92,13 +123,9 @@ Criteria have an optional `phase:` field (numeric, default 1). Phases run in asc
 
 **Phase failure reporting:** When a phase fails, include the phase number in the failure report and note which later phases were not run (e.g., "Phase 1: 2 failures. Phase 2: not run (3 criteria pending).").
 
-**Phase and scope are orthogonal.** `phase:` gates execution order (ascending); selective vs full filters the universe of criteria. Within a selective pass, the filter applies first (which deliverables' ACs + all globals), then phases gate the filtered set. Conflating them is wrong — phase ordering is unchanged by selection.
+**Phase and scope are orthogonal.** `phase:` gates execution order (ascending); selective vs full filters the universe of criteria. Within a selective pass, the filter applies first (which deliverables' ACs + all globals), then phases gate the filtered set.
 
-**Backward compatibility:** Manifests without any `phase:` fields have all criteria in phase 1 — identical to current behavior (all criteria run together per mode parallelism).
-
-## Mode-Aware Verification
-
-Load the mode file at `../do/references/execution-modes/{mode}.md` (default: `thorough`). Follow its rules for verification parallelism, model routing, and quality gate inclusion. The mode file defines which verifiers to skip, what model to use for criteria-checker agents, and how many concurrent verifiers to launch per phase. If mode file cannot be loaded, return an error to the caller immediately — do not attempt any verification.
+**Backward compatibility:** Manifests without any `phase:` fields have all criteria in phase 1 — identical to the prior behavior (all criteria run together per mode parallelism).
 
 ## Gotchas
 
@@ -111,56 +138,60 @@ Group results by phase, then Global Invariants first, then by Deliverable.
 
 | Condition | Action |
 |-----------|--------|
-| Any Global Invariant failed | Return all failures, globals highlighted |
-| Any AC failed | Return failures grouped by deliverable |
-| All in-scope pass, **selective mode that actually narrowed** (`--scope` was set) | **Auto-trigger a full pass** (re-invoke /verify internally with `--final`). Do NOT call /done. Manual criteria in scope are NOT escalated yet — they're deferred to the auto-triggered full pass per the rule below. |
-| All pass, **full mode**, manual criteria exist (no pending deferred-auto) | List manual criteria with how-to-verify, suggest /escalate |
-| All pass, **full mode**, **deferred-auto criteria exist and not all verified green via prior `--deferred` pass** (no manual criteria) | /escalate with "Deferred-Auto Pending" — see "Deferred-Pending Escalation" below. Do NOT call /done. |
-| All pass, **full mode**, **manual criteria AND pending deferred-auto criteria** | Combined /escalate (Manual Review + Deferred-Auto Pending) per "When BOTH" in Deferred-Pending Escalation below. Do NOT call /done. |
-| All pass, **full mode**, no pending deferred-auto criteria, no manual criteria | Call /done |
+| **Any Global Invariant failed** | **Return all failures, globals highlighted** |
+| **Any AC failed** (no global failures) | **Return failures grouped by deliverable** |
+| **All in-scope pass; true-selective pass (`--scope` was set)** | **Auto-trigger a full pass** (re-invoke /verify internally with `--final`). Do NOT call /done. Manual escalation and Deferred-Auto Pending escalation are both deferred to the auto-triggered full pass. |
+| **All pass; full or selective-degenerated-to-full; manual criteria exist; no pending deferred-auto** | **/escalate "Manual Criteria Review"** with each manual criterion + its how-to-verify. Do NOT call /done. |
+| **All pass; full or selective-degenerated-to-full; pending deferred-auto exist; no manual criteria** | **/escalate "Deferred-Auto Pending"** — see Deferred-Auto Pending Escalation. Do NOT call /done. |
+| **All pass; full or selective-degenerated-to-full; manual AND pending deferred-auto** | **Combined /escalate** (Manual Criteria Review + Deferred-Auto Pending). Do NOT call /done. |
+| **All pass; full or selective-degenerated-to-full; no manual; no pending deferred-auto** | **Call /done** |
 
-**Selective that degenerated to full = full mode for outcome handling.** When `--scope` is absent and `--final` is absent, the pass covered every criterion already. Treat as a full pass: if manual criteria exist OR pending deferred-auto criteria exist → escalate (combine both per "Deferred-Pending Escalation §When BOTH"); otherwise → call /done. There is no "auto-trigger another full pass" for degenerated-to-full — that's redundant since the pass already covered everything.
+**Selective-degenerated-to-full** = a selective pass where `--scope` was absent. The pass already covered every criterion, so it's treated as full for outcome handling. There is no "auto-trigger another full pass" — that would be redundant.
 
-**Manual criteria in selective mode.** When a selective pass encounters manual criteria within its in-scope deliverables and all automated checks pass, manual escalation is **deferred** to the auto-triggered full pass. Rationale: the full pass surfaces every manual criterion across every deliverable, so escalating partial manual criteria from a selective pass would fragment the user-facing escalation. Manual escalation fires exactly once per /verify chain — at the end of the full pass — never from a selective pass.
-
-**Hard final gate.** /done is unreachable from selective-mode green alone. Per project directive ("Done means nothing more to do"), only a full-mode green pass — every AC across every deliverable + every Global Invariant — **with no pending deferred-auto criteria** calls /done. When deferred-auto criteria are pending (no prior `--deferred` pass covered them), /verify routes to /escalate ("Deferred-Auto Pending") instead — see Deferred-Pending Escalation. The auto-triggered full pass is unconditional: no mode override, no opt-out. If the auto-triggered full pass fails, /verify returns the failures to /do, which enters the standard fix-loop. Failure during a final pass behaves identically to failure during any other pass — fix, then a fresh selective pass scoped to the failing deliverable, then auto-trigger full again.
-
-**`--final` is internal-only.** /verify uses `--final` to re-invoke itself after a selective green; /do does NOT pass `--final`. /do invokes /verify either with no scope flags (degenerates to full on first pass) or with `--scope D2,D3` (selective). The internal-only constraint preserves the gate: /do can never bypass the selective→full chain by manually requesting a final-only pass.
-
-**Mode is preserved across the recursion.** When /verify auto-triggers itself with `--final`, it carries forward the active `--mode <X>` from the current invocation (efficient | balanced | thorough). The auto-triggered final pass runs at the same intensity (parallelism + model routing + skip rules) as the selective pass that triggered it — never forced to thorough. The "full suite" guarantee is unconditional; the *intensity per criterion* follows the active mode (preserves the orthogonality between selective/full and mode established earlier in this skill).
+**Manual criteria in true selective mode** (where `--scope` was set). Manual escalation is **deferred** to the auto-triggered full pass so that escalation fires exactly once per /verify chain — at the end of the full pass. Surfacing partial manual criteria from a true selective pass would fragment the user-facing escalation.
 
 **On phase failure**: Show the failed phase, then for each failed criterion: ID, description, verification method, failure details (location, expected vs actual, fix hint). Note later phases not run and their pending criteria count.
 
+### Hard Final Gate
+
+- **/done is unreachable from selective-mode green alone.** Per project directive ("Done means nothing more to do"), only a full-mode green pass — every AC across every deliverable + every Global Invariant — **with no pending manual criteria and no pending deferred-auto criteria** calls /done.
+- **Pending manual blocks /done.** When manual criteria exist (and the pass is the kind that can call /done), /verify routes to /escalate ("Manual Criteria Review") instead — the user verifies manually, then re-invokes /verify.
+- **Pending deferred-auto blocks /done.** When deferred-auto criteria are pending, /verify routes to /escalate ("Deferred-Auto Pending") instead — see Deferred-Auto Pending Escalation.
+- **Both pending → combined /escalate.** Surface both types in one block (see Deferred-Auto Pending Escalation § "When BOTH").
+- **Once a true-selective pass goes green, the auto-trigger fires unconditionally** — no mode override, no opt-out.
+- **Auto-final failure → standard fix-loop.** /verify returns failures to /do, which fixes; /verify then runs a fresh selective pass scoped to the failing deliverable, then auto-triggers full again.
+- **`--final` is internal-only.** /verify uses `--final` to re-invoke itself after a true-selective green; /do never passes it. /do invokes /verify either with no scope flags (degenerates to full on first pass) or with `--scope D2,D3` (selective). This preserves the gate: /do can never bypass the selective→full chain.
+- **Mode is preserved across the auto-final re-invocation.** /verify carries forward the active `--mode <X>` (efficient | balanced | thorough). The auto-final pass runs at the same intensity as the selective pass that triggered it — never forced to thorough. The "full suite" guarantee is unconditional; the *intensity per criterion* follows the active mode.
+
 ## Deferred-Auto Criteria
 
-`method: deferred-auto` marks a criterion as **automatically verifiable but user-triggered** — typically a cross-repo gate the user signals readiness for (e.g., "all PRs deployed"). The verifier itself runs automatically (bash command, subagent prompt, etc.); only the *triggering* is user-controlled.
+`method: deferred-auto` marks a criterion as **automatically verifiable but user-triggered** — typically a cross-repo gate the user signals readiness for (e.g., "all PRs deployed"). The verifier itself runs automatically (bash command, subagent prompt, etc.); only the *triggering* is user-controlled. Deferred-auto verify blocks MUST declare an explicit sibling `inner_method:` (subagent | bash | codebase | research) — see Verification Routing for the field shape.
 
-**Normal flow skips them.** Selective and full passes (with or without `--scope`/`--final`) ignore `deferred-auto` criteria entirely during the pass — they never appear in the failure list of a normal pass. **However, their absence-of-coverage gates `/done` routing per "Deferred-Pending Escalation" below**: a normal-flow green pass with pending deferred-auto criteria routes to `/escalate` ("Deferred-Auto Pending"), not `/done`.
+**Normal flow skips them.** Selective and full passes (with or without `--scope`/`--final`) ignore `deferred-auto` criteria entirely during the pass — they never appear in the failure list of a normal pass. **However, uncovered deferred-auto criteria block /done — a normal-flow green pass with pending deferred-auto routes to /escalate ("Deferred-Auto Pending"), not /done.** See Deferred-Auto Pending Escalation below.
 
 **`--deferred` runs them.** When `/verify ... --deferred` is invoked, /verify runs **only** `deferred-auto` criteria (everything else is skipped, including INV-Gs and ACs of other methods).
 
 **Flag interactions:**
+
 - `--deferred` + `--scope` is supported. `--scope` narrows the deferred-auto set to in-scope deliverables.
 - `--deferred` does not interact with `--final` — never enters the final-gate machinery, never auto-triggers a follow-up pass, never calls /done.
 - `--deferred` inherits `--mode` — same parallelism / model routing as the parent invocation.
 - `--deferred` invoked without `--scope` covers all `deferred-auto` criteria across the manifest.
 - A manifest with no `deferred-auto` criteria sees `--deferred` as a clean no-op ("no deferred-auto criteria in manifest").
 
-**Deferred-Pending Escalation.** When a normal-flow `/verify` pass (selective or full) completes green but the manifest contains `deferred-auto` criteria that have not been verified green via a prior `/verify --deferred` run, `/verify` must NOT call `/done`. Instead, it routes to `/escalate` with type "Deferred-Auto Pending" and a message telling the user which deferred-auto criteria remain and instructing them to invoke `/verify --deferred` once prerequisites are in place. Once those criteria pass via `--deferred`, a subsequent normal `/verify` pass can call `/done`.
+**Coverage determination.** A deferred-auto criterion is "covered" when there exists a preceding pass-log block where `deferred: true`, `result: pass`, and either (a) `scope:` is empty (full deferred coverage), or (b) `scope:` contains the deliverable that owns the criterion. /verify aggregates coverage across all prior `--deferred` blocks: a criterion is pending iff no prior deferred-pass block satisfies (a) or (b). INV-G* deferred-auto criteria are deliverable-scope-independent — covered only by a block where `deferred: true` and `scope: []`.
 
-**Coverage determination.** A deferred-auto criterion is considered "covered" when there exists a preceding pass-log block with `deferred: true`, `result: pass`, and either (a) `scope:` is empty (full deferred coverage), or (b) `scope:` contains the deliverable that owns the criterion. /verify aggregates coverage across all prior `--deferred` blocks in the log: a criterion is pending iff no prior deferred-pass block satisfies (a) or (b) for it. INV-G* deferred-auto criteria are deliverable-scope-independent — they are covered only by a `deferred: true scope: []` block.
+### Deferred-Auto Pending Escalation
 
-**When BOTH manual criteria and pending deferred-auto criteria exist** after a normal full-mode green pass, surface BOTH in a single combined escalation block: list the manual criteria + their how-to-verify, AND list the pending deferred-auto criteria + the `/verify --deferred` instruction. /done remains unreachable until both are resolved.
+When a normal-flow `/verify` pass (selective or full) completes green but the manifest contains `deferred-auto` criteria not yet covered, /verify routes to `/escalate` with type `"Deferred-Auto Pending"`. The escalation message lists the pending criteria and instructs the user to invoke `/verify --deferred` once prerequisites are in place. Once those criteria pass via `--deferred`, a subsequent normal `/verify` pass can call `/done`.
 
-**After `/verify --deferred` completes green** (all deferred-auto criteria pass), close the user-as-coordinator loop with an explicit next-step instruction: emit a message like *"Deferred-auto criteria green. Re-invoke `/verify <manifest> <log>` (no flags) to reach /done."* Do NOT call /done from the `--deferred` pass itself — `--deferred` only verifies the deferred-auto subset; the final `/done` decision belongs to a normal-flow pass that confirms the full criterion universe is still green AND the deferred coverage now satisfies the gate.
+**When BOTH manual criteria AND pending deferred-auto exist** after a normal full-mode green pass, surface BOTH in a single combined escalation block: list the manual criteria + their how-to-verify, AND list the pending deferred-auto criteria + the `/verify --deferred` instruction. /done remains unreachable until both are resolved.
 
-**Cross-repo path delivery to verifiers.** When the manifest declares `Repos: [name: path, ...]`, **every `/verify` pass** (selective, full, and `--deferred`) prepends a verbatim string to each verifier's prompt before the criterion's own prompt:
+**After `/verify --deferred` completes green** (all deferred-auto criteria pass), close the user-as-coordinator loop with an explicit next-step instruction: emit a message like *"Deferred-auto criteria green. Re-invoke `/verify <manifest> <log>` (no flags) to reach /done."* Do NOT call /done from the `--deferred` pass itself — `--deferred` only verifies the deferred-auto subset; the final /done decision belongs to a normal-flow pass that confirms the full criterion universe is still green AND the deferred coverage now satisfies the gate.
 
-```
-Available repos: name1=/path/1, name2=/path/2, ...
-```
+### Cross-Repo Path Delivery
 
-This is the one mechanism — verifiers do not parse the manifest themselves. The injection fires on every pass, not just `--deferred`, so cross-repo verifiers can run during normal `/do→/verify` flow — that's what makes `/done` reachable for multi-repo manifests without per-repo /done independence. Single-repo manifests (no `Repos:` field) get no prefix injection. Full convention: `references/MULTI_REPO.md` (lives in `define/references/`) §e.
+When the manifest declares `Repos:`, every /verify pass (selective, full, and `--deferred`) prepends a verbatim cross-repo prefix to each verifier's prompt. Format and full convention: `define/references/MULTI_REPO.md` §e (single source of truth). The prefix injection fires on every pass, not just `--deferred`, so cross-repo verifiers can run during normal `/do→/verify` flow — that's what makes /done reachable for multi-repo manifests without per-repo /done independence. Single-repo manifests (no `Repos:` field) get no prefix injection.
 
 ## /verify Pass Logging Contract
 
@@ -170,17 +201,22 @@ Every /verify invocation appends a structured block to the execution log so /do 
 ## /verify pass {N}
 
 ```yaml
-mode: selective|full             # for --deferred passes: selective if --scope was set, else full
+mode: selective|full             # under deferred:true, reflects --scope filter only — see Deferred-Auto Criteria
 scope: [<deliverable-id>, ...]   # empty list when mode is full
 result: pass|fail
 failures: [<criterion-id>, ...]  # empty when pass; criterion IDs only, no narrative
-auto_triggered_final: true|false # true when this pass was auto-triggered after selective green; always false for --deferred passes
+auto_triggered_final: true|false # true only when this pass was auto-triggered by /verify after a true-selective green; false for first-pass-degenerated-to-full and for --deferred passes
 deferred: true|false             # true when this pass ran via --deferred (only deferred-auto criteria checked); false for normal selective/full passes
 ```
 
 [narrative — failed criterion details, fix hints, etc., per Outcome Handling]
 ````
 
-When `deferred: true`, consumers should treat the pass as a partial verification (only `deferred-auto` criteria) — never as evidence that normal-flow ACs/INVs passed. The `result: pass` of a deferred pass means "the deferred-auto criteria are green," not "the whole manifest is green."
+**Field semantics:**
 
-Pure markdown so humans can read; fenced YAML so /do and a future /verify can parse deterministically. Pass numbers are sequential within the execution log. /do uses the most recent block to track progress and decide which pass to invoke next.
+- **`deferred` is the master interpretation flag.** Consumers MUST read `deferred` before `mode`. Under `deferred: true`, `result: pass` means "the deferred-auto criteria are green," not "the whole manifest is green." Under `deferred: true`, write `mode: selective` if `--scope` was set, else `mode: full`.
+- **Degenerated-to-full logging.** When `--scope` and `--final` are both absent (and `--deferred` is not set), log `mode: full`, `scope: []`, `auto_triggered_final: false`. The pass already covered everything — log it as full.
+- **`result: pass` does not imply /done was called.** A green pass may route to /escalate (Manual Criteria Review, Deferred-Auto Pending, or both) instead. Consumers asking "did /done fire?" must re-derive from the manifest's manual / deferred-auto coverage, not from `result` alone.
+- **Consumers driving next-pass scope decisions** (e.g., /do scanning for the latest pass) MUST skip blocks where `deferred: true` — those reflect partial verification, not normal-flow AC/INV state.
+
+Pure markdown so humans can read; fenced YAML so /do and a future /verify can parse deterministically. Pass numbers are sequential within the execution log. /do reads the most recent block, skipping `deferred: true` blocks per Field semantics above, to track progress and decide which pass to invoke next.

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "c817b391918393b66d88acb6ce7663e2ba75f52c",
+  "source_commit": "08c688927317bb652db59f48299623fc5a9fad7b",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-02T07:44:57Z"
+  "synced_at": "2026-05-02T20:36:36Z"
 }

--- a/dist/opencode/commands/verify.md
+++ b/dist/opencode/commands/verify.md
@@ -1,5 +1,5 @@
 ---
-description: "Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest. Primary user-facing entry point is /verify --deferred (run user-triggered deferred-auto criteria); other invocations normally come from /do."
+description: "Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest. Normally invoked by /do; users invoke directly via /verify --deferred to run user-triggered deferred-auto criteria."
 ---
 
 Invoke the manifest-dev:verify skill with: "$ARGUMENTS"

--- a/dist/opencode/skills/define/SKILL.md
+++ b/dist/opencode/skills/define/SKILL.md
@@ -342,13 +342,14 @@ Three categories, each covering output or process:
   verify:
     method: bash | codebase | subagent | research | manual | deferred-auto
     phase: 1                       # optional integer, default 1; higher phases run after lower pass
-    command: "[if bash]"
-    agent: "[if subagent]"
+    inner_method: subagent | bash | codebase | research   # REQUIRED when method: deferred-auto
+    command: "[if bash, or if deferred-auto with inner_method: bash]"
+    agent: "[if subagent, or if deferred-auto with inner_method: subagent]"
     model: "[if subagent, default inherit]"
-    prompt: "[if subagent or research]"
+    prompt: "[if subagent or research, or matching deferred-auto inner_method]"
   ```
 
-*`deferred-auto`: user-triggered; runs only via `/verify --deferred`. See `references/MULTI_REPO.md` §e for cross-repo semantics.*
+*`deferred-auto`: user-triggered; runs only via `/verify --deferred`. The required `inner_method` field names the underlying verifier type used when the deferred run executes. See `references/MULTI_REPO.md` §e for cross-repo semantics.*
 
 *Auto-decided items (Encoding Disciplines § Auto-decided items) carry an `(auto)` annotation immediately after the ID, e.g. `- [INV-G2] (auto) Description: ...`. The same convention applies to AC-* and PG-* entries that were auto-decided. Each auto-decided item also appears in Known Assumptions with its reasoning.*
 
@@ -373,10 +374,11 @@ Three categories, each covering output or process:
   verify:
     method: bash | codebase | subagent | research | manual | deferred-auto
     phase: 1                       # optional integer, default 1
-    command: "[if bash]"
-    agent: "[if subagent]"
+    inner_method: subagent | bash | codebase | research   # REQUIRED when method: deferred-auto
+    command: "[if bash, or deferred-auto + inner_method: bash]"
+    agent: "[if subagent, or deferred-auto + inner_method: subagent]"
     model: "[if subagent, default inherit]"
-    prompt: "[if subagent or research]"
+    prompt: "[if subagent or research, or matching deferred-auto inner_method]"
   ```
   *AC verify blocks accept the same fields as INV-G verify blocks above.*
 

--- a/dist/opencode/skills/define/references/MULTI_REPO.md
+++ b/dist/opencode/skills/define/references/MULTI_REPO.md
@@ -83,12 +83,13 @@ Worked example — manifest declares:
 
 Cross-repo gates often cannot run during normal `/do→/verify` flow because they depend on prerequisites the user controls (e.g., "all PRs deployed to staging"). They are still **automatically verifiable** — just user-triggered.
 
-`method: deferred-auto` marks such criteria. Worked example:
+`method: deferred-auto` marks such criteria. Verify blocks MUST declare an explicit sibling `inner_method:` field naming the underlying verifier type (`subagent` | `bash` | `codebase` | `research`); under `/verify --deferred` the criterion is routed identically to a non-deferred criterion of that `inner_method`. Worked example:
 
 ```yaml
 - [INV-G7] Frontend SSO login round-trips through deployed backend
   verify:
     method: deferred-auto
+    inner_method: subagent
     agent: general-purpose
     prompt: "Hit https://staging.example.com/login with a test SAML assertion. Confirm successful redirect to /dashboard with a valid session cookie."
 ```

--- a/dist/opencode/skills/do/SKILL.md
+++ b/dist/opencode/skills/do/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: do
-description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Optional --mode efficient|balanced|thorough controls verification intensity (default: thorough). Only pass --mode when the user explicitly requests a different mode. Use when executing a manifest, running a plan, implementing a defined task.'
+description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Optional --mode efficient|balanced|thorough controls verification intensity (default: thorough). Use when executing a manifest, running a plan, implementing a defined task.'
 ---
 
 # /do - Manifest Executor
@@ -11,17 +11,17 @@ Execute a Manifest: satisfy all Deliverables' Acceptance Criteria while followin
 
 ## Input
 
-`$ARGUMENTS` = manifest file path (REQUIRED), optionally with execution log path, `--mode <level>`, and `--scope <deliverable-ids>`
+`$ARGUMENTS` = manifest file path (REQUIRED), optionally with execution log path, `--mode <level>`, and `--scope <deliverable-ids>`. Positional args (manifest path, then log path) and flags may interleave. First positional = manifest path; second positional (if present) = execution log path.
 
-If no arguments: Output error "Usage: /do <manifest-file-path> [log-file-path] [--mode efficient|balanced|thorough] [--scope D1,D2,...]"
+If no arguments, halt: `Usage: /do <manifest-file-path> [log-file-path] [--mode efficient|balanced|thorough] [--scope D1,D2,...]`
 
 Read the manifest file fully before any execution.
 
 ## Execution Mode
 
-Resolve mode from (highest precedence first): `--mode` argument → manifest `mode:` field → default `thorough`.
+Resolve mode from (highest precedence first): `--mode` argument → manifest `Mode` field → default `thorough`.
 
-Invalid mode value → error and halt: "Invalid mode '<value>'. Valid modes: efficient | balanced | thorough"
+Invalid `--mode` value → halt: `Invalid mode '<value>'. Valid modes: efficient | balanced | thorough`.
 
 Load the execution mode file for behavioral specifics:
 - `thorough` (default): read `references/execution-modes/thorough.md`
@@ -30,14 +30,15 @@ Load the execution mode file for behavioral specifics:
 
 Follow the loaded mode's rules for model routing, verification parallelism, fix-verify loop limits, and escalation for the remainder of this /do run.
 
-**Override precedence** (applies to all modes):
-1. **Criterion-level model wins**: When a manifest criterion specifies `model:` in its verify block, that overrides the mode's model routing.
-2. **Explicit model overrides skip**: If a criterion explicitly sets `model:`, it runs even when the mode would otherwise skip it.
-3. **Global Invariants always run**: INV-G* verification runs regardless of mode — constitutional constraints.
+**Model routing precedence** (applies to all modes):
+1. **Criterion-level model wins.** When a manifest criterion specifies `model:` in its verify block, that overrides the mode's model routing.
+2. **Explicit model overrides skip.** If a criterion explicitly sets `model:`, it runs even when the mode would otherwise skip it.
+
+**Always-on rule:** Global Invariants (INV-G*) verify regardless of mode — constitutional constraints.
 
 ## Existing Execution Log
 
-If input includes a log file path (iteration on previous work): **treat it as source of truth**. It contains prior execution history. Continue from where it left off—append to the same log, don't restart.
+If input includes a log file path (iteration on previous work): **treat it as source of truth**. It contains prior execution history. Continue from where it left off — append to the same log, don't restart.
 
 ## Scoped Execution
 
@@ -45,80 +46,79 @@ Parse `--scope` from arguments if present. Accepts comma-separated deliverable I
 
 When `--scope` is provided, read `references/SCOPED_EXECUTION.md` and follow its rules for scoped execution. This limits work to the specified deliverables while maintaining global invariant safety.
 
-When `--scope` is NOT provided, ignore this section entirely — no reference file is loaded, no scoping behavior applies. Full execution as normal.
+When `--scope` is NOT provided, ignore this section entirely. No reference file is loaded, no scoping behavior applies. Full execution as normal.
 
 ## Principles
 
 | Principle | Rule |
 |-----------|------|
 | **ACs define success** | Work toward acceptance criteria however makes sense. Manifest says WHAT, you decide HOW. |
-| **Approach is initial, not rigid** | Approach provides starting direction, but adapt freely when reality diverges. No escalation needed — log adjustments with rationale. |
+| **Approach is initial, not rigid** | Approach provides starting direction, but adapt freely when reality diverges. No escalation needed; log adjustments with rationale. |
 | **Target failures specifically** | On verification failure, fix the specific failing criterion. Don't restart. Don't touch passing criteria. |
 | **Verify fixes first** | After fixing a failure, confirm the fix works before re-running full verification. |
 | **Trade-offs guide adjustment** | When risks (R-*) materialize, consult trade-offs (T-*) for decision criteria. Log adjustments with rationale. |
 
 ## Constraints
 
-**Log after every action** - Write to execution log immediately after each AC attempt. No exceptions. This is disaster recovery—if context is lost, the log is the only record of what happened.
+**Log after every action.** Write to execution log immediately after each AC attempt. No exceptions. This is disaster recovery: if context is lost, the log is the only record of what happened.
 
-**Must call /verify** - Can't declare done without verification. Invoke manifest-dev:verify with manifest, log paths, the resolved mode, and an optional scope per the rules below: `/verify <manifest> <log> --mode <level> [--scope D2,D3]`. Never pass `--final` from /do — that flag is internal to /verify (auto-triggered after a selective green pass) and exists to enforce the hard final gate. /done is unreachable without a full-mode green pass; /verify owns the selective→full chain.
+**Must call /verify.** Can't declare done without verification. Invoke manifest-dev:verify with manifest, log paths, the resolved mode, and an optional scope per the rules below: `/verify <manifest> <log> --mode <level> [--scope D2,D3]`. Never pass `--final` from /do; that flag is internal to /verify (auto-triggered after a true-selective green pass where `--scope` was set). /done is unreachable without a full-pass green (every AC + every INV-G) with no pending manual or deferred-auto criteria.
 
-**Selective verification + fix-loop scope** - /verify supports two modes (see verify SKILL.md for full contract):
-- *First pass on fresh /do* — invoke without `--scope` and without `--final`. Selective mode degenerates to full (nothing to narrow). Equivalent to today's behavior.
-- *Scoped /do* (`--scope D2,D3` was passed to /do) — invoke /verify with the same `--scope D2,D3`. Selective pass runs those deliverables' ACs + all globals.
-- *Fix-loop after AC-X.Y failure* — invoke /verify with `--scope D{X}` (the failing criterion's deliverable). Other deliverables are not re-verified during this iteration; they get their pass at the mandatory full final gate when /verify auto-triggers it.
-- *Fix-loop after INV-G failure* — invoke /verify normally (globals always run; no narrowing makes sense). When the failure happened during a selective pass with a `--scope`, the next pass is selective on the same deliverable + globals. When the failure happened during a full pass (auto-triggered final, or first-pass degenerated-to-full — no `--scope` was set), the next pass is also full — invoke /verify with no `--scope`. INV-G failures are not deliverable-scoped, so falling through to full is the correct default.
+**Selective verification + fix-loop scope.** /verify supports selective and full passes (see verify SKILL.md for the full contract). /do invokes /verify in four patterns:
 
-The mandatory full final gate (auto-triggered by /verify after selective green) is the safety net for cross-deliverable regressions. Don't try to skip or short-circuit it.
+- *First pass on fresh /do.* Invoke without `--scope` and without `--final`. Selective mode degenerates to full (nothing to narrow).
+- *Scoped /do* (`--scope D2,D3` was passed to /do). Invoke /verify with the same `--scope D2,D3`. Selective pass runs those deliverables' ACs + all globals.
+- *Fix-loop after AC-X.Y failure.* Invoke /verify with `--scope D{X}` (the failing criterion's deliverable). Other deliverables are not re-verified during this iteration; they get their pass at the mandatory full final gate when /verify auto-triggers it. This applies whether the AC failure happened during a selective pass or during the auto-triggered full pass: scope to the failing deliverable, then let /verify auto-trigger full again on green.
+- *Fix-loop after INV-G failure.* Invoke /verify normally (globals always run; deliverable-scoping is meaningless for INV-G). When the failure happened during a selective pass with a `--scope`, the next pass is selective on the same scope + globals (re-pass exactly the deliverable IDs that were in the failing pass). When the failure happened during a full pass (auto-triggered final, or first-pass degenerated-to-full where `--scope` was not set), the next pass is also full: invoke /verify with no `--scope`.
 
-**Execution log /verify contract** - /verify appends a structured block (`## /verify pass {N}` + fenced YAML with `mode`, `scope`, `result`, `failures`, `auto_triggered_final`, `deferred`) per invocation. Read the most recent block before deciding the next pass's scope. Format defined in `verify/SKILL.md` "/verify Pass Logging Contract." When scanning for the most recent /verify pass to drive scope decisions, **skip blocks with `deferred: true`** — those reflect user-direct `--deferred` invocations (now possible since /verify is user-invocable), not /do-driven normal-flow passes.
+The mandatory full final gate (auto-triggered by /verify after true-selective green) is the safety net for cross-deliverable regressions. Selective scoping gives fast feedback during fixes; the full final gate guarantees nothing in the rest of the suite regressed. Don't try to skip or short-circuit it.
 
-**Escalation boundary** - Escalate when: (1) ACs can't be met as written (contract broken), (2) user requests a pause mid-workflow, (3) you discover an AC or invariant should be amended (use "Proposed Amendment" escalation type), or (4) the active execution mode's fix-verify loop limit is reached. If ACs remain achievable as written and no user interrupt, continue autonomously.
+**Execution log /verify contract.** /verify appends a structured block (`## /verify pass {N}` + fenced YAML with `mode`, `scope`, `result`, `failures`, `auto_triggered_final`, `deferred`) per invocation. Read the most recent block before deciding the next pass's scope. Format defined in `verify/SKILL.md` "/verify Pass Logging Contract." When scanning for the most recent /verify pass to drive scope decisions, **skip blocks with `deferred: true`**; those reflect user-direct `--deferred` invocations, not /do-driven normal-flow passes.
 
-**`/verify`-routed escalation passthrough.** When `/verify` itself routes to `/escalate` (e.g., "Deferred-Auto Pending", "Manual Criteria Review") instead of `/done`, treat as a clean terminal handoff: surface the escalation output verbatim to the caller, do NOT enter the fix-loop, do NOT increment loop counters. The implementation is green; further action belongs to the user (e.g., running `/verify --deferred` for deferred-auto pending). This is distinct from `/verify` returning failures (which enters the standard fix-loop).
+**Escalation boundary.** Escalate when: (1) ACs can't be met as written (contract broken); (2) user requests a pause mid-workflow; (3) you discover an AC or invariant should be amended (use "Proposed Amendment" escalation type); (4) the active execution mode's fix-verify loop limit is reached; (5) any user message arrives during /do or /verify (use "Self-Amendment"; see Mid-Execution Amendment below). If ACs remain achievable as written and no user interrupt, continue autonomously.
 
-**Mode-aware loop tracking** - Track fix-verify iteration count and escalation count in the execution log. When the active execution mode's limits are reached, follow its escalation rules.
+**`/verify`-routed escalation passthrough.** When `/verify` itself routes to `/escalate` (e.g., "Deferred-Auto Pending", "Manual Criteria Review", or the combined "Manual Review + Deferred-Auto Pending") instead of `/done`, treat as a clean terminal handoff: surface the escalation output verbatim to the caller, do NOT enter the fix-loop, do NOT increment loop counters. The implementation is green; further action belongs to the user (e.g., running `/verify --deferred` for deferred-auto pending). This is distinct from `/verify` returning failures (which enters the standard fix-loop).
 
-**Phase-aware verification** - /verify runs criteria in phases (ascending by `phase:` field, default 1). It may report "Phase N failed, Phase N+1 not run." After fixing failures, /verify restarts from Phase 1 to catch regressions. Loop limits apply per-phase; regressions increment the broken phase's counter, not the phase that caused them.
+**Mode-aware loop tracking.** Track fix-verify iteration count and escalation count in the execution log. When the active execution mode's limits are reached, follow its escalation rules.
 
-**Stop requires /escalate** - During /do, you cannot stop without calling /verify→/done or /escalate. If you need to pause, call /escalate with "User-Requested Pause" format. Bare outputs like "Done." or "Waiting." are not valid exits.
+**Phase-aware verification.** /verify runs criteria in phases (ascending by `phase:` field, default 1). It may report "Phase N failed, Phase N+1 not run." After fixing failures, /verify restarts from Phase 1 to catch regressions. Loop limits apply per-phase; regressions increment the broken phase's counter, not the phase that caused them.
+
+**Stop requires /escalate.** During /do, you cannot stop without calling /verify (which routes to /done or /escalate) or calling /escalate directly. If you need to pause, call /escalate with "User-Requested Pause" format. Silent halts and bare statements like "Done." or "Waiting." are not valid exits.
 
 ## Memento Pattern
 
 Externalize progress to survive context loss.
 
-**Execution log**: Create `/tmp/do-log-{timestamp}.md` at start. After EACH AC attempt, append what happened and the outcome. Goal: another agent reading only the log could resume work.
+**Execution log.** Create `/tmp/do-log-{timestamp}.md` at start. After EACH AC attempt, append what happened and the outcome. Goal: another agent reading only the log could resume work.
 
-**Todos**: Create from manifest (deliverables → ACs). Start with execution order from Approach (adjust if dependencies require). Update todo status after logging (log first, todo second).
+**Todos.** Create from manifest (deliverables → ACs). Start with execution order from Approach (adjust if dependencies require). Update todo status after logging (log first, todo second).
 
-**Refresh before verify** - Read full execution log before calling /verify to restore context.
+**Refresh before verify.** Read full execution log before calling /verify to restore context.
 
-**Refresh between deliverables** - Before starting a new deliverable, re-read the manifest's deliverable section and relevant log entries. Context degrades across long sessions.
+**Refresh between deliverables.** Before starting a new deliverable, re-read the manifest's deliverable section and relevant log entries. Context degrades across long sessions.
 
 ## Multi-Repo Navigation
 
-When the manifest declares `Repos: [name: path, ...]` in Intent, deliverables may live in repos other than cwd. Read the path map and use **absolute paths** in tool calls (Read/Edit/Write/Bash) when working on a deliverable tagged with a different repo. There is **no filter logic, no cwd matching, no per-repo configuration** — the LLM navigates as deliverables require.
+When the manifest declares `Repos: [name: path, ...]` in Intent, deliverables may live in repos other than cwd. Read the path map and use **absolute paths** in tool calls (Read/Edit/Write/Bash) when working on a deliverable tagged with a different repo. There is **no filter logic, no cwd matching, no per-repo configuration**; the LLM navigates as deliverables require.
 
 A single `/do` invocation can cover the whole multi-repo task by navigating between repos; alternatively the user invokes `/do` per repo with `--scope` for parallel execution. Either works. The execution log remains a single file per `/do` invocation.
 
-When the manifest has no `Repos:` field (single-repo manifest), this section does not apply — behavior is unchanged.
+When the manifest has no `Repos:` field (single-repo manifest), this section does not apply; behavior is unchanged.
 
-Full convention: `references/MULTI_REPO.md` (lives in `define/references/`).
+Full convention: `define/references/MULTI_REPO.md`.
 
 ## Mid-Execution Amendment
 
-**Default to amend.** Any user message arriving during /do or /verify defaults to triggering Self-Amendment. The manifest is the canonical source of truth for the PR/branch — or, in multi-repo cases, the **PR set / branch set** (see `references/AMENDMENT_MODE.md`). Feedback flows through it, not around it. The asymmetric framing is deliberate: silent scope drift (feedback acted on inline, manifest left out of date) is a worse failure than an occasional unnecessary amendment cycle.
+**Default to amend.** Any user message arriving during /do or /verify defaults to triggering Self-Amendment. The manifest is the canonical source of truth for the PR/branch (or, in multi-repo cases, the **PR set / branch set**; see `define/references/AMENDMENT_MODE.md`). Feedback flows through it, not around it. Asymmetric by design: silent scope drift (feedback acted on inline, manifest left out of date) is a worse failure than an occasional unnecessary amendment cycle.
 
-**Carve-out: pure questions.** Messages that ask about the manifest or process without requesting a state change are answered inline — no amendment.
+**Carve-out: pure questions.** Messages that ask about the manifest or process without requesting a state change are answered inline; no amendment.
 - *Amend:* "Also handle X." / "Change Y to Z." / "That's wrong, it should be …" / "Add a check for …"
 - *Inline:* "What does AC-1.1 require?" / "Why did you choose approach A over B?" / "Where's the execution log?" / "Which deliverable is D3?"
 
 **When ambiguous, amend.** A message that could be either ("hmm, what about the auth case?") goes to amendment. Re-running an amendment cycle is cheap; silently dropping a constraint that turns out to matter is expensive.
 
-**/verify-time feedback.** While /verify is running under /do, user feedback received mid-pass is semantically feedback to /do (the caller), not to /verify. The same default-to-amend rule applies. /verify itself never handles user feedback inline; the message is interpreted in /do's context and routed through Self-Amendment. (When /verify is invoked directly by the user — e.g., `/verify --deferred` — there is no /do caller; mid-pass user messages are handled per the user's own session reflex, not via /do's amendment route.)
+**/verify-time feedback.** While /verify is running under /do, user feedback received mid-pass is semantically feedback to /do (the caller), not to /verify. The same default-to-amend rule applies. /verify itself never handles user feedback inline (per /verify's "Don't handle user feedback during a pass" Principle); the message is interpreted in /do's context and routed through Self-Amendment. When /verify is invoked directly by the user (e.g., `/verify --deferred`), there is no /do caller, and mid-pass user messages are governed by /verify's own Principle, not /do's amendment route.
 
-**Amendment flow** — Amend the manifest autonomously via Self-Amendment escalation and `/define --amend <manifest-path> --from-do`, then resume with the updated manifest and existing log. Log the trigger before amending. No human wait — the entire cycle is autonomous.
+**Amendment flow.** Amend the manifest autonomously via Self-Amendment escalation and `/define --amend <manifest-path> --from-do`, then resume with the updated manifest and existing log. Log the trigger before amending. No human wait; the entire cycle is autonomous.
 
-**Amendment loop guard** (R-7) — If Self-Amendment escalations repeat without new external input (user messages or PR comments) between them, the amendments are likely oscillating — escalate as "Proposed Amendment" for human decision instead. The same guard applies to post-/done re-entry: when feedback after completion triggers re-entry to /do via amendment, the consecutive-amendments-without-external-input counter still applies. Purpose: prevent runaway loops and unnecessary token burn.
-
-**No-manifest case.** When /do is invoked without a manifest (rare — typically /do follows /define), default-to-amend doesn't apply: there is nothing to amend. Behavior falls back to inline handling. This is fail-open by design.
+**Amendment loop guard.** If Self-Amendment escalations repeat without new external input (user messages or PR comments) between them, the amendments are likely oscillating; escalate as "Proposed Amendment" for human decision instead. The same guard applies to post-/done re-entry: when feedback after completion triggers re-entry to /do via amendment, the consecutive-amendments-without-external-input counter still applies. Purpose: prevent runaway loops and unnecessary token burn.

--- a/dist/opencode/skills/verify/SKILL.md
+++ b/dist/opencode/skills/verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify
-description: 'Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest. Primary user-facing entry point is /verify --deferred (run user-triggered deferred-auto criteria); other invocations normally come from /do.'
+description: 'Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest. Normally invoked by /do; users invoke directly via /verify --deferred to run user-triggered deferred-auto criteria.'
 user-invocable: true
 ---
 
@@ -10,49 +10,82 @@ Orchestrate verification of all criteria from a Manifest by spawning parallel ve
 
 **Input**: $ARGUMENTS
 
-Format: `<manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough] [--scope D1,D2,...] [--final] [--deferred]`
+Format: `<manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough] [--scope D1,D2,...] [--deferred]`
 
-Both paths required — return usage error if missing. Mode defaults to `thorough` if not provided. `--scope` and `--final` are mutually exclusive (final is full by definition); when both appear, treat as final. `--deferred` runs only `method: deferred-auto` criteria — see "Deferred-Auto Criteria" below.
+If either path is missing, halt: `Usage: /verify <manifest-file-path> <execution-log-path> [--mode efficient|balanced|thorough] [--scope D1,D2,...] [--deferred]`. If the manifest path doesn't exist, halt: `Cannot verify: manifest '<path>' not found.` If the execution log path doesn't exist, **create it as an empty file** before proceeding — /verify must always be able to append a pass-log block.
+
+`--deferred` runs only `method: deferred-auto` criteria — see "Deferred-Auto Criteria" below.
+
+`--final` is internal-only — see "Hard Final Gate" below. /do never passes it; users never pass it.
+
+## Mode Resolution
+
+Resolve mode from (highest precedence first): `--mode` argument → manifest `Mode` field → `thorough`.
+
+Invalid `--mode` value → halt: `Invalid mode '<value>'. Valid modes: efficient | balanced | thorough`.
+
+The resolved mode controls verifier parallelism, model routing, and reviewer-skip rules per `../do/references/execution-modes/{mode}.md`. Load that file at entry; if it cannot be loaded, halt with the load error — do not attempt verification.
 
 ## Selective vs Full Verification
 
-/verify runs in one of two modes — selective or full — driven by the caller (/do):
+/verify runs in one of two modes — selective or full — driven by the caller (/do, or a user-direct invocation):
 
-- **Selective pass.** Runs only the ACs of the in-scope deliverables (passed via `--scope D2,D3`, or computed by /do as the deliverable owning a failed criterion in fix-loop) **plus all Global Invariants** (INV-G* always run). Used during the fix-loop and after scoped /do invocations to keep token cost bounded.
-- **Full pass.** Runs every AC across every deliverable plus all globals. Triggered by `--final` from /do, or auto-triggered by /verify itself after a selective pass goes green (see Outcome Handling).
+- **Selective pass.** Runs only the ACs of the in-scope deliverables (passed via `--scope D2,D3` — /do computes the failing-deliverable scope and passes it during fix-loop) **plus all Global Invariants** (INV-G* are in scope on every pass, subject to Phased Execution gating). Used during the fix-loop and after scoped /do invocations to keep token cost bounded.
+- **Full pass.** Runs every AC across every deliverable plus all globals (same phase gating). Auto-triggered by /verify itself (re-invoking with `--final`) after a true-selective pass goes green — see Hard Final Gate.
 
-**When `--scope` is absent and `--final` is absent**, selective mode degenerates to full — there's no narrowing to apply, so behavior matches today's "verify everything." This is also the first /verify pass on a fresh /do (no failure context yet, no scope flag).
+**Terminology.** *True-selective* = a selective pass where `--scope` was set (the filter actually narrowed). *Selective-degenerated-to-full* = a selective pass where `--scope` was absent (no narrowing to apply, so the pass covers everything). Outcome handling distinguishes the two — see Outcome Handling.
 
-**Why this exists.** Re-running every AC on every fix-loop iteration costs N × loops verifier invocations. Most fixes touch one deliverable; re-verifying the rest is waste. The mandatory full final gate (Outcome Handling) catches anything cross-deliverable that selective mode missed — that's the safety net.
+**When `--scope` is absent and `--final` is absent**, selective mode degenerates to full — behavior matches "verify everything." This applies to the first /verify pass on a fresh /do (no failure context yet, no scope flag) and to user-direct invocations like `/verify <manifest> <log>` with no flags.
+
+**Why this exists.** Re-running every AC on every fix-loop iteration costs N × loops verifier invocations. Most fixes touch one deliverable; re-verifying the rest is waste. The mandatory full final gate (Hard Final Gate) catches anything cross-deliverable that selective mode missed — that's the safety net.
 
 ## Principles
+
+Operating principles for every pass:
 
 | Principle | Rule |
 |-----------|------|
 | **Context before spawning** | Read manifest and execution log before spawning verifiers — criterion IDs and prompts drive agent composition. |
 | **Orchestrate, don't verify** | Spawn agents to verify. You aggregate results and coordinate, never run checks yourself. |
-| **All in-scope criteria, no exceptions** | Every criterion in the current pass's scope (selective: in-scope deliverables' ACs + all INV-G*; full: every AC + every INV-G*) MUST be verified. Skipping any in-scope criterion is a critical failure. |
+| **All in-scope criteria, mode-authorized skips only** | Every criterion in the current pass's scope (selective: in-scope deliverables' ACs + all INV-G*; full: every AC + every INV-G*) MUST be verified, except where the active execution mode file explicitly authorizes a skip (e.g., quality-gate reviewers in efficient mode). Skipping any criterion not authorized by the mode file is a critical failure. |
 | **Parallelism per mode** | The active execution mode defines how many verifiers to launch concurrently within each phase. Phases always run sequentially — see Phased Execution below. |
 | **Actionable feedback** | Pass through file:line, expected vs actual, fix hints. |
-| **Don't handle user feedback during a pass** | While /verify is running, any user message arriving mid-pass is semantically feedback to the caller (/do, or the user who invoked /verify --deferred directly) — /verify never amends, never re-prompts, never deviates from its current pass. It returns results; the caller interprets new user input per its own rules (e.g., /do's Mid-Execution Amendment). User-direct invocations of /verify --deferred run to completion the same way. |
+| **Don't handle user feedback during a pass** | **While /verify is running**, any user message arriving mid-pass is semantically feedback to the caller (/do, or the user who invoked /verify --deferred directly) — /verify never amends, never re-prompts, never deviates from its current pass. It returns results; the caller interprets new user input per its own rules (e.g., /do's Mid-Execution Amendment). User-direct invocations of /verify --deferred run to completion the same way. |
 
 ## Verification Routing
 
-Route `manual` criteria to /escalate. Route `subagent` criteria to the named agent specified in the criterion. Route `deferred-auto` criteria per the "Deferred-Auto Criteria" section below — they are **skipped during normal /verify flow** and only run when `--deferred` is passed; under `--deferred`, they are routed by the inner shape of their verify block (if `agent:` is set, route to that named subagent; if `command:` is set, route to criteria-checker as bash; otherwise default to criteria-checker). All other types (`bash`, `codebase`, `research`) spawn criteria-checker agents. If a criterion has no verification type, default to criteria-checker.
+Route by criterion `method:`:
+
+| Method | Verifier |
+|--------|----------|
+| `bash`, `codebase`, `research` | criteria-checker (mode-routed model) |
+| `subagent` | the named agent in the criterion's `agent:` field |
+| `manual` | /escalate (no automated check exists) |
+| `deferred-auto` | skipped on normal passes (see Deferred-Auto Criteria); under `--deferred`, routed by the inner nested `method:` field |
+| (none / unrecognized) | criteria-checker |
+
+**Deferred-auto requires an explicit inner method.** A `method: deferred-auto` verify block MUST declare a sibling `inner_method:` field (`subagent` | `bash` | `codebase` | `research`). Under `--deferred`, /verify routes the criterion identically to a non-deferred criterion of that `inner_method`. If `inner_method` is missing, halt: `Deferred-auto criterion <ID> missing inner_method.` Field shape (canonical example):
+
+```yaml
+verify:
+  method: deferred-auto
+  inner_method: subagent
+  agent: general-purpose
+  prompt: "..."
+```
 
 ## Agent Prompt Composition
 
-When spawning verifier agents, pass the criterion's manifest data. Do not add your own framing.
+Pass each verifier exactly three sections, **in this order, each on its own line**:
 
-**Include**: Criterion ID, description, verification method, and the verify block's `command:` or `prompt:` field verbatim. Add file scope when the criterion targets specific files.
+1. **Cross-repo prefix** (only when the manifest declares `Repos:`) — the verbatim string defined in `define/references/MULTI_REPO.md` §e (single source of truth). Single-repo manifests skip this line.
+2. **Optional context line** (only when at least one of manifest / discovery log / execution log path exists) — `Optional context — manifest: <path>, discovery log: <path>, execution log: <path>`. Include only paths that exist. This is informational, not directive — agents decide whether the context is relevant.
+3. **Criterion content** — the criterion's manifest data: ID, description, verification method, and the verify block's `command:` or `prompt:` field verbatim. If `prompt:` is absent (e.g., bash criteria), pass the criterion's description as the agent prompt instead. Add file scope when the criterion targets specific files.
 
-**Optional context file paths**: When a manifest file, discovery log, or execution log exists, append their file paths as optional reference material. Present them neutrally — agents can read them if useful for understanding scope or context, but are not required to.
+The cross-repo prefix is the one prescribed exception to "do not add framing" — it is manifest-driven (derived from `Repos:`), not orchestrator opinion.
 
-Format: `Optional context — manifest: <path>, discovery log: <path>, execution log: <path>`
+**Never add to the criterion content:**
 
-Only include paths that exist. This is informational, not directive — agents decide whether the context is relevant to their review.
-
-**Never add**:
 - Severity thresholds ("only report medium+ issues", "focus on critical findings")
 - Implementation context ("the code was refactored to...", "this was implemented by...")
 - Opinions or expectations ("this should pass", "this is likely fine")
@@ -61,9 +94,7 @@ Only include paths that exist. This is informational, not directive — agents d
 - Suggested outcomes ("confirm that X works correctly")
 - Interpretations of manifest intent ("the goal is to...", "this change is about...")
 
-The verify block's `prompt:` field is manifest-authored — pass it verbatim. These rules target language you add beyond what the manifest specifies. The optional context file paths are raw references, not framing — they provide access to source material without steering the agent's analysis.
-
-**Exception — manifest-driven `Repos:` prefix.** When the manifest declares `Repos:`, the cross-repo path prefix (`Available repos: name=/path, ...`) is prepended to every verifier's prompt per "Cross-repo path delivery to verifiers" below. This is the one prescribed exception to "Do not add your own framing" — the prefix is manifest-driven (derived from `Repos:`), not orchestrator opinion.
+The verify block's `prompt:` field is manifest-authored — pass it verbatim. These rules target language you add beyond what the manifest specifies. The optional context line is raw references, not framing — it provides access to source material without steering the agent's analysis.
 
 ## Criterion Types
 
@@ -73,7 +104,7 @@ The verify block's `prompt:` field is manifest-authored — pass it verbatim. Th
 | Acceptance Criteria | AC-{D}.{N} | Deliverable incomplete |
 | Process Guidance | PG-{N} | Not verified (guidance only) |
 
-Note: PG-* items guide HOW to work. Followed during /do, not checked by /verify.
+`{D}` = deliverable number; `{N}` = ordinal within scope (1-based). PG-* items guide HOW to work — followed during /do, not checked by /verify.
 
 ## Agent Failures
 
@@ -92,13 +123,9 @@ Criteria have an optional `phase:` field (numeric, default 1). Phases run in asc
 
 **Phase failure reporting:** When a phase fails, include the phase number in the failure report and note which later phases were not run (e.g., "Phase 1: 2 failures. Phase 2: not run (3 criteria pending).").
 
-**Phase and scope are orthogonal.** `phase:` gates execution order (ascending); selective vs full filters the universe of criteria. Within a selective pass, the filter applies first (which deliverables' ACs + all globals), then phases gate the filtered set. Conflating them is wrong — phase ordering is unchanged by selection.
+**Phase and scope are orthogonal.** `phase:` gates execution order (ascending); selective vs full filters the universe of criteria. Within a selective pass, the filter applies first (which deliverables' ACs + all globals), then phases gate the filtered set.
 
-**Backward compatibility:** Manifests without any `phase:` fields have all criteria in phase 1 — identical to current behavior (all criteria run together per mode parallelism).
-
-## Mode-Aware Verification
-
-Load the mode file at `../do/references/execution-modes/{mode}.md` (default: `thorough`). Follow its rules for verification parallelism, model routing, and quality gate inclusion. The mode file defines which verifiers to skip, what model to use for criteria-checker agents, and how many concurrent verifiers to launch per phase. If mode file cannot be loaded, return an error to the caller immediately — do not attempt any verification.
+**Backward compatibility:** Manifests without any `phase:` fields have all criteria in phase 1 — identical to the prior behavior (all criteria run together per mode parallelism).
 
 ## Gotchas
 
@@ -111,56 +138,60 @@ Group results by phase, then Global Invariants first, then by Deliverable.
 
 | Condition | Action |
 |-----------|--------|
-| Any Global Invariant failed | Return all failures, globals highlighted |
-| Any AC failed | Return failures grouped by deliverable |
-| All in-scope pass, **selective mode that actually narrowed** (`--scope` was set) | **Auto-trigger a full pass** (re-invoke /verify internally with `--final`). Do NOT call /done. Manual criteria in scope are NOT escalated yet — they're deferred to the auto-triggered full pass per the rule below. |
-| All pass, **full mode**, manual criteria exist (no pending deferred-auto) | List manual criteria with how-to-verify, suggest /escalate |
-| All pass, **full mode**, **deferred-auto criteria exist and not all verified green via prior `--deferred` pass** (no manual criteria) | /escalate with "Deferred-Auto Pending" — see "Deferred-Pending Escalation" below. Do NOT call /done. |
-| All pass, **full mode**, **manual criteria AND pending deferred-auto criteria** | Combined /escalate (Manual Review + Deferred-Auto Pending) per "When BOTH" in Deferred-Pending Escalation below. Do NOT call /done. |
-| All pass, **full mode**, no pending deferred-auto criteria, no manual criteria | Call /done |
+| **Any Global Invariant failed** | **Return all failures, globals highlighted** |
+| **Any AC failed** (no global failures) | **Return failures grouped by deliverable** |
+| **All in-scope pass; true-selective pass (`--scope` was set)** | **Auto-trigger a full pass** (re-invoke /verify internally with `--final`). Do NOT call /done. Manual escalation and Deferred-Auto Pending escalation are both deferred to the auto-triggered full pass. |
+| **All pass; full or selective-degenerated-to-full; manual criteria exist; no pending deferred-auto** | **/escalate "Manual Criteria Review"** with each manual criterion + its how-to-verify. Do NOT call /done. |
+| **All pass; full or selective-degenerated-to-full; pending deferred-auto exist; no manual criteria** | **/escalate "Deferred-Auto Pending"** — see Deferred-Auto Pending Escalation. Do NOT call /done. |
+| **All pass; full or selective-degenerated-to-full; manual AND pending deferred-auto** | **Combined /escalate** (Manual Criteria Review + Deferred-Auto Pending). Do NOT call /done. |
+| **All pass; full or selective-degenerated-to-full; no manual; no pending deferred-auto** | **Call /done** |
 
-**Selective that degenerated to full = full mode for outcome handling.** When `--scope` is absent and `--final` is absent, the pass covered every criterion already. Treat as a full pass: if manual criteria exist OR pending deferred-auto criteria exist → escalate (combine both per "Deferred-Pending Escalation §When BOTH"); otherwise → call /done. There is no "auto-trigger another full pass" for degenerated-to-full — that's redundant since the pass already covered everything.
+**Selective-degenerated-to-full** = a selective pass where `--scope` was absent. The pass already covered every criterion, so it's treated as full for outcome handling. There is no "auto-trigger another full pass" — that would be redundant.
 
-**Manual criteria in selective mode.** When a selective pass encounters manual criteria within its in-scope deliverables and all automated checks pass, manual escalation is **deferred** to the auto-triggered full pass. Rationale: the full pass surfaces every manual criterion across every deliverable, so escalating partial manual criteria from a selective pass would fragment the user-facing escalation. Manual escalation fires exactly once per /verify chain — at the end of the full pass — never from a selective pass.
-
-**Hard final gate.** /done is unreachable from selective-mode green alone. Per project directive ("Done means nothing more to do"), only a full-mode green pass — every AC across every deliverable + every Global Invariant — **with no pending deferred-auto criteria** calls /done. When deferred-auto criteria are pending (no prior `--deferred` pass covered them), /verify routes to /escalate ("Deferred-Auto Pending") instead — see Deferred-Pending Escalation. The auto-triggered full pass is unconditional: no mode override, no opt-out. If the auto-triggered full pass fails, /verify returns the failures to /do, which enters the standard fix-loop. Failure during a final pass behaves identically to failure during any other pass — fix, then a fresh selective pass scoped to the failing deliverable, then auto-trigger full again.
-
-**`--final` is internal-only.** /verify uses `--final` to re-invoke itself after a selective green; /do does NOT pass `--final`. /do invokes /verify either with no scope flags (degenerates to full on first pass) or with `--scope D2,D3` (selective). The internal-only constraint preserves the gate: /do can never bypass the selective→full chain by manually requesting a final-only pass.
-
-**Mode is preserved across the recursion.** When /verify auto-triggers itself with `--final`, it carries forward the active `--mode <X>` from the current invocation (efficient | balanced | thorough). The auto-triggered final pass runs at the same intensity (parallelism + model routing + skip rules) as the selective pass that triggered it — never forced to thorough. The "full suite" guarantee is unconditional; the *intensity per criterion* follows the active mode (preserves the orthogonality between selective/full and mode established earlier in this skill).
+**Manual criteria in true selective mode** (where `--scope` was set). Manual escalation is **deferred** to the auto-triggered full pass so that escalation fires exactly once per /verify chain — at the end of the full pass. Surfacing partial manual criteria from a true selective pass would fragment the user-facing escalation.
 
 **On phase failure**: Show the failed phase, then for each failed criterion: ID, description, verification method, failure details (location, expected vs actual, fix hint). Note later phases not run and their pending criteria count.
 
+### Hard Final Gate
+
+- **/done is unreachable from selective-mode green alone.** Per project directive ("Done means nothing more to do"), only a full-mode green pass — every AC across every deliverable + every Global Invariant — **with no pending manual criteria and no pending deferred-auto criteria** calls /done.
+- **Pending manual blocks /done.** When manual criteria exist (and the pass is the kind that can call /done), /verify routes to /escalate ("Manual Criteria Review") instead — the user verifies manually, then re-invokes /verify.
+- **Pending deferred-auto blocks /done.** When deferred-auto criteria are pending, /verify routes to /escalate ("Deferred-Auto Pending") instead — see Deferred-Auto Pending Escalation.
+- **Both pending → combined /escalate.** Surface both types in one block (see Deferred-Auto Pending Escalation § "When BOTH").
+- **Once a true-selective pass goes green, the auto-trigger fires unconditionally** — no mode override, no opt-out.
+- **Auto-final failure → standard fix-loop.** /verify returns failures to /do, which fixes; /verify then runs a fresh selective pass scoped to the failing deliverable, then auto-triggers full again.
+- **`--final` is internal-only.** /verify uses `--final` to re-invoke itself after a true-selective green; /do never passes it. /do invokes /verify either with no scope flags (degenerates to full on first pass) or with `--scope D2,D3` (selective). This preserves the gate: /do can never bypass the selective→full chain.
+- **Mode is preserved across the auto-final re-invocation.** /verify carries forward the active `--mode <X>` (efficient | balanced | thorough). The auto-final pass runs at the same intensity as the selective pass that triggered it — never forced to thorough. The "full suite" guarantee is unconditional; the *intensity per criterion* follows the active mode.
+
 ## Deferred-Auto Criteria
 
-`method: deferred-auto` marks a criterion as **automatically verifiable but user-triggered** — typically a cross-repo gate the user signals readiness for (e.g., "all PRs deployed"). The verifier itself runs automatically (bash command, subagent prompt, etc.); only the *triggering* is user-controlled.
+`method: deferred-auto` marks a criterion as **automatically verifiable but user-triggered** — typically a cross-repo gate the user signals readiness for (e.g., "all PRs deployed"). The verifier itself runs automatically (bash command, subagent prompt, etc.); only the *triggering* is user-controlled. Deferred-auto verify blocks MUST declare an explicit sibling `inner_method:` (subagent | bash | codebase | research) — see Verification Routing for the field shape.
 
-**Normal flow skips them.** Selective and full passes (with or without `--scope`/`--final`) ignore `deferred-auto` criteria entirely during the pass — they never appear in the failure list of a normal pass. **However, their absence-of-coverage gates `/done` routing per "Deferred-Pending Escalation" below**: a normal-flow green pass with pending deferred-auto criteria routes to `/escalate` ("Deferred-Auto Pending"), not `/done`.
+**Normal flow skips them.** Selective and full passes (with or without `--scope`/`--final`) ignore `deferred-auto` criteria entirely during the pass — they never appear in the failure list of a normal pass. **However, uncovered deferred-auto criteria block /done — a normal-flow green pass with pending deferred-auto routes to /escalate ("Deferred-Auto Pending"), not /done.** See Deferred-Auto Pending Escalation below.
 
 **`--deferred` runs them.** When `/verify ... --deferred` is invoked, /verify runs **only** `deferred-auto` criteria (everything else is skipped, including INV-Gs and ACs of other methods).
 
 **Flag interactions:**
+
 - `--deferred` + `--scope` is supported. `--scope` narrows the deferred-auto set to in-scope deliverables.
 - `--deferred` does not interact with `--final` — never enters the final-gate machinery, never auto-triggers a follow-up pass, never calls /done.
 - `--deferred` inherits `--mode` — same parallelism / model routing as the parent invocation.
 - `--deferred` invoked without `--scope` covers all `deferred-auto` criteria across the manifest.
 - A manifest with no `deferred-auto` criteria sees `--deferred` as a clean no-op ("no deferred-auto criteria in manifest").
 
-**Deferred-Pending Escalation.** When a normal-flow `/verify` pass (selective or full) completes green but the manifest contains `deferred-auto` criteria that have not been verified green via a prior `/verify --deferred` run, `/verify` must NOT call `/done`. Instead, it routes to `/escalate` with type "Deferred-Auto Pending" and a message telling the user which deferred-auto criteria remain and instructing them to invoke `/verify --deferred` once prerequisites are in place. Once those criteria pass via `--deferred`, a subsequent normal `/verify` pass can call `/done`.
+**Coverage determination.** A deferred-auto criterion is "covered" when there exists a preceding pass-log block where `deferred: true`, `result: pass`, and either (a) `scope:` is empty (full deferred coverage), or (b) `scope:` contains the deliverable that owns the criterion. /verify aggregates coverage across all prior `--deferred` blocks: a criterion is pending iff no prior deferred-pass block satisfies (a) or (b). INV-G* deferred-auto criteria are deliverable-scope-independent — covered only by a block where `deferred: true` and `scope: []`.
 
-**Coverage determination.** A deferred-auto criterion is considered "covered" when there exists a preceding pass-log block with `deferred: true`, `result: pass`, and either (a) `scope:` is empty (full deferred coverage), or (b) `scope:` contains the deliverable that owns the criterion. /verify aggregates coverage across all prior `--deferred` blocks in the log: a criterion is pending iff no prior deferred-pass block satisfies (a) or (b) for it. INV-G* deferred-auto criteria are deliverable-scope-independent — they are covered only by a `deferred: true scope: []` block.
+### Deferred-Auto Pending Escalation
 
-**When BOTH manual criteria and pending deferred-auto criteria exist** after a normal full-mode green pass, surface BOTH in a single combined escalation block: list the manual criteria + their how-to-verify, AND list the pending deferred-auto criteria + the `/verify --deferred` instruction. /done remains unreachable until both are resolved.
+When a normal-flow `/verify` pass (selective or full) completes green but the manifest contains `deferred-auto` criteria not yet covered, /verify routes to `/escalate` with type `"Deferred-Auto Pending"`. The escalation message lists the pending criteria and instructs the user to invoke `/verify --deferred` once prerequisites are in place. Once those criteria pass via `--deferred`, a subsequent normal `/verify` pass can call `/done`.
 
-**After `/verify --deferred` completes green** (all deferred-auto criteria pass), close the user-as-coordinator loop with an explicit next-step instruction: emit a message like *"Deferred-auto criteria green. Re-invoke `/verify <manifest> <log>` (no flags) to reach /done."* Do NOT call /done from the `--deferred` pass itself — `--deferred` only verifies the deferred-auto subset; the final `/done` decision belongs to a normal-flow pass that confirms the full criterion universe is still green AND the deferred coverage now satisfies the gate.
+**When BOTH manual criteria AND pending deferred-auto exist** after a normal full-mode green pass, surface BOTH in a single combined escalation block: list the manual criteria + their how-to-verify, AND list the pending deferred-auto criteria + the `/verify --deferred` instruction. /done remains unreachable until both are resolved.
 
-**Cross-repo path delivery to verifiers.** When the manifest declares `Repos: [name: path, ...]`, **every `/verify` pass** (selective, full, and `--deferred`) prepends a verbatim string to each verifier's prompt before the criterion's own prompt:
+**After `/verify --deferred` completes green** (all deferred-auto criteria pass), close the user-as-coordinator loop with an explicit next-step instruction: emit a message like *"Deferred-auto criteria green. Re-invoke `/verify <manifest> <log>` (no flags) to reach /done."* Do NOT call /done from the `--deferred` pass itself — `--deferred` only verifies the deferred-auto subset; the final /done decision belongs to a normal-flow pass that confirms the full criterion universe is still green AND the deferred coverage now satisfies the gate.
 
-```
-Available repos: name1=/path/1, name2=/path/2, ...
-```
+### Cross-Repo Path Delivery
 
-This is the one mechanism — verifiers do not parse the manifest themselves. The injection fires on every pass, not just `--deferred`, so cross-repo verifiers can run during normal `/do→/verify` flow — that's what makes `/done` reachable for multi-repo manifests without per-repo /done independence. Single-repo manifests (no `Repos:` field) get no prefix injection. Full convention: `references/MULTI_REPO.md` (lives in `define/references/`) §e.
+When the manifest declares `Repos:`, every /verify pass (selective, full, and `--deferred`) prepends a verbatim cross-repo prefix to each verifier's prompt. Format and full convention: `define/references/MULTI_REPO.md` §e (single source of truth). The prefix injection fires on every pass, not just `--deferred`, so cross-repo verifiers can run during normal `/do→/verify` flow — that's what makes /done reachable for multi-repo manifests without per-repo /done independence. Single-repo manifests (no `Repos:` field) get no prefix injection.
 
 ## /verify Pass Logging Contract
 
@@ -170,17 +201,22 @@ Every /verify invocation appends a structured block to the execution log so /do 
 ## /verify pass {N}
 
 ```yaml
-mode: selective|full             # for --deferred passes: selective if --scope was set, else full
+mode: selective|full             # under deferred:true, reflects --scope filter only — see Deferred-Auto Criteria
 scope: [<deliverable-id>, ...]   # empty list when mode is full
 result: pass|fail
 failures: [<criterion-id>, ...]  # empty when pass; criterion IDs only, no narrative
-auto_triggered_final: true|false # true when this pass was auto-triggered after selective green; always false for --deferred passes
+auto_triggered_final: true|false # true only when this pass was auto-triggered by /verify after a true-selective green; false for first-pass-degenerated-to-full and for --deferred passes
 deferred: true|false             # true when this pass ran via --deferred (only deferred-auto criteria checked); false for normal selective/full passes
 ```
 
 [narrative — failed criterion details, fix hints, etc., per Outcome Handling]
 ````
 
-When `deferred: true`, consumers should treat the pass as a partial verification (only `deferred-auto` criteria) — never as evidence that normal-flow ACs/INVs passed. The `result: pass` of a deferred pass means "the deferred-auto criteria are green," not "the whole manifest is green."
+**Field semantics:**
 
-Pure markdown so humans can read; fenced YAML so /do and a future /verify can parse deterministically. Pass numbers are sequential within the execution log. /do uses the most recent block to track progress and decide which pass to invoke next.
+- **`deferred` is the master interpretation flag.** Consumers MUST read `deferred` before `mode`. Under `deferred: true`, `result: pass` means "the deferred-auto criteria are green," not "the whole manifest is green." Under `deferred: true`, write `mode: selective` if `--scope` was set, else `mode: full`.
+- **Degenerated-to-full logging.** When `--scope` and `--final` are both absent (and `--deferred` is not set), log `mode: full`, `scope: []`, `auto_triggered_final: false`. The pass already covered everything — log it as full.
+- **`result: pass` does not imply /done was called.** A green pass may route to /escalate (Manual Criteria Review, Deferred-Auto Pending, or both) instead. Consumers asking "did /done fire?" must re-derive from the manifest's manual / deferred-auto coverage, not from `result` alone.
+- **Consumers driving next-pass scope decisions** (e.g., /do scanning for the latest pass) MUST skip blocks where `deferred: true` — those reflect partial verification, not normal-flow AC/INV state.
+
+Pure markdown so humans can read; fenced YAML so /do and a future /verify can parse deterministically. Pass numbers are sequential within the execution log. /do reads the most recent block, skipping `deferred: true` blocks per Field semantics above, to track progress and decide which pass to invoke next.


### PR DESCRIPTION
## Summary

Delta sync of `claude-plugins/manifest-dev/skills/{define,do,verify}/SKILL.md` and `define/references/MULTI_REPO.md` to all three CLI distributions, picking up the verify SKILL.md rewrite (#114) and the deferred-auto `inner_method` shape (#112 / #113).

- **define/SKILL.md**: deferred-auto verify blocks now require sibling `inner_method:` field.
  - Gemini: Session line retargeted to `~/.gemini/tmp/<project_hash>/chats/session-${GEMINI_SESSION_ID}.jsonl` per reference rule.
  - OpenCode + Codex: Session line omitted (no agent-visible per-session JSONL).
- **do/SKILL.md**: prose tightening, mid-execution amendment carve-out clarifications. Copied unchanged across all three.
- **verify/SKILL.md**: full rewrite with explicit `--final` semantics, true-selective vs degenerated-to-full terminology, deferred-auto pending escalation flow. Copied unchanged across all three.
- **define/references/MULTI_REPO.md**: `inner_method` field requirement documented in cross-repo deferred-auto example. Copied unchanged across all three.
- **opencode commands/verify.md**: description string updated to match new source.
- **dist/{cli}/.sync-meta.json**: bumped to source HEAD `08c6889`.

No skills/agents added/removed/renamed → no README or context-file table regeneration needed. Infrastructure files (`install.sh`, `install_helpers.py`) untouched.

## Test plan

- [ ] Verify each dist's SKILL.md content matches source (with documented per-CLI adaptations).
- [ ] `dist/{cli}/.sync-meta.json` records the new source SHA.
- [ ] Spot-check the deferred-auto `inner_method` example in each dist's `define/references/MULTI_REPO.md`.

https://claude.ai/code/session_01UNhxPUG6NCvdABDMxfUWYn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNhxPUG6NCvdABDMxfUWYn)_