### PR TITLE
chore: mirror .claude/skills into .agents/skills via symlinks

### DIFF
--- a/.agents/skills/auto
+++ b/.agents/skills/auto
@@ -1,0 +1,1 @@
+../../.claude/skills/auto

--- a/.agents/skills/auto-optimize-prompt
+++ b/.agents/skills/auto-optimize-prompt
@@ -1,0 +1,1 @@
+../../.claude/skills/auto-optimize-prompt

--- a/.agents/skills/compress-prompt
+++ b/.agents/skills/compress-prompt
@@ -1,0 +1,1 @@
+../../.claude/skills/compress-prompt

--- a/.agents/skills/define
+++ b/.agents/skills/define
@@ -1,0 +1,1 @@
+../../.claude/skills/define

--- a/.agents/skills/do
+++ b/.agents/skills/do
@@ -1,0 +1,1 @@
+../../.claude/skills/do

--- a/.agents/skills/done
+++ b/.agents/skills/done
@@ -1,0 +1,1 @@
+../../.claude/skills/done

--- a/.agents/skills/drive
+++ b/.agents/skills/drive
@@ -1,0 +1,1 @@
+../../.claude/skills/drive

--- a/.agents/skills/drive-tick
+++ b/.agents/skills/drive-tick
@@ -1,0 +1,1 @@
+../../.claude/skills/drive-tick

--- a/.agents/skills/escalate
+++ b/.agents/skills/escalate
@@ -1,0 +1,1 @@
+../../.claude/skills/escalate

--- a/.agents/skills/figure-out
+++ b/.agents/skills/figure-out
@@ -1,0 +1,1 @@
+../../.claude/skills/figure-out

--- a/.agents/skills/harden-task-file
+++ b/.agents/skills/harden-task-file
@@ -1,0 +1,1 @@
+../../.claude/skills/harden-task-file

--- a/.agents/skills/learn-from-session
+++ b/.agents/skills/learn-from-session
@@ -1,0 +1,1 @@
+../../.claude/skills/learn-from-session

--- a/.agents/skills/optimize-prompt-token-efficiency
+++ b/.agents/skills/optimize-prompt-token-efficiency
@@ -1,0 +1,1 @@
+../../.claude/skills/optimize-prompt-token-efficiency

--- a/.agents/skills/prompt-engineering
+++ b/.agents/skills/prompt-engineering
@@ -1,0 +1,1 @@
+../../.claude/skills/prompt-engineering

--- a/.agents/skills/review-prompt
+++ b/.agents/skills/review-prompt
@@ -1,0 +1,1 @@
+../../.claude/skills/review-prompt

--- a/.agents/skills/stop-thinking-disciplines
+++ b/.agents/skills/stop-thinking-disciplines
@@ -1,0 +1,1 @@
+../../.claude/skills/stop-thinking-disciplines

--- a/.agents/skills/sync-tools
+++ b/.agents/skills/sync-tools
@@ -1,0 +1,1 @@
+../../.claude/skills/sync-tools

--- a/.agents/skills/thinking-disciplines
+++ b/.agents/skills/thinking-disciplines
@@ -1,0 +1,1 @@
+../../.claude/skills/thinking-disciplines

--- a/.agents/skills/verify
+++ b/.agents/skills/verify
@@ -1,0 +1,1 @@
+../../.claude/skills/verify

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,12 @@ Read before building plugins:
 
 **Symlink note**: `.claude/` skills/agents are hardlinked to their `claude-plugins/manifest-dev/` counterparts for local development on environments where plugins aren't supported yet. When modifying plugin components, **always edit the `claude-plugins/` version** — changes propagate to `.claude/` via the hardlink.
 
+**Local Claude skills → `.agents/skills/`**: `.agents/skills/` mirrors `.claude/skills/` for the Agent Skills Open Standard (Codex CLI, etc.). **Whenever you add a new skill under `.claude/skills/`, also create the matching symlink in `.agents/skills/`**:
+
+```bash
+ln -sfn ../../.claude/skills/<skill-name> .agents/skills/<skill-name>
+```
+
 ### Plugin Components
 
 Each plugin can contain:


### PR DESCRIPTION
## Summary

Mirrors all 19 skills from `.claude/skills/` into `.agents/skills/` via per-skill symlinks (each `.agents/skills/<name>` → `../../.claude/skills/<name>`).

`.agents/skills/` is the project-local convention for the Agent Skills Open Standard used by Codex CLI and similar tools (referenced by `dist/codex/README.md`). Mirroring the existing `.claude/skills/` exposes the same skills to those CLIs during local development on this repo, without requiring a separate install step.

Symlinking through `.claude/skills/` (rather than direct-to-source) keeps a single source of truth — when `.claude/skills/` gains/loses an entry, only `.agents/skills/` needs updating, and following the chain transparently resolves to either the plugin source or the local skill dir.

## Test plan

- [x] Verify each `.agents/skills/<name>/SKILL.md` resolves through the symlink chain (all 19 skills OK)
- [x] Confirm symlinks use relative paths so they remain valid across clones

---
_Generated by [Claude Code](https://claude.ai/code/session_01YahSrhHiwcweSvqFdci24V)_