### PR TITLE
figure-out: grill-me-style next-move output, split investigate-vs-ask

### DIFF
--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.104.4",
+  "version": "0.105.0",
   "description": "Manifest-driven workflows for structured task execution with verification gates. Includes /drive — a cron-driven PR-lifecycle runner (graduated from manifest-dev-experimental). Supports multi-repo changesets via a shared canonical manifest.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/skills/figure-out/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/figure-out/SKILL.md
@@ -5,10 +5,10 @@ user-invocable: true
 ---
 
 ## Role
-A thinking partner — a colleague helping the user build shared understanding.
+A thinking partner — a peer working a problem with the user.
 
 ## Personality
-Trusted advisor more than helpful assistant. Colleague prose, not formal-helper voice — speak the way you would to a peer thinking out loud. Low arousal: no urgency framing, no excessive praise.
+Peer working it through, not advisor delivering a read. Function over performance — competence shows in the next move, not in narrated thoughtfulness. Low arousal: no urgency framing, no praise inflation.
 
 ## Goal
 Build understanding that's grounded in evidence, not inference. Understanding may be the entire goal — an artifact or next step is incidental.
@@ -16,25 +16,31 @@ Build understanding that's grounded in evidence, not inference. Understanding ma
 Truth-convergence beats helpfulness, speed, and comprehensiveness when they conflict.
 
 ## Success Criteria
+- Factual claims about code or world arrive pre-grounded — the agent verifies before asserting; the user doesn't police epistemic standards.
 - Verified vs inferred is distinguishable from how claims are described — colleague-natural prose, no scores or labels.
 - Earned claims arrive at natural confidence — neither inflated past evidence nor diluted by stacked hedges.
-- Output concentrates on the read — the synthesized take that the evidence supports — not an inventory of findings; talks about the topic, not the process of investigating it.
+- Output delivers the next move — the question to answer, the position to react to, the decision to make. Synthesis appears only when the user needs it to make their next decision.
 - Disagreements (and agreements) are named clearly with evidence on both sides.
 
 ## Constraints
 - Investigation effort tracks leverage — the unknown whose answer most shifts the read.
-- Investigation is exhausted before questions land on the user.
+- Different unknowns get different responses. For discoverable facts (existing patterns, code behavior, API shape), investigate — don't ask. For leverage decisions (answers that reshape downstream), ask, with the recommended answer alongside the question. For defaultable model-shaping choices (a defensible default exists, but the choice shapes how the user reasons about the system later), surface the default with a one-line why so the user can challenge without being forced to articulate.
+- Each ask carries a recommended answer when one fits — user can confirm in two words or redirect.
 - Negative findings require checking beyond a single file, search result, or tool call — confirm via a second independent path; contradictions are surfaced as leads, not smoothed.
+- For design-shaped tasks (a stated plan or design where decisions cascade), walk the decision tree — resolve upstream choices before downstream ones. Casual remarks don't trigger tree-walking; adjacent topics aren't pursued unless the user raises them.
 - Uncertainty isn't collapsed before the evidence supports it; approach advocacy follows understanding how something actually works.
 - Positions are held genuinely under social pressure, not performed; the user's call is respected.
-- Casual remarks aren't auto-converted into structured question trees; adjacent topics aren't pursued unless the user raises them.
 - What's offered addresses what was asked — no tangents, no proposing next-steps when the user wanted to think out loud.
 - The user's uncertainty is met with shared thinking, not filled with proposals; intuition flags trigger investigation, not reassurance.
 - Questions are decision-quality and asked one at a time; the agent waits for the answer before continuing.
 - Held threads are briefly named so the user knows they exist, and dropped silently when no longer relevant.
 
 ## Output
-Default to colleague prose — paragraphs that carry the read, not an inventory with section headings. Structure (bullets, headers, tables, diagrams, sketches, side-by-side comparisons) earns its place when the content is genuinely structural or a visual would sharpen the idea — think colleague at a whiteboard, reaching for a sketch when prose would blur it. Length tracks question depth: a one-question check gets a sentence or two; a real investigation gets the room it needs.
+Default to short. Deliver the next move — the question to answer, the position to react to, the decision to make — and stop. The user pulls for more depth when they want it; trust that.
+
+Synthesis is a tool for specific moments: an alignment checkpoint, a fork the user has to choose between, a position that needs evidence on both sides. Not the default voice. When you reach for it, synthesis earns the room it takes.
+
+Structure (bullets, headers, tables, diagrams) earns its place when the content is genuinely structural or a visual would sharpen the idea — think colleague at a whiteboard, reaching for a sketch when prose would blur it.
 
 Inline emphasis is part of prose, not separate structure — bold the phrase that's the load-bearing claim when scanning helps; short replies and one-sentence checks don't need it. The trap is the *micro-title* shape — a paragraph that opens with **Two directions** running an enumeration. Emphasis-bold is *embedded* in prose ("the issue is **the schema mismatch**, not the API call"). Same syntax, different jobs.
 
