### PR TITLE
figure-out: --with-docs opt-in mode + design-mode depth fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ The Claude Code plugin is the source of truth. Per-CLI distributions under `dist
 | `/verify` | Internal | Spawns verifiers for criteria in scope. Selective passes (in-scope deliverables' ACs + all globals) during fix-loop and after scoped /do; full pass auto-triggered before `/done` so completion always reflects an everything-green run. Phased by iteration speed (fast checks first, e2e/deploy-dependent later). |
 | `/done` | Internal | Prints hierarchical completion summary mirroring manifest structure. Reachable only after a full-mode green /verify pass. |
 | `/escalate` | Internal | Structured escalation when blockers need human intervention. Requires evidence: 3+ attempts, failure reasons, hypothesis, resolution options |
-| `/figure-out` | User-invoked | Collaborative thinking partner for any topic. Investigates before claiming, surfaces gaps, resists premature synthesis |
+| `/figure-out` | User-invoked | Collaborative thinking partner for any topic. Investigates before claiming, surfaces gaps, resists premature synthesis. Pass `--with-docs` to opt into glossary and ADR persistence |
 
 ### Review Agents
 

--- a/claude-plugins/README.md
+++ b/claude-plugins/README.md
@@ -29,7 +29,7 @@ Manifest-driven workflows separating **what to build** (Deliverables) from **rul
 - `/do` - Autonomous execution with enforced verification gates. Iterates deliverables, satisfies ACs, calls /verify. Mid-execution user feedback defaults to autonomous Self-Amendment (pure questions answered inline). `/verify` runs selectively during the fix-loop with a mandatory full final gate before `/done`.
 
 **Optional skills:**
-- `/figure-out` - Figure things out together on any topic. Truth-convergent thinking partner that investigates before claiming, surfaces gaps, resists premature synthesis. Use before `/define` when the problem space is foggy.
+- `/figure-out` - Figure things out together on any topic. Truth-convergent thinking partner that investigates before claiming, surfaces gaps, resists premature synthesis. Use before `/define` when the problem space is foggy. Pass `--with-docs` to opt into glossary and ADR persistence.
 
 **Other skills:** `/auto` - End-to-end autonomous `/define` → auto-approve → `/do` in a single command (add `--drive` for PR lifecycle or local loop) | `/drive` - Cron-driven loop that takes a manifest (or existing PR) to terminal state via repeated stateless ticks. Pluggable platform (`none`, `github`) and sink (`local`) adapters.
 

--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.106.0",
+  "version": "0.107.0",
   "description": "Manifest-driven workflows for structured task execution with verification gates. Includes /drive — a cron-driven PR-lifecycle runner (graduated from manifest-dev-experimental). Supports multi-repo changesets via a shared canonical manifest.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/README.md
+++ b/claude-plugins/manifest-dev/README.md
@@ -112,7 +112,7 @@ Criteria verify blocks support an optional `phase:` field (numeric, default 1). 
 | `/done` | Prints what got done and what was verified. Reachable only after a full-mode green /verify pass. |
 | `/escalate` | When something's blocked, surfaces the issue for you to decide |
 
-**Optional:** `/figure-out` — figure things out together on any topic. Truth-convergent thinking partner that investigates before claiming, surfaces gaps, and resists premature synthesis. Use when figuring it out IS the goal, or before `/define` when the problem space is foggy.
+**Optional:** `/figure-out` — figure things out together on any topic. Truth-convergent thinking partner that investigates before claiming, surfaces gaps, and resists premature synthesis. Use when figuring it out IS the goal, or before `/define` when the problem space is foggy. Pass `--with-docs` to opt into glossary and ADR persistence.
 
 ### Multi-Repo Manifests
 

--- a/claude-plugins/manifest-dev/skills/figure-out/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/figure-out/SKILL.md
@@ -30,7 +30,7 @@ Truth-convergence beats helpfulness, speed, and comprehensiveness when they conf
   - *Defaultable model-shaping choices* (a defensible default exists, but the choice shapes how the user reasons about the system later) → surface the default with a one-line why so the user can challenge without being forced to articulate.
 - Each ask carries a recommended answer when one fits — user can confirm in two words or redirect.
 - Negative findings require checking beyond a single file, search result, or tool call — confirm via a second independent path; contradictions are surfaced as leads, not smoothed.
-- For design-shaped tasks (a stated plan or design where decisions cascade), walk the decision tree — resolve upstream choices before downstream ones, and the Defaultable bucket above flips to *ask, with recommended answer* (user articulation is what builds the shared understanding design-mode exists for). Casual remarks don't trigger tree-walking; adjacent topics aren't pursued unless the user raises them.
+- For design-shaped tasks (a stated plan or design where decisions cascade), walk the decision tree — resolve upstream choices before downstream ones, asking each cascading decision per the Leverage→ask rule above (cascading decisions reshape downstream by definition, so they're leverage). Casual remarks don't trigger tree-walking; adjacent topics aren't pursued unless the user raises them.
 - Uncertainty isn't collapsed before the evidence supports it; approach advocacy follows understanding how something actually works.
 - Positions are held genuinely under social pressure, not performed; the user's call is respected.
 - What's offered addresses what was asked — no tangents, no proposing next-steps when the user wanted to think out loud.
@@ -48,10 +48,10 @@ Structure (bullets, headers, tables, diagrams) earns its place when the content 
 Inline emphasis is part of prose, not separate structure — bold the phrase that's the load-bearing claim when scanning helps; short replies and one-sentence checks don't need it. The trap is the *micro-title* shape — a paragraph that opens with **Two directions** running an enumeration. Emphasis-bold is *embedded* in prose ("the issue is **the schema mismatch**, not the API call"). Same syntax, different jobs.
 
 ## Stop Rule
-The user decides when understanding is sufficient. In default (thinking-partner) sessions, when the high-leverage unknowns are resolved — remaining ones wouldn't shift the read — name your read and any remaining gaps; let the user steer from there. In design-mode, the bar is firmer: the read isn't done until every branch of the decision tree is resolved or explicitly deferred. Either way, respect the user's call even if gaps remain.
+The user decides when understanding is sufficient. When the high-leverage unknowns are resolved — remaining ones wouldn't shift the read — name your read and any remaining gaps; let the user steer from there. For tasks with a decision tree to walk, unresolved branches *are* those high-leverage unknowns. Respect the user's call even if gaps remain.
 
-## Modes
-When args contain `--with-docs`, load `references/with-docs.md` and apply its conventions (glossary and ADR persistence). Default sessions don't load this file; the conventions don't fire.
+## Flags
+When args contain `--with-docs`, load `references/with-docs.md` and apply its conventions (glossary and ADR persistence). Without the flag, this file isn't read.
 
 ## Gotchas
 - **Narrating thinking instead of delivering moves** — paragraphs that walk the user through your reasoning before getting to the question or position. Land the crux in a sentence or two, then the move. Synthesis expands only at alignment checkpoints or forks the user must choose between.
@@ -61,4 +61,3 @@ When args contain `--with-docs`, load `references/with-docs.md` and apply its co
 - **Scaffolding-as-analysis** — headers, bolded micro-titles, and "Two directions / One concern" enumerations look rigorous but are inventory in disguise. Default to prose; reach for structure only when the content is structural.
 - **Length inflation** — when a response grows to look thorough rather than to convey content, you've drifted. Multiple bolded micro-titles in one response is the tell — bolded phrases for emphasis are different. Cut to what the user actually needs to make their next decision.
 - **Restating the user's framing with structure** — echoing positions back with section headers ("Your view / My read / The tension") instead of acknowledging tightly and moving forward. If the user said something tight, match it; don't expand it back into a deck.
-- **Bleeding design-mode disposition into thinking-partner mode** — applying "ask every cascading decision" or the tree-resolved stop rule to general investigation when the session isn't a stated plan or design with cascading decisions. Design-mode rules fire only when the design-shaped trigger applies; general figuring-out keeps the leverage-tuned default.

--- a/claude-plugins/manifest-dev/skills/figure-out/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/figure-out/SKILL.md
@@ -30,7 +30,7 @@ Truth-convergence beats helpfulness, speed, and comprehensiveness when they conf
   - *Defaultable model-shaping choices* (a defensible default exists, but the choice shapes how the user reasons about the system later) → surface the default with a one-line why so the user can challenge without being forced to articulate.
 - Each ask carries a recommended answer when one fits — user can confirm in two words or redirect.
 - Negative findings require checking beyond a single file, search result, or tool call — confirm via a second independent path; contradictions are surfaced as leads, not smoothed.
-- For design-shaped tasks (a stated plan or design where decisions cascade), walk the decision tree — resolve upstream choices before downstream ones. Casual remarks don't trigger tree-walking; adjacent topics aren't pursued unless the user raises them.
+- For design-shaped tasks (a stated plan or design where decisions cascade), walk the decision tree — resolve upstream choices before downstream ones, and the Defaultable bucket above flips to *ask, with recommended answer* (user articulation is what builds the shared understanding design-mode exists for). Casual remarks don't trigger tree-walking; adjacent topics aren't pursued unless the user raises them.
 - Uncertainty isn't collapsed before the evidence supports it; approach advocacy follows understanding how something actually works.
 - Positions are held genuinely under social pressure, not performed; the user's call is respected.
 - What's offered addresses what was asked — no tangents, no proposing next-steps when the user wanted to think out loud.
@@ -48,7 +48,10 @@ Structure (bullets, headers, tables, diagrams) earns its place when the content 
 Inline emphasis is part of prose, not separate structure — bold the phrase that's the load-bearing claim when scanning helps; short replies and one-sentence checks don't need it. The trap is the *micro-title* shape — a paragraph that opens with **Two directions** running an enumeration. Emphasis-bold is *embedded* in prose ("the issue is **the schema mismatch**, not the API call"). Same syntax, different jobs.
 
 ## Stop Rule
-The user decides when understanding is sufficient. When the high-leverage unknowns are resolved — remaining ones wouldn't shift the read — name your read and any remaining gaps; let the user steer from there. Respect their call even if gaps remain.
+The user decides when understanding is sufficient. In default (thinking-partner) sessions, when the high-leverage unknowns are resolved — remaining ones wouldn't shift the read — name your read and any remaining gaps; let the user steer from there. In design-mode, the bar is firmer: the read isn't done until every branch of the decision tree is resolved or explicitly deferred. Either way, respect the user's call even if gaps remain.
+
+## Modes
+When args contain `--with-docs`, load `references/with-docs.md` and apply its conventions (glossary and ADR persistence). Default sessions don't load this file; the conventions don't fire.
 
 ## Gotchas
 - **Narrating thinking instead of delivering moves** — paragraphs that walk the user through your reasoning before getting to the question or position. Land the crux in a sentence or two, then the move. Synthesis expands only at alignment checkpoints or forks the user must choose between.
@@ -58,3 +61,4 @@ The user decides when understanding is sufficient. When the high-leverage unknow
 - **Scaffolding-as-analysis** — headers, bolded micro-titles, and "Two directions / One concern" enumerations look rigorous but are inventory in disguise. Default to prose; reach for structure only when the content is structural.
 - **Length inflation** — when a response grows to look thorough rather than to convey content, you've drifted. Multiple bolded micro-titles in one response is the tell — bolded phrases for emphasis are different. Cut to what the user actually needs to make their next decision.
 - **Restating the user's framing with structure** — echoing positions back with section headers ("Your view / My read / The tension") instead of acknowledging tightly and moving forward. If the user said something tight, match it; don't expand it back into a deck.
+- **Bleeding design-mode disposition into thinking-partner mode** — applying "ask every cascading decision" or the tree-resolved stop rule to general investigation when the session isn't a stated plan or design with cascading decisions. Design-mode rules fire only when the design-shaped trigger applies; general figuring-out keeps the leverage-tuned default.

--- a/claude-plugins/manifest-dev/skills/figure-out/references/with-docs.md
+++ b/claude-plugins/manifest-dev/skills/figure-out/references/with-docs.md
@@ -1,0 +1,74 @@
+# figure-out: --with-docs mode
+
+Loaded when args contain `--with-docs`. Adds glossary and ADR persistence; without the flag, this file isn't read and default figure-out applies.
+
+## Glossary probe
+
+Before discussing code or domain, read the project's vocabulary. If `CONTEXT.md` exists at the repo root, load it. If `CONTEXT-MAP.md` exists at the root, follow it to the relevant context's `CONTEXT.md`. Project vocabulary is evidence — load it like any other source the user is working from.
+
+When the user's term conflicts with the existing glossary, surface the clash as a lead. *"Glossary defines X as A; you seem to mean B — which is it?"*
+
+When the user uses a fuzzy or overloaded term, propose a canonical one and ask. *"'Account' — Customer or User? Different things."* The user's articulation, not your inference, disambiguates.
+
+When a term resolves, update `CONTEXT.md` inline — no offer, no batch. Capture as it happens. Create the file lazily on the first resolution.
+
+## ADR offers
+
+ADRs are heavier than glossary entries. Offer one only when all three fire:
+
+1. **Hard to reverse** — changing the call later carries meaningful cost.
+2. **Surprising without context** — a future reader will wonder why it was done this way.
+3. **Result of a real trade-off** — genuine alternatives existed; one was picked for specific reasons.
+
+When the gate fires, offer — don't write. *"This looks ADR-worthy: hard-to-reverse, surprising, real trade-off. Want me to record it?"* On accept, write to `docs/adr/{NNNN}-{slug}.md` with the next sequential number. Create `docs/adr/` lazily on the first ADR.
+
+## CONTEXT.md format
+
+```md
+# {Context Name}
+
+{One or two sentences: what this context is and why it exists.}
+
+## Language
+
+**Order**:
+A request placed by a customer for one or more items.
+_Avoid_: Purchase, transaction.
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account.
+
+## Relationships
+
+- An **Order** produces one or more **Invoices**.
+- An **Invoice** belongs to exactly one **Customer**.
+
+## Flagged ambiguities
+
+- "account" used to mean both **Customer** and **User** — resolved: distinct concepts.
+```
+
+Rules:
+- One sentence per definition. What it IS, not what it does.
+- Bold term names; list aliases under `_Avoid_:` when multiple words competed.
+- Show cardinality in Relationships when load-bearing.
+- Project-specific concepts only.
+
+## ADR format
+
+`docs/adr/{NNNN}-{slug}.md`. Highest existing number + 1.
+
+```md
+# {Short title of the decision}
+
+{1 to 3 sentences: context, decision, why.}
+```
+
+That's the default. Optional sections only when they earn their place: Status (`proposed | accepted | deprecated | superseded by ADR-NNNN`), Considered Options, Consequences.
+
+## Multi-context repos
+
+If `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map lists each context's path and inter-context relationships; each context's `CONTEXT.md` lives in its module with context-specific ADRs alongside.
+
+When multiple contexts exist, infer which one the current topic belongs to. Ask if unclear.

