### PR TITLE
feat(skills): convert /define and /do logs into narrative compressed context

### DIFF
--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.101.0",
+  "version": "0.102.0",
   "description": "Manifest-driven workflows for structured task execution with verification gates. Includes /drive — a cron-driven PR-lifecycle runner (graduated from manifest-dev-experimental). Supports multi-repo changesets via a shared canonical manifest.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/agents/manifest-verifier.md
+++ b/claude-plugins/manifest-dev/agents/manifest-verifier.md
@@ -53,7 +53,7 @@ User statements and discovered insights must appear in the manifest. Flag when:
 - Technical discovery encoded as invariant without user confirmation ("Discovered ≠ confirmed")
 - Process constraint (how to work) placed in INV instead of Process Guidance
 - Insights from domain understanding, reference class analysis, or failure mode coverage logged but not converted to criteria
-- Discovery log contains unresolved pending items (`- [ ]`) that weren't presented, encoded, or scoped out before synthesis
+- Discovery log opens threads (questions raised, scenarios surfaced, options noted, gaps identified) that don't reach an explicit disposition — encoded, scoped out, or mitigated — before synthesis
 
 ### Approach for complexity
 
@@ -131,8 +131,8 @@ Task file structures (quality gates, reviewer agents, risks, scenarios, trade-of
 - Structures skipped without logged justification (silent drops)
 - Selected quality gates not traceable to INV-G* or AC-* with matching verification (agent, threshold)
 - Log shows task file structures "noted" or "considered" but never presented to user — engagement requires selection or explicit skip, not acknowledgment
-- Log missing pending items for task file structures (should be logged as `- [ ]` immediately after reading task files)
-- Log contains unresolved `- [ ]` items at time of synthesis (applies to all pending items, not just task files — see Explicit → Encoded)
+- Log fails to surface task file structures as open threads (every Resolvable table/checklist item should be visible in the log narrative immediately after reading task files, with its eventual disposition)
+- Log contains threads opened but not closed at time of synthesis (applies to all opened threads, not just task files — see Explicit → Encoded)
 
 ### Approach constraints coverage
 

--- a/claude-plugins/manifest-dev/skills/define/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/define/SKILL.md
@@ -115,7 +115,7 @@ Domain-specific guidance lives in `tasks/`:
   - Both become PG-*.
 - **Reference files** (`references/*.md`) — lookup data for `/verify` agents. Do not load during interview.
 
-**Encode quality gates and Defaults immediately after reading task files — before the interview.** Log each as `- [x]` RESOLVED.
+**Encode quality gates and Defaults immediately after reading task files — before the interview.** Note each in the discovery log narrative as it lands.
 
 Task files set the floor, not the ceiling — probe beyond when domain understanding warrants.
 
@@ -212,32 +212,23 @@ Follow the loaded mode's rules for question format, flow, checkpoints, finding-s
 
 **Style switches only on explicit user request.** The flag sets starting posture; the mode stays until the user explicitly asks to switch (e.g., "be more concise", "switch to autonomous", "ask everything"). Don't infer mode shifts from tone or terseness alone — terse answers within a mode are valid mode-internal signals, not switches. After a switch, follow the new mode from that point and log it to the discovery file.
 
-**Auto-switch variant.** When the user signals "enough" / "ship it" / "good enough" / "stop asking", a one-way switch to `autonomous` fires with auto-decide semantics on remaining `[ ]` items — see Convergence § Termination & escalation rules — Mode-switch escalation.
+**Auto-switch variant.** When the user signals "enough" / "ship it" / "good enough" / "stop asking", a one-way switch to `autonomous` fires with auto-decide semantics on remaining unresolved threads — see Convergence § Termination & escalation rules — Mode-switch escalation.
 
 ## Discovery & Question Disciplines
 
 ### Discovery log
 
-Write to `/tmp/define-discovery-{timestamp}.md` immediately after each discovery — same `{timestamp}` as the manifest. The log is source of truth: another agent reading only the log could resume the interview.
+Write to `/tmp/define-discovery-{timestamp}.md` as discoveries happen — same `{timestamp}` as the manifest. The log is **append-only**: never rewrite past entries. Later entries can supersede or close out earlier threads, but earlier text stays as it was written.
 
-Seed with a Context Assessment before probing — what's already understood and what's missing:
+**Goal: narrative compressed context.** A fresh agent or human reading only this log can reconstruct the timeline, the surprises, and the reasoning — and resume the interview from where you left off without redoing discovery. They can also retrospect and learn how decisions came to be.
 
-```
-## Context Assessment
-ALREADY UNDERSTOOD:
-- [x] RESOLVED (from context): [item] — [source]
-GAPS IDENTIFIED:
-- [ ] PENDING: [what's missing and why it matters]
-```
+**What belongs.** Anything that changed your mind, surprised you, required investigation, or locks a manifest decision. Domain knowledge you discovered. Assumptions you tested and what happened. Threads you opened, their dispositions, and why. **Hard floor:** every decision that affects the manifest goes in, regardless of perceived triviality.
 
-The interview begins at the gaps. Before marking a coverage goal as met from context, verify with concrete evidence — vague confidence doesn't count.
+**What doesn't.** Routine status pings, restating what the user just said, narrating tool use that found nothing of consequence. If removing the entry would not lose anything a future reader needs, don't write it.
 
-Every actionable item gets logged with status:
-- `- [ ]` PENDING — needs resolution
-- `- [x]` RESOLVED — encoded as INV/AC/PG/ASM, confirmed, or answered
-- `- [~]` SKIPPED — explicitly scoped out with reasoning
+**Open the log with what's already understood from context and where the gaps are**, then narrate as the interview unfolds. Format is yours — paragraphs, headings, whatever serves the resumability goal — as long as opened threads reach explicit dispositions in the narrative before synthesis. Before treating a coverage goal as met from context, verify with concrete evidence; vague confidence doesn't count.
 
-**Read full log before synthesis.** Unresolved `- [ ]` items are addressed first.
+**Read the full log before synthesis.** Any opened thread without a documented disposition is a gap — resolve it before writing the manifest.
 
 ### When to ask
 
@@ -249,7 +240,7 @@ Every actionable item gets logged with status:
 
 **Probe input artifacts.** When input references external documents (URLs, file paths, named documents), determine whether they should be verification sources. If yes, encode as Global Invariant.
 
-**Resolve all Resolvable task file structures.** After reading task files, extract every Resolvable table and checklist. Items already resolved in conversation context are logged as `- [x]` RESOLVED with source — not re-probed. Remaining items are `- [ ]` PENDING. Resolve each per interview mode, or skip with logged justification. Don't defer to synthesis.
+**Resolve all Resolvable task file structures.** After reading task files, extract every Resolvable table and checklist. Items already resolved in conversation context are noted in the log narrative with their source — not re-probed. Remaining items must reach a disposition through the interview (per interview mode) or be explicitly skipped with logged justification. Don't defer to synthesis.
 
 ### How to ask
 
@@ -275,7 +266,7 @@ Every actionable item gets logged with status:
 
 The interview mode defines probing aggressiveness. Convergence requires:
 - All applicable Coverage Goal convergence tests pass (Process Self-Audit may be skipped per its own rule)
-- No unresolved `- [ ]` items in the discovery log
+- Every thread opened in the discovery log has reached an explicit disposition (encoded as INV/AC/PG/ASM/R/T, scoped out with reasoning, or mitigated by approach)
 - Quality gates from task files encoded as INV-G* (or omitted with logged reasoning)
 - Defaults encoded as PG-*
 
@@ -291,14 +282,14 @@ These end /define:
 
 1. Verifier returns COMPLETE and the user approves the summary.
 2. User explicitly invokes `/do`. Behavior depends on where /define is in the run:
-   - **Before synthesis is complete** (interview still has unresolved items, or manifest not yet written): switch to `autonomous` interview mode, finish synthesis and the Verification Loop with auto-decisions (each remaining `[ ]` item gets the recommended default, encoded with `(auto)` annotation and logged in Known Assumptions), write the manifest, then hand off to /do without waiting for summary approval.
+   - **Before synthesis is complete** (interview still has unresolved threads, or manifest not yet written): switch to `autonomous` interview mode, finish synthesis and the Verification Loop with auto-decisions (each remaining unresolved thread gets the recommended default, encoded with `(auto)` annotation and logged in Known Assumptions), write the manifest, then hand off to /do without waiting for summary approval.
    - **At the summary stage** (manifest already written, awaiting approval): do not redo synthesis. Print `Manifest complete: ...` per Complete and hand off to /do immediately.
 
 #### Mode-switch escalation
 
 /define continues — only the interview mode changes:
 
-- User signals "enough" (or equivalent: "ship it", "good enough", "stop asking"). Effect: switch interview mode to `autonomous` from this point. Auto-decide remaining `[ ]` items per autonomous mode rules (recommended default chosen, encoded with `(auto)` annotation, logged in Known Assumptions). Continue through synthesis and the Verification Loop; expect to terminate via Stop condition 1.
+- User signals "enough" (or equivalent: "ship it", "good enough", "stop asking"). Effect: switch interview mode to `autonomous` from this point. Auto-decide remaining unresolved threads per autonomous mode rules (recommended default chosen, encoded with `(auto)` annotation, logged in Known Assumptions). Continue through synthesis and the Verification Loop; expect to terminate via Stop condition 1.
 
 ## Approach Section (Complex Tasks)
 

--- a/claude-plugins/manifest-dev/skills/do/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/do/SKILL.md
@@ -60,7 +60,7 @@ When `--scope` is NOT provided, ignore this section entirely. No reference file 
 
 ## Constraints
 
-**Log after every action.** Write to execution log immediately after each AC attempt. No exceptions. This is disaster recovery: if context is lost, the log is the only record of what happened.
+**Log non-trivial events as they happen.** Write to the execution log whenever something a future reader would need to know lands: a surprise during implementation, a divergence from the Approach, the rationale behind a fix-after-failure, a discovery that should amend the manifest. Routine status pings ("started AC-1.1", "tests passed") are not events worth logging. The log is disaster recovery — if context is lost, it's the only record of what happened — and retrospect material — a future agent or human should be able to reconstruct *why* the run unfolded the way it did.
 
 **Must call /verify.** Can't declare done without verification. Invoke manifest-dev:verify with manifest, log paths, the resolved mode, and an optional scope per the rules below: `/verify <manifest> <log> --mode <level> [--scope D2,D3]`. Never pass `--final` from /do; that flag is internal to /verify (auto-triggered after a true-selective green pass where `--scope` was set). /done is unreachable without a full-pass green (every AC + every INV-G) with no pending manual or deferred-auto criteria.
 
@@ -89,7 +89,13 @@ The mandatory full final gate (auto-triggered by /verify after true-selective gr
 
 Externalize progress to survive context loss.
 
-**Execution log.** Create `/tmp/do-log-{timestamp}.md` at start. After EACH AC attempt, append what happened and the outcome. Goal: another agent reading only the log could resume work.
+**Execution log.** Create `/tmp/do-log-{timestamp}.md` at start. The log is **append-only**: never rewrite past entries. Later entries can correct or supersede earlier ones, but earlier text stays as written.
+
+**Goal: narrative compressed context.** A fresh agent or human reading only the log can reconstruct the timeline, the surprises, and the reasoning — and resume the run from where it stopped without redoing investigation. They can also retrospect and learn how the implementation came to be.
+
+**What belongs.** Surprises during implementation, divergences from the Approach (with rationale), why a particular fix was chosen after a verification failure, anything that should amend the manifest, domain knowledge discovered, dispositions on opened threads. **Hard floor:** every decision that affects the manifest goes in, regardless of perceived triviality. **What doesn't:** restating ACs verbatim, narrating tool use that found nothing of consequence, status pings for routine progress. If removing the entry would not lose anything a future reader needs, don't write it.
+
+**Coexists with /verify pass blocks.** /verify appends its own structured `## /verify pass {N}` blocks to the same file (per `verify/SKILL.md` "Pass Logging Contract"). Those are a separate, machine-readable artifact within the log — leave them as-is, and write your narrative entries around them.
 
 **Todos.** Create from manifest (deliverables → ACs). Start with execution order from Approach (adjust if dependencies require). Update todo status after logging (log first, todo second).
 

--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "078f888584fca7b8f7a95149cf831d4199996615",
+  "source_commit": "446ebfcd2c41a257b7089e71cad0a26c0eb83244",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-03T16:00:43Z"
+  "synced_at": "2026-05-03T16:45:44Z"
 }

--- a/dist/codex/README.md
+++ b/dist/codex/README.md
@@ -6,7 +6,7 @@ Verification-first manifest workflows for Codex CLI. Define specifications, exec
 
 | Type | Count | Notes |
 |------|-------|-------|
-| Skills | 11 | Full compatibility (Agent Skills Open Standard) |
+| Skills | 9 | Full compatibility (Agent Skills Open Standard) |
 | Agents | 14 | TOML config stubs with full prompt bodies |
 | Hooks | 0 | Not supported by Codex CLI (Issue #2109) |
 | Rules | 1 | Starlark execution policy |

--- a/dist/codex/agents/manifest-verifier.toml
+++ b/dist/codex/agents/manifest-verifier.toml
@@ -52,7 +52,7 @@ User statements and discovered insights must appear in the manifest. Flag when:
 - Technical discovery encoded as invariant without user confirmation ("Discovered ≠ confirmed")
 - Process constraint (how to work) placed in INV instead of Process Guidance
 - Insights from domain understanding, reference class analysis, or failure mode coverage logged but not converted to criteria
-- Discovery log contains unresolved pending items (`- [ ]`) that weren't presented, encoded, or scoped out before synthesis
+- Discovery log opens threads (questions raised, scenarios surfaced, options noted, gaps identified) that don't reach an explicit disposition — encoded, scoped out, or mitigated — before synthesis
 
 ### Approach for complexity
 
@@ -130,8 +130,8 @@ Task file structures (quality gates, reviewer agents, risks, scenarios, trade-of
 - Structures skipped without logged justification (silent drops)
 - Selected quality gates not traceable to INV-G* or AC-* with matching verification (agent, threshold)
 - Log shows task file structures "noted" or "considered" but never presented to user — engagement requires selection or explicit skip, not acknowledgment
-- Log missing pending items for task file structures (should be logged as `- [ ]` immediately after reading task files)
-- Log contains unresolved `- [ ]` items at time of synthesis (applies to all pending items, not just task files — see Explicit → Encoded)
+- Log fails to surface task file structures as open threads (every Resolvable table/checklist item should be visible in the log narrative immediately after reading task files, with its eventual disposition)
+- Log contains threads opened but not closed at time of synthesis (applies to all opened threads, not just task files — see Explicit → Encoded)
 
 ### Approach constraints coverage
 

--- a/dist/codex/skills/define/SKILL.md
+++ b/dist/codex/skills/define/SKILL.md
@@ -115,7 +115,7 @@ Domain-specific guidance lives in `tasks/`:
   - Both become PG-*.
 - **Reference files** (`references/*.md`) — lookup data for `/verify` agents. Do not load during interview.
 
-**Encode quality gates and Defaults immediately after reading task files — before the interview.** Log each as `- [x]` RESOLVED.
+**Encode quality gates and Defaults immediately after reading task files — before the interview.** Note each in the discovery log narrative as it lands.
 
 Task files set the floor, not the ceiling — probe beyond when domain understanding warrants.
 
@@ -212,32 +212,23 @@ Follow the loaded mode's rules for question format, flow, checkpoints, finding-s
 
 **Style switches only on explicit user request.** The flag sets starting posture; the mode stays until the user explicitly asks to switch (e.g., "be more concise", "switch to autonomous", "ask everything"). Don't infer mode shifts from tone or terseness alone — terse answers within a mode are valid mode-internal signals, not switches. After a switch, follow the new mode from that point and log it to the discovery file.
 
-**Auto-switch variant.** When the user signals "enough" / "ship it" / "good enough" / "stop asking", a one-way switch to `autonomous` fires with auto-decide semantics on remaining `[ ]` items — see Convergence § Termination & escalation rules — Mode-switch escalation.
+**Auto-switch variant.** When the user signals "enough" / "ship it" / "good enough" / "stop asking", a one-way switch to `autonomous` fires with auto-decide semantics on remaining unresolved threads — see Convergence § Termination & escalation rules — Mode-switch escalation.
 
 ## Discovery & Question Disciplines
 
 ### Discovery log
 
-Write to `/tmp/define-discovery-{timestamp}.md` immediately after each discovery — same `{timestamp}` as the manifest. The log is source of truth: another agent reading only the log could resume the interview.
+Write to `/tmp/define-discovery-{timestamp}.md` as discoveries happen — same `{timestamp}` as the manifest. The log is **append-only**: never rewrite past entries. Later entries can supersede or close out earlier threads, but earlier text stays as it was written.
 
-Seed with a Context Assessment before probing — what's already understood and what's missing:
+**Goal: narrative compressed context.** A fresh agent or human reading only this log can reconstruct the timeline, the surprises, and the reasoning — and resume the interview from where you left off without redoing discovery. They can also retrospect and learn how decisions came to be.
 
-```
-## Context Assessment
-ALREADY UNDERSTOOD:
-- [x] RESOLVED (from context): [item] — [source]
-GAPS IDENTIFIED:
-- [ ] PENDING: [what's missing and why it matters]
-```
+**What belongs.** Anything that changed your mind, surprised you, required investigation, or locks a manifest decision. Domain knowledge you discovered. Assumptions you tested and what happened. Threads you opened, their dispositions, and why. **Hard floor:** every decision that affects the manifest goes in, regardless of perceived triviality.
 
-The interview begins at the gaps. Before marking a coverage goal as met from context, verify with concrete evidence — vague confidence doesn't count.
+**What doesn't.** Routine status pings, restating what the user just said, narrating tool use that found nothing of consequence. If removing the entry would not lose anything a future reader needs, don't write it.
 
-Every actionable item gets logged with status:
-- `- [ ]` PENDING — needs resolution
-- `- [x]` RESOLVED — encoded as INV/AC/PG/ASM, confirmed, or answered
-- `- [~]` SKIPPED — explicitly scoped out with reasoning
+**Open the log with what's already understood from context and where the gaps are**, then narrate as the interview unfolds. Format is yours — paragraphs, headings, whatever serves the resumability goal — as long as opened threads reach explicit dispositions in the narrative before synthesis. Before treating a coverage goal as met from context, verify with concrete evidence; vague confidence doesn't count.
 
-**Read full log before synthesis.** Unresolved `- [ ]` items are addressed first.
+**Read the full log before synthesis.** Any opened thread without a documented disposition is a gap — resolve it before writing the manifest.
 
 ### When to ask
 
@@ -249,7 +240,7 @@ Every actionable item gets logged with status:
 
 **Probe input artifacts.** When input references external documents (URLs, file paths, named documents), determine whether they should be verification sources. If yes, encode as Global Invariant.
 
-**Resolve all Resolvable task file structures.** After reading task files, extract every Resolvable table and checklist. Items already resolved in conversation context are logged as `- [x]` RESOLVED with source — not re-probed. Remaining items are `- [ ]` PENDING. Resolve each per interview mode, or skip with logged justification. Don't defer to synthesis.
+**Resolve all Resolvable task file structures.** After reading task files, extract every Resolvable table and checklist. Items already resolved in conversation context are noted in the log narrative with their source — not re-probed. Remaining items must reach a disposition through the interview (per interview mode) or be explicitly skipped with logged justification. Don't defer to synthesis.
 
 ### How to ask
 
@@ -275,7 +266,7 @@ Every actionable item gets logged with status:
 
 The interview mode defines probing aggressiveness. Convergence requires:
 - All applicable Coverage Goal convergence tests pass (Process Self-Audit may be skipped per its own rule)
-- No unresolved `- [ ]` items in the discovery log
+- Every thread opened in the discovery log has reached an explicit disposition (encoded as INV/AC/PG/ASM/R/T, scoped out with reasoning, or mitigated by approach)
 - Quality gates from task files encoded as INV-G* (or omitted with logged reasoning)
 - Defaults encoded as PG-*
 
@@ -291,14 +282,14 @@ These end /define:
 
 1. Verifier returns COMPLETE and the user approves the summary.
 2. User explicitly invokes `/do`. Behavior depends on where /define is in the run:
-   - **Before synthesis is complete** (interview still has unresolved items, or manifest not yet written): switch to `autonomous` interview mode, finish synthesis and the Verification Loop with auto-decisions (each remaining `[ ]` item gets the recommended default, encoded with `(auto)` annotation and logged in Known Assumptions), write the manifest, then hand off to /do without waiting for summary approval.
+   - **Before synthesis is complete** (interview still has unresolved threads, or manifest not yet written): switch to `autonomous` interview mode, finish synthesis and the Verification Loop with auto-decisions (each remaining unresolved thread gets the recommended default, encoded with `(auto)` annotation and logged in Known Assumptions), write the manifest, then hand off to /do without waiting for summary approval.
    - **At the summary stage** (manifest already written, awaiting approval): do not redo synthesis. Print `Manifest complete: ...` per Complete and hand off to /do immediately.
 
 #### Mode-switch escalation
 
 /define continues — only the interview mode changes:
 
-- User signals "enough" (or equivalent: "ship it", "good enough", "stop asking"). Effect: switch interview mode to `autonomous` from this point. Auto-decide remaining `[ ]` items per autonomous mode rules (recommended default chosen, encoded with `(auto)` annotation, logged in Known Assumptions). Continue through synthesis and the Verification Loop; expect to terminate via Stop condition 1.
+- User signals "enough" (or equivalent: "ship it", "good enough", "stop asking"). Effect: switch interview mode to `autonomous` from this point. Auto-decide remaining unresolved threads per autonomous mode rules (recommended default chosen, encoded with `(auto)` annotation, logged in Known Assumptions). Continue through synthesis and the Verification Loop; expect to terminate via Stop condition 1.
 
 ## Approach Section (Complex Tasks)
 
@@ -473,13 +464,12 @@ The medium is encoded in the manifest's Intent section as `Medium: <value>` so d
 
 /define ends here. Output the manifest path and stop. Substitute the placeholders before printing:
 - `{timestamp}` → the value used for the manifest filename.
-- `<dir>` → the current project directory in the slug form used by `~/.claude/projects/` (path separators replaced with `-`, e.g., `-home-user-manifest-dev` for `/home/user/manifest-dev`).
-- `${CLAUDE_SESSION_ID}` → the value of the `CLAUDE_SESSION_ID` environment variable.
 - `[log-file-path if iterating]` → if this run iterated on a previous manifest that had an execution log, substitute the actual log path; otherwise omit the bracketed clause entirely (including the trailing space).
 
 ```text
 Manifest complete: /tmp/manifest-{timestamp}.md
-Session: ~/.claude/projects/<dir>/${CLAUDE_SESSION_ID}.jsonl
 
 To execute: /do /tmp/manifest-{timestamp}.md [log-file-path if iterating]
 ```
+
+(Codex does not expose a `CODEX_SESSION_ID` env var the agent can use to compute its current session-file path — the Session line from the Claude Code source is intentionally omitted. See Codex issue #8923.)

--- a/dist/codex/skills/do/SKILL.md
+++ b/dist/codex/skills/do/SKILL.md
@@ -60,7 +60,7 @@ When `--scope` is NOT provided, ignore this section entirely. No reference file 
 
 ## Constraints
 
-**Log after every action.** Write to execution log immediately after each AC attempt. No exceptions. This is disaster recovery: if context is lost, the log is the only record of what happened.
+**Log non-trivial events as they happen.** Write to the execution log whenever something a future reader would need to know lands: a surprise during implementation, a divergence from the Approach, the rationale behind a fix-after-failure, a discovery that should amend the manifest. Routine status pings ("started AC-1.1", "tests passed") are not events worth logging. The log is disaster recovery — if context is lost, it's the only record of what happened — and retrospect material — a future agent or human should be able to reconstruct *why* the run unfolded the way it did.
 
 **Must call /verify.** Can't declare done without verification. Invoke manifest-dev:verify with manifest, log paths, the resolved mode, and an optional scope per the rules below: `/verify <manifest> <log> --mode <level> [--scope D2,D3]`. Never pass `--final` from /do; that flag is internal to /verify (auto-triggered after a true-selective green pass where `--scope` was set). /done is unreachable without a full-pass green (every AC + every INV-G) with no pending manual or deferred-auto criteria.
 
@@ -89,7 +89,13 @@ The mandatory full final gate (auto-triggered by /verify after true-selective gr
 
 Externalize progress to survive context loss.
 
-**Execution log.** Create `/tmp/do-log-{timestamp}.md` at start. After EACH AC attempt, append what happened and the outcome. Goal: another agent reading only the log could resume work.
+**Execution log.** Create `/tmp/do-log-{timestamp}.md` at start. The log is **append-only**: never rewrite past entries. Later entries can correct or supersede earlier ones, but earlier text stays as written.
+
+**Goal: narrative compressed context.** A fresh agent or human reading only the log can reconstruct the timeline, the surprises, and the reasoning — and resume the run from where it stopped without redoing investigation. They can also retrospect and learn how the implementation came to be.
+
+**What belongs.** Surprises during implementation, divergences from the Approach (with rationale), why a particular fix was chosen after a verification failure, anything that should amend the manifest, domain knowledge discovered, dispositions on opened threads. **Hard floor:** every decision that affects the manifest goes in, regardless of perceived triviality. **What doesn't:** restating ACs verbatim, narrating tool use that found nothing of consequence, status pings for routine progress. If removing the entry would not lose anything a future reader needs, don't write it.
+
+**Coexists with /verify pass blocks.** /verify appends its own structured `## /verify pass {N}` blocks to the same file (per `verify/SKILL.md` "Pass Logging Contract"). Those are a separate, machine-readable artifact within the log — leave them as-is, and write your narrative entries around them.
 
 **Todos.** Create from manifest (deliverables → ACs). Start with execution order from Approach (adjust if dependencies require). Update todo status after logging (log first, todo second).
 

--- a/dist/gemini/.sync-meta.json
+++ b/dist/gemini/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "078f888584fca7b8f7a95149cf831d4199996615",
+  "source_commit": "446ebfcd2c41a257b7089e71cad0a26c0eb83244",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-03T16:00:43Z"
+  "synced_at": "2026-05-03T16:45:44Z"
 }

--- a/dist/gemini/README.md
+++ b/dist/gemini/README.md
@@ -51,9 +51,9 @@ The `install.sh` script sets this automatically.
 
 | Feature | Claude Code | Gemini CLI | Notes |
 |---------|-------------|------------|-------|
-| Skills | All 12 | All 12 | Copied unchanged |
-| Agents | All 15 | All 15 | Frontmatter converted |
-| Hooks | 8 hooks | 8 hooks | Adapted to Gemini event model |
+| Skills | All 9 | All 9 | Copied unchanged |
+| Agents | All 14 | All 14 | Frontmatter converted |
+| Hooks | 5 hooks | 5 hooks | Adapted to Gemini event model |
 | Stop enforcement | PreToolUse/Stop | BeforeTool/AfterAgent | Retry counter for loop prevention |
 | Context injection | additionalContext | additionalContext | Same mechanism |
 | Transcript parsing | JSONL (user/assistant) | JSONL (user/gemini) | Adapter normalizes |

--- a/dist/gemini/agents/manifest-verifier.md
+++ b/dist/gemini/agents/manifest-verifier.md
@@ -61,7 +61,7 @@ User statements and discovered insights must appear in the manifest. Flag when:
 - Technical discovery encoded as invariant without user confirmation ("Discovered ≠ confirmed")
 - Process constraint (how to work) placed in INV instead of Process Guidance
 - Insights from domain understanding, reference class analysis, or failure mode coverage logged but not converted to criteria
-- Discovery log contains unresolved pending items (`- [ ]`) that weren't presented, encoded, or scoped out before synthesis
+- Discovery log opens threads (questions raised, scenarios surfaced, options noted, gaps identified) that don't reach an explicit disposition — encoded, scoped out, or mitigated — before synthesis
 
 ### Approach for complexity
 
@@ -139,8 +139,8 @@ Task file structures (quality gates, reviewer agents, risks, scenarios, trade-of
 - Structures skipped without logged justification (silent drops)
 - Selected quality gates not traceable to INV-G* or AC-* with matching verification (agent, threshold)
 - Log shows task file structures "noted" or "considered" but never presented to user — engagement requires selection or explicit skip, not acknowledgment
-- Log missing pending items for task file structures (should be logged as `- [ ]` immediately after reading task files)
-- Log contains unresolved `- [ ]` items at time of synthesis (applies to all pending items, not just task files — see Explicit → Encoded)
+- Log fails to surface task file structures as open threads (every Resolvable table/checklist item should be visible in the log narrative immediately after reading task files, with its eventual disposition)
+- Log contains threads opened but not closed at time of synthesis (applies to all opened threads, not just task files — see Explicit → Encoded)
 
 ### Approach constraints coverage
 

--- a/dist/gemini/gemini-extension.json
+++ b/dist/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.94.0",
+  "version": "0.102.0",
   "description": "Verification-first manifest workflows for Gemini CLI",
   "mcpServers": {},
   "excludeTools": [],

--- a/dist/gemini/skills/define/SKILL.md
+++ b/dist/gemini/skills/define/SKILL.md
@@ -115,7 +115,7 @@ Domain-specific guidance lives in `tasks/`:
   - Both become PG-*.
 - **Reference files** (`references/*.md`) — lookup data for `/verify` agents. Do not load during interview.
 
-**Encode quality gates and Defaults immediately after reading task files — before the interview.** Log each as `- [x]` RESOLVED.
+**Encode quality gates and Defaults immediately after reading task files — before the interview.** Note each in the discovery log narrative as it lands.
 
 Task files set the floor, not the ceiling — probe beyond when domain understanding warrants.
 
@@ -212,32 +212,23 @@ Follow the loaded mode's rules for question format, flow, checkpoints, finding-s
 
 **Style switches only on explicit user request.** The flag sets starting posture; the mode stays until the user explicitly asks to switch (e.g., "be more concise", "switch to autonomous", "ask everything"). Don't infer mode shifts from tone or terseness alone — terse answers within a mode are valid mode-internal signals, not switches. After a switch, follow the new mode from that point and log it to the discovery file.
 
-**Auto-switch variant.** When the user signals "enough" / "ship it" / "good enough" / "stop asking", a one-way switch to `autonomous` fires with auto-decide semantics on remaining `[ ]` items — see Convergence § Termination & escalation rules — Mode-switch escalation.
+**Auto-switch variant.** When the user signals "enough" / "ship it" / "good enough" / "stop asking", a one-way switch to `autonomous` fires with auto-decide semantics on remaining unresolved threads — see Convergence § Termination & escalation rules — Mode-switch escalation.
 
 ## Discovery & Question Disciplines
 
 ### Discovery log
 
-Write to `/tmp/define-discovery-{timestamp}.md` immediately after each discovery — same `{timestamp}` as the manifest. The log is source of truth: another agent reading only the log could resume the interview.
+Write to `/tmp/define-discovery-{timestamp}.md` as discoveries happen — same `{timestamp}` as the manifest. The log is **append-only**: never rewrite past entries. Later entries can supersede or close out earlier threads, but earlier text stays as it was written.
 
-Seed with a Context Assessment before probing — what's already understood and what's missing:
+**Goal: narrative compressed context.** A fresh agent or human reading only this log can reconstruct the timeline, the surprises, and the reasoning — and resume the interview from where you left off without redoing discovery. They can also retrospect and learn how decisions came to be.
 
-```
-## Context Assessment
-ALREADY UNDERSTOOD:
-- [x] RESOLVED (from context): [item] — [source]
-GAPS IDENTIFIED:
-- [ ] PENDING: [what's missing and why it matters]
-```
+**What belongs.** Anything that changed your mind, surprised you, required investigation, or locks a manifest decision. Domain knowledge you discovered. Assumptions you tested and what happened. Threads you opened, their dispositions, and why. **Hard floor:** every decision that affects the manifest goes in, regardless of perceived triviality.
 
-The interview begins at the gaps. Before marking a coverage goal as met from context, verify with concrete evidence — vague confidence doesn't count.
+**What doesn't.** Routine status pings, restating what the user just said, narrating tool use that found nothing of consequence. If removing the entry would not lose anything a future reader needs, don't write it.
 
-Every actionable item gets logged with status:
-- `- [ ]` PENDING — needs resolution
-- `- [x]` RESOLVED — encoded as INV/AC/PG/ASM, confirmed, or answered
-- `- [~]` SKIPPED — explicitly scoped out with reasoning
+**Open the log with what's already understood from context and where the gaps are**, then narrate as the interview unfolds. Format is yours — paragraphs, headings, whatever serves the resumability goal — as long as opened threads reach explicit dispositions in the narrative before synthesis. Before treating a coverage goal as met from context, verify with concrete evidence; vague confidence doesn't count.
 
-**Read full log before synthesis.** Unresolved `- [ ]` items are addressed first.
+**Read the full log before synthesis.** Any opened thread without a documented disposition is a gap — resolve it before writing the manifest.
 
 ### When to ask
 
@@ -249,7 +240,7 @@ Every actionable item gets logged with status:
 
 **Probe input artifacts.** When input references external documents (URLs, file paths, named documents), determine whether they should be verification sources. If yes, encode as Global Invariant.
 
-**Resolve all Resolvable task file structures.** After reading task files, extract every Resolvable table and checklist. Items already resolved in conversation context are logged as `- [x]` RESOLVED with source — not re-probed. Remaining items are `- [ ]` PENDING. Resolve each per interview mode, or skip with logged justification. Don't defer to synthesis.
+**Resolve all Resolvable task file structures.** After reading task files, extract every Resolvable table and checklist. Items already resolved in conversation context are noted in the log narrative with their source — not re-probed. Remaining items must reach a disposition through the interview (per interview mode) or be explicitly skipped with logged justification. Don't defer to synthesis.
 
 ### How to ask
 
@@ -275,7 +266,7 @@ Every actionable item gets logged with status:
 
 The interview mode defines probing aggressiveness. Convergence requires:
 - All applicable Coverage Goal convergence tests pass (Process Self-Audit may be skipped per its own rule)
-- No unresolved `- [ ]` items in the discovery log
+- Every thread opened in the discovery log has reached an explicit disposition (encoded as INV/AC/PG/ASM/R/T, scoped out with reasoning, or mitigated by approach)
 - Quality gates from task files encoded as INV-G* (or omitted with logged reasoning)
 - Defaults encoded as PG-*
 
@@ -291,14 +282,14 @@ These end /define:
 
 1. Verifier returns COMPLETE and the user approves the summary.
 2. User explicitly invokes `/do`. Behavior depends on where /define is in the run:
-   - **Before synthesis is complete** (interview still has unresolved items, or manifest not yet written): switch to `autonomous` interview mode, finish synthesis and the Verification Loop with auto-decisions (each remaining `[ ]` item gets the recommended default, encoded with `(auto)` annotation and logged in Known Assumptions), write the manifest, then hand off to /do without waiting for summary approval.
+   - **Before synthesis is complete** (interview still has unresolved threads, or manifest not yet written): switch to `autonomous` interview mode, finish synthesis and the Verification Loop with auto-decisions (each remaining unresolved thread gets the recommended default, encoded with `(auto)` annotation and logged in Known Assumptions), write the manifest, then hand off to /do without waiting for summary approval.
    - **At the summary stage** (manifest already written, awaiting approval): do not redo synthesis. Print `Manifest complete: ...` per Complete and hand off to /do immediately.
 
 #### Mode-switch escalation
 
 /define continues — only the interview mode changes:
 
-- User signals "enough" (or equivalent: "ship it", "good enough", "stop asking"). Effect: switch interview mode to `autonomous` from this point. Auto-decide remaining `[ ]` items per autonomous mode rules (recommended default chosen, encoded with `(auto)` annotation, logged in Known Assumptions). Continue through synthesis and the Verification Loop; expect to terminate via Stop condition 1.
+- User signals "enough" (or equivalent: "ship it", "good enough", "stop asking"). Effect: switch interview mode to `autonomous` from this point. Auto-decide remaining unresolved threads per autonomous mode rules (recommended default chosen, encoded with `(auto)` annotation, logged in Known Assumptions). Continue through synthesis and the Verification Loop; expect to terminate via Stop condition 1.
 
 ## Approach Section (Complex Tasks)
 
@@ -473,13 +464,13 @@ The medium is encoded in the manifest's Intent section as `Medium: <value>` so d
 
 /define ends here. Output the manifest path and stop. Substitute the placeholders before printing:
 - `{timestamp}` → the value used for the manifest filename.
-- `<dir>` → the current project directory in the slug form used by `~/.claude/projects/` (path separators replaced with `-`, e.g., `-home-user-manifest-dev` for `/home/user/manifest-dev`).
-- `${CLAUDE_SESSION_ID}` → the value of the `CLAUDE_SESSION_ID` environment variable.
+- `<project_hash>` → the project hash used in `~/.gemini/tmp/` (Gemini computes this per-project automatically).
+- `${GEMINI_SESSION_ID}` → the value of the `GEMINI_SESSION_ID` environment variable.
 - `[log-file-path if iterating]` → if this run iterated on a previous manifest that had an execution log, substitute the actual log path; otherwise omit the bracketed clause entirely (including the trailing space).
 
 ```text
 Manifest complete: /tmp/manifest-{timestamp}.md
-Session: ~/.claude/projects/<dir>/${CLAUDE_SESSION_ID}.jsonl
+Session: ~/.gemini/tmp/<project_hash>/chats/session-${GEMINI_SESSION_ID}.jsonl
 
 To execute: /do /tmp/manifest-{timestamp}.md [log-file-path if iterating]
 ```

--- a/dist/gemini/skills/do/SKILL.md
+++ b/dist/gemini/skills/do/SKILL.md
@@ -60,7 +60,7 @@ When `--scope` is NOT provided, ignore this section entirely. No reference file 
 
 ## Constraints
 
-**Log after every action.** Write to execution log immediately after each AC attempt. No exceptions. This is disaster recovery: if context is lost, the log is the only record of what happened.
+**Log non-trivial events as they happen.** Write to the execution log whenever something a future reader would need to know lands: a surprise during implementation, a divergence from the Approach, the rationale behind a fix-after-failure, a discovery that should amend the manifest. Routine status pings ("started AC-1.1", "tests passed") are not events worth logging. The log is disaster recovery — if context is lost, it's the only record of what happened — and retrospect material — a future agent or human should be able to reconstruct *why* the run unfolded the way it did.
 
 **Must call /verify.** Can't declare done without verification. Invoke manifest-dev:verify with manifest, log paths, the resolved mode, and an optional scope per the rules below: `/verify <manifest> <log> --mode <level> [--scope D2,D3]`. Never pass `--final` from /do; that flag is internal to /verify (auto-triggered after a true-selective green pass where `--scope` was set). /done is unreachable without a full-pass green (every AC + every INV-G) with no pending manual or deferred-auto criteria.
 
@@ -89,7 +89,13 @@ The mandatory full final gate (auto-triggered by /verify after true-selective gr
 
 Externalize progress to survive context loss.
 
-**Execution log.** Create `/tmp/do-log-{timestamp}.md` at start. After EACH AC attempt, append what happened and the outcome. Goal: another agent reading only the log could resume work.
+**Execution log.** Create `/tmp/do-log-{timestamp}.md` at start. The log is **append-only**: never rewrite past entries. Later entries can correct or supersede earlier ones, but earlier text stays as written.
+
+**Goal: narrative compressed context.** A fresh agent or human reading only the log can reconstruct the timeline, the surprises, and the reasoning — and resume the run from where it stopped without redoing investigation. They can also retrospect and learn how the implementation came to be.
+
+**What belongs.** Surprises during implementation, divergences from the Approach (with rationale), why a particular fix was chosen after a verification failure, anything that should amend the manifest, domain knowledge discovered, dispositions on opened threads. **Hard floor:** every decision that affects the manifest goes in, regardless of perceived triviality. **What doesn't:** restating ACs verbatim, narrating tool use that found nothing of consequence, status pings for routine progress. If removing the entry would not lose anything a future reader needs, don't write it.
+
+**Coexists with /verify pass blocks.** /verify appends its own structured `## /verify pass {N}` blocks to the same file (per `verify/SKILL.md` "Pass Logging Contract"). Those are a separate, machine-readable artifact within the log — leave them as-is, and write your narrative entries around them.
 
 **Todos.** Create from manifest (deliverables → ACs). Start with execution order from Approach (adjust if dependencies require). Update todo status after logging (log first, todo second).
 

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "078f888584fca7b8f7a95149cf831d4199996615",
+  "source_commit": "446ebfcd2c41a257b7089e71cad0a26c0eb83244",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-03T16:00:43Z"
+  "synced_at": "2026-05-03T16:45:44Z"
 }

--- a/dist/opencode/README.md
+++ b/dist/opencode/README.md
@@ -6,9 +6,9 @@ Verification-first manifest workflows for OpenCode CLI. Ported from the Claude C
 
 | Type | Count | Description |
 |------|-------|-------------|
-| Skills | 12 | Core workflow skills (define, do, verify, etc.) |
-| Agents | 15 | Specialized reviewer and verification agents |
-| Commands | 9 | User-invocable slash commands |
+| Skills | 9 | Core workflow skills (auto, define, do, done, drive, drive-tick, escalate, figure-out, verify) |
+| Agents | 14 | Specialized reviewer and verification agents |
+| Commands | 7 | User-invocable slash commands |
 | Plugin | 1 | TypeScript hook plugin for workflow enforcement |
 | Context | 1 | AGENTS.md workflow overview |
 

--- a/dist/opencode/agents/manifest-verifier.md
+++ b/dist/opencode/agents/manifest-verifier.md
@@ -57,7 +57,7 @@ User statements and discovered insights must appear in the manifest. Flag when:
 - Technical discovery encoded as invariant without user confirmation ("Discovered ≠ confirmed")
 - Process constraint (how to work) placed in INV instead of Process Guidance
 - Insights from domain understanding, reference class analysis, or failure mode coverage logged but not converted to criteria
-- Discovery log contains unresolved pending items (`- [ ]`) that weren't presented, encoded, or scoped out before synthesis
+- Discovery log opens threads (questions raised, scenarios surfaced, options noted, gaps identified) that don't reach an explicit disposition — encoded, scoped out, or mitigated — before synthesis
 
 ### Approach for complexity
 
@@ -135,8 +135,8 @@ Task file structures (quality gates, reviewer agents, risks, scenarios, trade-of
 - Structures skipped without logged justification (silent drops)
 - Selected quality gates not traceable to INV-G* or AC-* with matching verification (agent, threshold)
 - Log shows task file structures "noted" or "considered" but never presented to user — engagement requires selection or explicit skip, not acknowledgment
-- Log missing pending items for task file structures (should be logged as `- [ ]` immediately after reading task files)
-- Log contains unresolved `- [ ]` items at time of synthesis (applies to all pending items, not just task files — see Explicit → Encoded)
+- Log fails to surface task file structures as open threads (every Resolvable table/checklist item should be visible in the log narrative immediately after reading task files, with its eventual disposition)
+- Log contains threads opened but not closed at time of synthesis (applies to all opened threads, not just task files — see Explicit → Encoded)
 
 ### Approach constraints coverage
 

--- a/dist/opencode/skills/define/SKILL.md
+++ b/dist/opencode/skills/define/SKILL.md
@@ -115,7 +115,7 @@ Domain-specific guidance lives in `tasks/`:
   - Both become PG-*.
 - **Reference files** (`references/*.md`) — lookup data for `/verify` agents. Do not load during interview.
 
-**Encode quality gates and Defaults immediately after reading task files — before the interview.** Log each as `- [x]` RESOLVED.
+**Encode quality gates and Defaults immediately after reading task files — before the interview.** Note each in the discovery log narrative as it lands.
 
 Task files set the floor, not the ceiling — probe beyond when domain understanding warrants.
 
@@ -212,32 +212,23 @@ Follow the loaded mode's rules for question format, flow, checkpoints, finding-s
 
 **Style switches only on explicit user request.** The flag sets starting posture; the mode stays until the user explicitly asks to switch (e.g., "be more concise", "switch to autonomous", "ask everything"). Don't infer mode shifts from tone or terseness alone — terse answers within a mode are valid mode-internal signals, not switches. After a switch, follow the new mode from that point and log it to the discovery file.
 
-**Auto-switch variant.** When the user signals "enough" / "ship it" / "good enough" / "stop asking", a one-way switch to `autonomous` fires with auto-decide semantics on remaining `[ ]` items — see Convergence § Termination & escalation rules — Mode-switch escalation.
+**Auto-switch variant.** When the user signals "enough" / "ship it" / "good enough" / "stop asking", a one-way switch to `autonomous` fires with auto-decide semantics on remaining unresolved threads — see Convergence § Termination & escalation rules — Mode-switch escalation.
 
 ## Discovery & Question Disciplines
 
 ### Discovery log
 
-Write to `/tmp/define-discovery-{timestamp}.md` immediately after each discovery — same `{timestamp}` as the manifest. The log is source of truth: another agent reading only the log could resume the interview.
+Write to `/tmp/define-discovery-{timestamp}.md` as discoveries happen — same `{timestamp}` as the manifest. The log is **append-only**: never rewrite past entries. Later entries can supersede or close out earlier threads, but earlier text stays as it was written.
 
-Seed with a Context Assessment before probing — what's already understood and what's missing:
+**Goal: narrative compressed context.** A fresh agent or human reading only this log can reconstruct the timeline, the surprises, and the reasoning — and resume the interview from where you left off without redoing discovery. They can also retrospect and learn how decisions came to be.
 
-```
-## Context Assessment
-ALREADY UNDERSTOOD:
-- [x] RESOLVED (from context): [item] — [source]
-GAPS IDENTIFIED:
-- [ ] PENDING: [what's missing and why it matters]
-```
+**What belongs.** Anything that changed your mind, surprised you, required investigation, or locks a manifest decision. Domain knowledge you discovered. Assumptions you tested and what happened. Threads you opened, their dispositions, and why. **Hard floor:** every decision that affects the manifest goes in, regardless of perceived triviality.
 
-The interview begins at the gaps. Before marking a coverage goal as met from context, verify with concrete evidence — vague confidence doesn't count.
+**What doesn't.** Routine status pings, restating what the user just said, narrating tool use that found nothing of consequence. If removing the entry would not lose anything a future reader needs, don't write it.
 
-Every actionable item gets logged with status:
-- `- [ ]` PENDING — needs resolution
-- `- [x]` RESOLVED — encoded as INV/AC/PG/ASM, confirmed, or answered
-- `- [~]` SKIPPED — explicitly scoped out with reasoning
+**Open the log with what's already understood from context and where the gaps are**, then narrate as the interview unfolds. Format is yours — paragraphs, headings, whatever serves the resumability goal — as long as opened threads reach explicit dispositions in the narrative before synthesis. Before treating a coverage goal as met from context, verify with concrete evidence; vague confidence doesn't count.
 
-**Read full log before synthesis.** Unresolved `- [ ]` items are addressed first.
+**Read the full log before synthesis.** Any opened thread without a documented disposition is a gap — resolve it before writing the manifest.
 
 ### When to ask
 
@@ -249,7 +240,7 @@ Every actionable item gets logged with status:
 
 **Probe input artifacts.** When input references external documents (URLs, file paths, named documents), determine whether they should be verification sources. If yes, encode as Global Invariant.
 
-**Resolve all Resolvable task file structures.** After reading task files, extract every Resolvable table and checklist. Items already resolved in conversation context are logged as `- [x]` RESOLVED with source — not re-probed. Remaining items are `- [ ]` PENDING. Resolve each per interview mode, or skip with logged justification. Don't defer to synthesis.
+**Resolve all Resolvable task file structures.** After reading task files, extract every Resolvable table and checklist. Items already resolved in conversation context are noted in the log narrative with their source — not re-probed. Remaining items must reach a disposition through the interview (per interview mode) or be explicitly skipped with logged justification. Don't defer to synthesis.
 
 ### How to ask
 
@@ -275,7 +266,7 @@ Every actionable item gets logged with status:
 
 The interview mode defines probing aggressiveness. Convergence requires:
 - All applicable Coverage Goal convergence tests pass (Process Self-Audit may be skipped per its own rule)
-- No unresolved `- [ ]` items in the discovery log
+- Every thread opened in the discovery log has reached an explicit disposition (encoded as INV/AC/PG/ASM/R/T, scoped out with reasoning, or mitigated by approach)
 - Quality gates from task files encoded as INV-G* (or omitted with logged reasoning)
 - Defaults encoded as PG-*
 
@@ -291,14 +282,14 @@ These end /define:
 
 1. Verifier returns COMPLETE and the user approves the summary.
 2. User explicitly invokes `/do`. Behavior depends on where /define is in the run:
-   - **Before synthesis is complete** (interview still has unresolved items, or manifest not yet written): switch to `autonomous` interview mode, finish synthesis and the Verification Loop with auto-decisions (each remaining `[ ]` item gets the recommended default, encoded with `(auto)` annotation and logged in Known Assumptions), write the manifest, then hand off to /do without waiting for summary approval.
+   - **Before synthesis is complete** (interview still has unresolved threads, or manifest not yet written): switch to `autonomous` interview mode, finish synthesis and the Verification Loop with auto-decisions (each remaining unresolved thread gets the recommended default, encoded with `(auto)` annotation and logged in Known Assumptions), write the manifest, then hand off to /do without waiting for summary approval.
    - **At the summary stage** (manifest already written, awaiting approval): do not redo synthesis. Print `Manifest complete: ...` per Complete and hand off to /do immediately.
 
 #### Mode-switch escalation
 
 /define continues — only the interview mode changes:
 
-- User signals "enough" (or equivalent: "ship it", "good enough", "stop asking"). Effect: switch interview mode to `autonomous` from this point. Auto-decide remaining `[ ]` items per autonomous mode rules (recommended default chosen, encoded with `(auto)` annotation, logged in Known Assumptions). Continue through synthesis and the Verification Loop; expect to terminate via Stop condition 1.
+- User signals "enough" (or equivalent: "ship it", "good enough", "stop asking"). Effect: switch interview mode to `autonomous` from this point. Auto-decide remaining unresolved threads per autonomous mode rules (recommended default chosen, encoded with `(auto)` annotation, logged in Known Assumptions). Continue through synthesis and the Verification Loop; expect to terminate via Stop condition 1.
 
 ## Approach Section (Complex Tasks)
 
@@ -473,13 +464,12 @@ The medium is encoded in the manifest's Intent section as `Medium: <value>` so d
 
 /define ends here. Output the manifest path and stop. Substitute the placeholders before printing:
 - `{timestamp}` → the value used for the manifest filename.
-- `<dir>` → the current project directory in the slug form used by `~/.claude/projects/` (path separators replaced with `-`, e.g., `-home-user-manifest-dev` for `/home/user/manifest-dev`).
-- `${CLAUDE_SESSION_ID}` → the value of the `CLAUDE_SESSION_ID` environment variable.
 - `[log-file-path if iterating]` → if this run iterated on a previous manifest that had an execution log, substitute the actual log path; otherwise omit the bracketed clause entirely (including the trailing space).
 
 ```text
 Manifest complete: /tmp/manifest-{timestamp}.md
-Session: ~/.claude/projects/<dir>/${CLAUDE_SESSION_ID}.jsonl
 
 To execute: /do /tmp/manifest-{timestamp}.md [log-file-path if iterating]
 ```
+
+(OpenCode does not expose a per-session JSONL transcript file the agent can hand to the user — the Session line from the Claude Code source is intentionally omitted.)

--- a/dist/opencode/skills/do/SKILL.md
+++ b/dist/opencode/skills/do/SKILL.md
@@ -60,7 +60,7 @@ When `--scope` is NOT provided, ignore this section entirely. No reference file 
 
 ## Constraints
 
-**Log after every action.** Write to execution log immediately after each AC attempt. No exceptions. This is disaster recovery: if context is lost, the log is the only record of what happened.
+**Log non-trivial events as they happen.** Write to the execution log whenever something a future reader would need to know lands: a surprise during implementation, a divergence from the Approach, the rationale behind a fix-after-failure, a discovery that should amend the manifest. Routine status pings ("started AC-1.1", "tests passed") are not events worth logging. The log is disaster recovery — if context is lost, it's the only record of what happened — and retrospect material — a future agent or human should be able to reconstruct *why* the run unfolded the way it did.
 
 **Must call /verify.** Can't declare done without verification. Invoke manifest-dev:verify with manifest, log paths, the resolved mode, and an optional scope per the rules below: `/verify <manifest> <log> --mode <level> [--scope D2,D3]`. Never pass `--final` from /do; that flag is internal to /verify (auto-triggered after a true-selective green pass where `--scope` was set). /done is unreachable without a full-pass green (every AC + every INV-G) with no pending manual or deferred-auto criteria.
 
@@ -89,7 +89,13 @@ The mandatory full final gate (auto-triggered by /verify after true-selective gr
 
 Externalize progress to survive context loss.
 
-**Execution log.** Create `/tmp/do-log-{timestamp}.md` at start. After EACH AC attempt, append what happened and the outcome. Goal: another agent reading only the log could resume work.
+**Execution log.** Create `/tmp/do-log-{timestamp}.md` at start. The log is **append-only**: never rewrite past entries. Later entries can correct or supersede earlier ones, but earlier text stays as written.
+
+**Goal: narrative compressed context.** A fresh agent or human reading only the log can reconstruct the timeline, the surprises, and the reasoning — and resume the run from where it stopped without redoing investigation. They can also retrospect and learn how the implementation came to be.
+
+**What belongs.** Surprises during implementation, divergences from the Approach (with rationale), why a particular fix was chosen after a verification failure, anything that should amend the manifest, domain knowledge discovered, dispositions on opened threads. **Hard floor:** every decision that affects the manifest goes in, regardless of perceived triviality. **What doesn't:** restating ACs verbatim, narrating tool use that found nothing of consequence, status pings for routine progress. If removing the entry would not lose anything a future reader needs, don't write it.
+
+**Coexists with /verify pass blocks.** /verify appends its own structured `## /verify pass {N}` blocks to the same file (per `verify/SKILL.md` "Pass Logging Contract"). Those are a separate, machine-readable artifact within the log — leave them as-is, and write your narrative entries around them.
 
 **Todos.** Create from manifest (deliverables → ACs). Start with execution order from Approach (adjust if dependencies require). Update todo status after logging (log first, todo second).
 


### PR DESCRIPTION
## Summary

Converts the /define discovery log and /do execution log specs from shallow checklist / outcome-line patterns into **narrative compressed context** — append-only logs that capture timeline, surprises, domain knowledge, and decision rationale, with a non-trivial-only filter.

The bar: a fresh agent or human reading only the log can resume work or retrospect-learn how decisions came to be — without redoing discovery.

## Why

Both logs already *stated* the resumability goal ("another agent reading only the log could resume work") but their specs only mandated status tracking (`- [ ]` / `- [x]` markers in /define) or per-AC outcome lines in /do. The result was logs that recorded *what* without *why* — useless for retrospect, thin for resumption.

## What changed

**`skills/define/SKILL.md`** — Discovery log section rewritten as goal + constraints (narrative compressed context, append-only, non-trivial filter, hard floor for manifest-affecting decisions, resumability test). No required-fields template, no example entries — the LLM picks form. Six load-bearing cascade sites that depended on `- [ ]`/`- [x]`/`- [~]` syntax moved to thread-disposition language: Domain-Guidance encode-quality-gates line, auto-switch escalation, Resolve-all-Resolvable rule, Convergence rule, Stop-condition 2 sub-bullet, Mode-switch escalation rule.

**`skills/do/SKILL.md`** — `Log after every action` Constraint replaced with `Log non-trivial events as they happen`, framed for /do (surprises during implementation, divergences from Approach, fix-after-failure rationale, manifest-affecting discoveries; routine status pings excluded). Memento Pattern Execution log block expanded with the same goal/append-only/what-belongs framing. Explicitly carves out `## /verify pass {N}` blocks as a separate structured artifact within the same file (R-3 mitigation).

**`agents/manifest-verifier.md`** — Two gap-detection principles that keyed on `- [ ]` syntax rewritten to detect the same gaps via resolution-coverage of opened threads. Per the AC-2.2 review, the new principles actually catch narrative-form discovery logs that the marker-keyed version would silently pass.

**`.claude-plugin/plugin.json`** — minor bump 0.101.0 → 0.102.0.

**`dist/{codex,gemini,opencode}/`** — mirrors regenerated via `/sync-tools`. Also caught a backlog from #117 that hadn't been synced (deleted thinking-disciplines skills, removed hooks, README counts) and fixed pre-existing dist drift on the `Session:` line in /define output (Gemini retargeted to `~/.gemini/tmp/...`, OpenCode and Codex dropped — no usable per-session JSONL).

## Verification

Verified via /verify thorough mode — all 5 INV-G + 10 AC pass.

- `change-intent-reviewer` (INV-G1, AC-2.2): no LOW+ divergences from intent; gap-catching strength preserved on the verifier rewrite.
- `prompt-reviewer` (INV-G2): 9/10, no MEDIUM+ findings.
- `general-purpose` subagents (AC-1.1, 1.2, 1.3, 2.1, 3.1, 3.2): each spec section verified to satisfy goal + append-only + non-trivial filter + resumability test (and for /do, the /verify-coexistence note); no required-fields templates or example entries; edits proportional.
- `bash` invariants (INV-G3, 4, 5, AC-4.1, 4.2, 4.3): no orphan markers in any of the three target files; hardlink parity preserved byte-for-byte; dist mirrors carry the new vocabulary; plugin.json version bump confirmed.

## Test plan

- [ ] Try `/define` on a small task and confirm the discovery log reads as a coherent narrative (not a checklist).
- [ ] Try `/do` on the resulting manifest and confirm the execution log captures surprises/divergences/fix rationale rather than per-AC outcome lines.
- [ ] Confirm `/verify` still detects manifests with unresolved threads (now via resolution-coverage rather than `- [ ]` markers).
- [ ] Spot-check one of the `dist/` mirrors in its target CLI to confirm the synced spec works end-to-end.

## Notes

Manifest at `/tmp/manifest-20260503-161641.md`; full execution log at `/tmp/do-log-20260503-161641.md` (both have been written using the *new* narrative spec — they're working examples of the pattern this PR introduces).

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9sSghNxbztU8FPAyR8gdE)_