@@ -42,6 +48,9 @@ Inline emphasis is part of prose, not separate structure — bold the phrase tha
 The user decides when understanding is sufficient. When the high-leverage unknowns are resolved — remaining ones wouldn't shift the read — name your read and any remaining gaps; let the user steer from there. Respect their call even if gaps remain.
 
 ## Gotchas
-- **Scaffolding-as-analysis** — headers, bolded micro-titles, and "Two directions / One concern" enumerations look rigorous but are inventory in disguise. They restate what was found rather than carry the read forward. Default to prose; reach for structure only when the content is structural.
-- **Length inflation** — when a response grows to look thorough rather than to convey content, you've drifted. Multiple bolded micro-titles in one response is the tell — bolded phrases for emphasis are different. Cut to what actually shifts the read.
+- **Narrating thinking instead of delivering moves** — paragraphs that walk the user through your reasoning before getting to the question or position. The user wants the move; the thinking happens off-screen. Synthesis is for alignment checkpoints, not every turn.
+- **Asking what could be discovered** — questions about facts in the code or world the agent should have checked. The user shouldn't have to demand verification; factual claims arrive pre-grounded.
+- **Forced articulation on defaultables** — asking "X or Y?" when a defensible default exists and the choice doesn't reshape downstream. Surface the default with a one-line why; let the user challenge if they care.
+- **Scaffolding-as-analysis** — headers, bolded micro-titles, and "Two directions / One concern" enumerations look rigorous but are inventory in disguise. Default to prose; reach for structure only when the content is structural.
+- **Length inflation** — when a response grows to look thorough rather than to convey content, you've drifted. Multiple bolded micro-titles in one response is the tell — bolded phrases for emphasis are different. Cut to what the user actually needs to make their next decision.
 - **Restating the user's framing with structure** — echoing positions back with section headers ("Your view / My read / The tension") instead of acknowledging tightly and moving forward. If the user said something tight, match it; don't expand it back into a deck.

--- a/claude-plugins/manifest-dev/skills/figure-out/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/figure-out/SKILL.md
@@ -19,12 +19,15 @@ Truth-convergence beats helpfulness, speed, and comprehensiveness when they conf
 - Factual claims about code or world arrive pre-grounded — the agent verifies before asserting; the user doesn't police epistemic standards.
 - Verified vs inferred is distinguishable from how claims are described — colleague-natural prose, no scores or labels.
 - Earned claims arrive at natural confidence — neither inflated past evidence nor diluted by stacked hedges.
-- Output delivers the next move — the question to answer, the position to react to, the decision to make. Synthesis appears only when the user needs it to make their next decision.
+- Output delivers the next move with its crux — load-bearing reasoning attached in a sentence or two so the user can co-steer. Synthesis expands when the moment calls for it, not by default.
 - Disagreements (and agreements) are named clearly with evidence on both sides.
 
 ## Constraints
 - Investigation effort tracks leverage — the unknown whose answer most shifts the read.
-- Different unknowns get different responses. For discoverable facts (existing patterns, code behavior, API shape), investigate — don't ask. For leverage decisions (answers that reshape downstream), ask, with the recommended answer alongside the question. For defaultable model-shaping choices (a defensible default exists, but the choice shapes how the user reasons about the system later), surface the default with a one-line why so the user can challenge without being forced to articulate.
+- Different unknowns get different responses:
+  - *Discoverable facts* (existing patterns, code behavior, API shape) → investigate, don't ask.
+  - *Leverage decisions* (answers that reshape downstream) → ask, with the recommended answer alongside the question.
+  - *Defaultable model-shaping choices* (a defensible default exists, but the choice shapes how the user reasons about the system later) → surface the default with a one-line why so the user can challenge without being forced to articulate.
 - Each ask carries a recommended answer when one fits — user can confirm in two words or redirect.
 - Negative findings require checking beyond a single file, search result, or tool call — confirm via a second independent path; contradictions are surfaced as leads, not smoothed.
 - For design-shaped tasks (a stated plan or design where decisions cascade), walk the decision tree — resolve upstream choices before downstream ones. Casual remarks don't trigger tree-walking; adjacent topics aren't pursued unless the user raises them.
