### PR TITLE
feat(figure-out): add right-size stance to counter ambition bias

### DIFF
--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.102.1",
+  "version": "0.103.0",
   "description": "Manifest-driven workflows for structured task execution with verification gates. Includes /drive — a cron-driven PR-lifecycle runner (graduated from manifest-dev-experimental). Supports multi-repo changesets via a shared canonical manifest.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/skills/figure-out/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/figure-out/SKILL.md
@@ -12,7 +12,7 @@ Truth-convergence is your north star. Not helpfulness, not comprehensiveness, no
 
 ## Stance
 
-Six operational stances. Each counters a specific failure mode in how you reason and communicate.
+Seven operational stances. Each counters a specific failure mode in how you reason and communicate.
 
 **Come prepared.** Investigate before engaging the user. Map the territory — files, data, dependencies — before forming a view. If you can find out, find out; don't default questions to the user that exploration could answer.
 
@@ -29,6 +29,10 @@ Six operational stances. Each counters a specific failure mode in how you reason
 **Verify before proposing.** Don't advocate for an approach you haven't checked the mechanics of. Confirm the API exists, the pattern works, the file is where you think.
 
 *Failure: Solution sprint.* Jumping to "here's what to do" before the problem is understood. Understanding may be the entire goal — resist the pull to solve.
+
+**Right-size your proposals.** Default to the smallest version that solves the problem. Your pull is toward comprehensive, well-shaped patterns — that pull is wrong for many concrete problems. When the work has direction-vs-scope structure (like architecture), commit to the direction before the scope, so the user reacts to the smaller decision before the larger one.
+
+*Failure: Ambition without consequence.* Reaching for the well-shaped pattern without pricing what it actually costs — debugging surface, edge cases, maintenance. Right-sizing is your job, not the user's to dial back after the fact.
 
 **Genuine agreement, genuine disagreement.** Name evidence on both. Never cave to social pressure; never disagree for the sake of appearing rigorous. If you still disagree after genuine exchange, say so once clearly — "Your call. I want to flag [specific risk] in case it matters later." — then respect their decision. Don't re-raise resolved disagreements.
 
@@ -88,3 +92,5 @@ The user decides when understanding is sufficient. There is no convergence check
 If the session has been going long and things feel like they're converging, share that honestly: "I think we've got a solid read on this. The main thing I'm still unsure about is [X]. Worth digging into that or are you satisfied?" This isn't pushing to end — it's sharing your assessment like a colleague would.
 
 If you believe significant gaps remain when the user signals done: state the gaps once clearly, then respect their call. Don't end with unacknowledged gaps.
+
+If figuring this out points to a concrete change to implement, /define is the next stop and will read this conversation as context.


### PR DESCRIPTION
## Summary

- Adds a seventh stance to `/figure-out` — **Right-size your proposals.** — paired with the failure mode *Ambition without consequence.* Encodes default-to-smallest, direction-before-scope as an embedded disposition (not a procedural list), and reframes right-sizing as the agent's job rather than the user's to dial back after the fact.
- Adds a one-line composition pointer in the Ending section so the `/figure-out` → `/define` transition is discoverable when a thinking session leads toward implementation.
- Bumps plugin version `0.102.1` → `0.103.0` (minor — new behavior).

The change models its own thesis: stance body sits in the existing-stance length range, no incidental edits to the other six stances, dist/ sync deferred to the standard follow-up `chore(dist)` PR per repo convention.

## Test plan

- [x] `change-intent-reviewer` reports 0 findings against stated intent
- [x] `prompt-reviewer` reports no MEDIUM+ findings on updated SKILL.md
- [x] Existing six stances + Ending section paragraphs byte-preserved (verified via `git diff origin/main`)
- [x] `claude-plugins/.../figure-out/SKILL.md` and `.claude/skills/figure-out/SKILL.md` byte-identical (hardlink — same inode)
- [x] Plugin version `0.103.0` present in `plugin.json`
- [x] READMEs reviewed; no updates required (skill description and trigger terms unchanged)

https://claude.ai/code/session_01HAvhnq36HkR9SzQx6Evdr6

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAvhnq36HkR9SzQx6Evdr6)_