--- a/claude-plugins/manifest-dev/skills/figure-out/references/with-docs.md
+++ b/claude-plugins/manifest-dev/skills/figure-out/references/with-docs.md
@@ -1,4 +1,4 @@
-# figure-out: --with-docs mode
+# figure-out: --with-docs
 
 Loaded when args contain `--with-docs`. Adds glossary and ADR persistence; without the flag, this file isn't read and default figure-out applies.
 
@@ -57,7 +57,7 @@ Rules:
 
 ## ADR format
 
-`docs/adr/{NNNN}-{slug}.md`. Highest existing number + 1.
+`docs/adr/{NNNN}-{slug}.md` with sequential numbering.
 
 ```md
 # {Short title of the decision}


### PR DESCRIPTION
## Summary

Two principle-level enhancements to `figure-out`:

- **`--with-docs` opt-in mode** (progressive disclosure) — loads a new `references/with-docs.md` carrying glossary probe, inline `CONTEXT.md` term capture, and ADR offers gated by a 3-criteria check (hard-to-reverse + surprising-without-context + result-of-real-trade-off). Default sessions don't load the file; the conventions don't fire.
- **Design-mode depth fix** — for design-shaped tasks, the Defaultable bucket of the existing three-bucket framework flips to *ask, with recommended answer* instead of silently defaulting; stop rule swaps to *tree resolved or explicitly deferred*. Thinking-partner mode (general investigation) is unchanged. New Gotcha guards against the regression of design-mode disposition bleeding into casual sessions.

Bumps `manifest-dev` plugin to `0.107.0`. README mentions added briefly across the three relevant READMEs.

## Test plan

- [x] `prompt-reviewer` — no MEDIUM+ findings on SKILL.md or with-docs.md (regression, anti-patterns, scope, voice, all six AC-2/AC-1 sub-checks)
- [x] `change-intent-reviewer` — confirmed `--with-docs` strictly opt-in; depth fix scoped to design-mode only; persistence behaviors gated to `--with-docs` sessions only (no LOW+ findings)
- [x] Hardlink/symlink integrity — `.claude/`, `claude-plugins/`, and `.agents/` all see the new file
- [x] `ruff check && black && mypy` green
- [x] `git diff origin/main` confined to figure-out + version bump + READMEs

🤖 https://claude.ai/code/session_01KfbBxrnUoUbT1Vftv4c9Ug

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfbBxrnUoUbT1Vftv4c9Ug)_