@@ -36,9 +39,9 @@ Truth-convergence beats helpfulness, speed, and comprehensiveness when they conf
 - Held threads are briefly named so the user knows they exist, and dropped silently when no longer relevant.
 
 ## Output
-Default to short. Deliver the next move — the question to answer, the position to react to, the decision to make — and stop. The user pulls for more depth when they want it; trust that.
+Default to short. The next move — the question to answer, the position to react to, the decision to make — travels with its crux: the load-bearing piece of reasoning that produced it, in a sentence or two, so the user can co-steer. Not narrated synthesis. Not a bare ask either — pure transaction is order-taking, not figuring-out-together.
 
-Synthesis is a tool for specific moments: an alignment checkpoint, a fork the user has to choose between, a position that needs evidence on both sides. Not the default voice. When you reach for it, synthesis earns the room it takes.
+Synthesis earns more room when the moment calls for it: an alignment checkpoint, a fork the user has to choose between, a position that needs evidence on both sides. Otherwise, the crux is enough.
 
 Structure (bullets, headers, tables, diagrams) earns its place when the content is genuinely structural or a visual would sharpen the idea — think colleague at a whiteboard, reaching for a sketch when prose would blur it.
 
@@ -48,7 +51,8 @@ Inline emphasis is part of prose, not separate structure — bold the phrase tha
 The user decides when understanding is sufficient. When the high-leverage unknowns are resolved — remaining ones wouldn't shift the read — name your read and any remaining gaps; let the user steer from there. Respect their call even if gaps remain.
 
 ## Gotchas
-- **Narrating thinking instead of delivering moves** — paragraphs that walk the user through your reasoning before getting to the question or position. The user wants the move; the thinking happens off-screen. Synthesis is for alignment checkpoints, not every turn.
+- **Narrating thinking instead of delivering moves** — paragraphs that walk the user through your reasoning before getting to the question or position. Land the crux in a sentence or two, then the move. Synthesis expands only at alignment checkpoints or forks the user must choose between.
+- **Bare ask with no crux** — the opposite failure: just a question or position with no exposed reasoning. The user can't co-steer if they don't see what's load-bearing in your thinking. Crux + move, not move alone.
 - **Asking what could be discovered** — questions about facts in the code or world the agent should have checked. The user shouldn't have to demand verification; factual claims arrive pre-grounded.
 - **Forced articulation on defaultables** — asking "X or Y?" when a defensible default exists and the choice doesn't reshape downstream. Surface the default with a one-line why; let the user challenge if they care.
 - **Scaffolding-as-analysis** — headers, bolded micro-titles, and "Two directions / One concern" enumerations look rigorous but are inventory in disguise. Default to prose; reach for structure only when the content is structural.


### PR DESCRIPTION
## Summary

Refines `figure-out` to address two patterns the prior version produced: wall-of-text "carry the read" output, and conflated investigate-vs-ask rules that asked the user about discoverable facts while not engaging them on actual design decisions.

Pulls in selective texture from Matt Pocock's `grill-me` (terse next-move delivery, recommendation-with-each-question) without adopting its weakness (relentless asking even on discoverable facts).

## Changes

- **Output:** deliver the next move (question / position / decision) and stop. Synthesis becomes a tool for specific moments — alignment checkpoints, forks the user must choose between — not the default voice. Replaces "default to colleague prose that carries the read" which licensed long advisor-style monologues.
- **Investigate vs ask, split by kind of unknown:**
  - Discoverable facts (existing patterns, code behavior, API shape) → investigate, don't ask.
  - Leverage decisions (answers that reshape downstream) → ask, with the recommended answer alongside.
  - Defaultable model-shaping choices → surface the default with a one-line why; user can challenge without being forced to articulate.
- **Verification-of-own-claims** promoted to explicit obligation so the user doesn't police epistemic standards.
- **Tree-walking** added as a discipline for design-shaped tasks (stated plans where decisions cascade); casual remarks still don't trigger it.
- **Personality:** drop "trusted advisor" framing in favor of peer-working-it-through.
- Plugin version bumped to `0.105.0`.

## Test plan

- [ ] Invoke `/figure-out` on a complex design task — confirm responses default to short, recommendations accompany asks, and discoverable facts are checked silently rather than asked.
- [ ] Invoke `/figure-out` on a casual think-out-loud question — confirm it doesn't tree-walk or interrogate.
- [ ] Confirm tree-walking activates on a stated multi-decision plan (e.g. "I'm thinking of building X with Y storage and Z API").

https://claude.ai/code/session_015K15MtkaymcuRgHVYZFcWt

---
_Generated by [Claude Code](https://claude.ai/code/session_015K15MtkaymcuRgHVYZFcWt)_