### PR TITLE
chore(dist): sync figure-out --with-docs to gemini, opencode, codex

### DIFF
--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "ea1aded5e8d500bc80225a6b593925d09c1f44f7",
+  "source_commit": "e1fc238c9adeb8e48acfd34755ad2d897be138c3",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-06T11:29:45Z"
+  "synced_at": "2026-05-08T21:28:27Z"
 }

--- a/dist/codex/skills/figure-out/SKILL.md
+++ b/dist/codex/skills/figure-out/SKILL.md
@@ -30,7 +30,7 @@ Truth-convergence beats helpfulness, speed, and comprehensiveness when they conf
   - *Defaultable model-shaping choices* (a defensible default exists, but the choice shapes how the user reasons about the system later) → surface the default with a one-line why so the user can challenge without being forced to articulate.
 - Each ask carries a recommended answer when one fits — user can confirm in two words or redirect.
 - Negative findings require checking beyond a single file, search result, or tool call — confirm via a second independent path; contradictions are surfaced as leads, not smoothed.
-- For design-shaped tasks (a stated plan or design where decisions cascade), walk the decision tree — resolve upstream choices before downstream ones. Casual remarks don't trigger tree-walking; adjacent topics aren't pursued unless the user raises them.
+- For design-shaped tasks (a stated plan or design where decisions cascade), walk the decision tree — resolve upstream choices before downstream ones, asking each cascading decision per the Leverage→ask rule above (cascading decisions reshape downstream by definition, so they're leverage). Casual remarks don't trigger tree-walking; adjacent topics aren't pursued unless the user raises them.
 - Uncertainty isn't collapsed before the evidence supports it; approach advocacy follows understanding how something actually works.
 - Positions are held genuinely under social pressure, not performed; the user's call is respected.
 - What's offered addresses what was asked — no tangents, no proposing next-steps when the user wanted to think out loud.
@@ -48,7 +48,10 @@ Structure (bullets, headers, tables, diagrams) earns its place when the content 
 Inline emphasis is part of prose, not separate structure — bold the phrase that's the load-bearing claim when scanning helps; short replies and one-sentence checks don't need it. The trap is the *micro-title* shape — a paragraph that opens with **Two directions** running an enumeration. Emphasis-bold is *embedded* in prose ("the issue is **the schema mismatch**, not the API call"). Same syntax, different jobs.
 
 ## Stop Rule
-The user decides when understanding is sufficient. When the high-leverage unknowns are resolved — remaining ones wouldn't shift the read — name your read and any remaining gaps; let the user steer from there. Respect their call even if gaps remain.
+The user decides when understanding is sufficient. When the high-leverage unknowns are resolved — remaining ones wouldn't shift the read — name your read and any remaining gaps; let the user steer from there. For tasks with a decision tree to walk, unresolved branches *are* those high-leverage unknowns. Respect the user's call even if gaps remain.
+
+## Flags
+When args contain `--with-docs`, load `references/with-docs.md` and apply its conventions (glossary and ADR persistence). Without the flag, this file isn't read.
 
 ## Gotchas
 - **Narrating thinking instead of delivering moves** — paragraphs that walk the user through your reasoning before getting to the question or position. Land the crux in a sentence or two, then the move. Synthesis expands only at alignment checkpoints or forks the user must choose between.

--- a/dist/codex/skills/figure-out/references/with-docs.md
+++ b/dist/codex/skills/figure-out/references/with-docs.md
@@ -1,0 +1,74 @@
+# figure-out: --with-docs
+
+Loaded when args contain `--with-docs`. Adds glossary and ADR persistence; without the flag, this file isn't read and default figure-out applies.
+
+## Glossary probe
+
+Before discussing code or domain, read the project's vocabulary. If `CONTEXT.md` exists at the repo root, load it. If `CONTEXT-MAP.md` exists at the root, follow it to the relevant context's `CONTEXT.md`. Project vocabulary is evidence — load it like any other source the user is working from.
+
+When the user's term conflicts with the existing glossary, surface the clash as a lead. *"Glossary defines X as A; you seem to mean B — which is it?"*
+
+When the user uses a fuzzy or overloaded term, propose a canonical one and ask. *"'Account' — Customer or User? Different things."* The user's articulation, not your inference, disambiguates.
+
+When a term resolves, update `CONTEXT.md` inline — no offer, no batch. Capture as it happens. Create the file lazily on the first resolution.
+
+## ADR offers
+
+ADRs are heavier than glossary entries. Offer one only when all three fire:
+
+1. **Hard to reverse** — changing the call later carries meaningful cost.
+2. **Surprising without context** — a future reader will wonder why it was done this way.
+3. **Result of a real trade-off** — genuine alternatives existed; one was picked for specific reasons.
+
+When the gate fires, offer — don't write. *"This looks ADR-worthy: hard-to-reverse, surprising, real trade-off. Want me to record it?"* On accept, write to `docs/adr/{NNNN}-{slug}.md` with the next sequential number. Create `docs/adr/` lazily on the first ADR.
+
+## CONTEXT.md format
+
+```md
+# {Context Name}
+
+{One or two sentences: what this context is and why it exists.}
+
+## Language
+
+**Order**:
+A request placed by a customer for one or more items.
+_Avoid_: Purchase, transaction.
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account.
+
+## Relationships
+
+- An **Order** produces one or more **Invoices**.
+- An **Invoice** belongs to exactly one **Customer**.
+
+## Flagged ambiguities
+
+- "account" used to mean both **Customer** and **User** — resolved: distinct concepts.
+```
+
+Rules:
+- One sentence per definition. What it IS, not what it does.
+- Bold term names; list aliases under `_Avoid_:` when multiple words competed.
+- Show cardinality in Relationships when load-bearing.
+- Project-specific concepts only.
+
+## ADR format
+
+`docs/adr/{NNNN}-{slug}.md` with sequential numbering.
+
+```md
+# {Short title of the decision}
+
+{1 to 3 sentences: context, decision, why.}
+```
+
+That's the default. Optional sections only when they earn their place: Status (`proposed | accepted | deprecated | superseded by ADR-NNNN`), Considered Options, Consequences.
+
+## Multi-context repos
+
+If `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map lists each context's path and inter-context relationships; each context's `CONTEXT.md` lives in its module with context-specific ADRs alongside.
+
+When multiple contexts exist, infer which one the current topic belongs to. Ask if unclear.

--- a/dist/gemini/.sync-meta.json
+++ b/dist/gemini/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "ea1aded5e8d500bc80225a6b593925d09c1f44f7",
+  "source_commit": "e1fc238c9adeb8e48acfd34755ad2d897be138c3",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-06T11:29:45Z"
+  "synced_at": "2026-05-08T21:28:27Z"
 }

--- a/dist/gemini/skills/figure-out/SKILL.md
+++ b/dist/gemini/skills/figure-out/SKILL.md
@@ -30,7 +30,7 @@ Truth-convergence beats helpfulness, speed, and comprehensiveness when they conf
   - *Defaultable model-shaping choices* (a defensible default exists, but the choice shapes how the user reasons about the system later) → surface the default with a one-line why so the user can challenge without being forced to articulate.
 - Each ask carries a recommended answer when one fits — user can confirm in two words or redirect.
 - Negative findings require checking beyond a single file, search result, or tool call — confirm via a second independent path; contradictions are surfaced as leads, not smoothed.
-- For design-shaped tasks (a stated plan or design where decisions cascade), walk the decision tree — resolve upstream choices before downstream ones. Casual remarks don't trigger tree-walking; adjacent topics aren't pursued unless the user raises them.
+- For design-shaped tasks (a stated plan or design where decisions cascade), walk the decision tree — resolve upstream choices before downstream ones, asking each cascading decision per the Leverage→ask rule above (cascading decisions reshape downstream by definition, so they're leverage). Casual remarks don't trigger tree-walking; adjacent topics aren't pursued unless the user raises them.
 - Uncertainty isn't collapsed before the evidence supports it; approach advocacy follows understanding how something actually works.
 - Positions are held genuinely under social pressure, not performed; the user's call is respected.
 - What's offered addresses what was asked — no tangents, no proposing next-steps when the user wanted to think out loud.
@@ -48,7 +48,10 @@ Structure (bullets, headers, tables, diagrams) earns its place when the content 
 Inline emphasis is part of prose, not separate structure — bold the phrase that's the load-bearing claim when scanning helps; short replies and one-sentence checks don't need it. The trap is the *micro-title* shape — a paragraph that opens with **Two directions** running an enumeration. Emphasis-bold is *embedded* in prose ("the issue is **the schema mismatch**, not the API call"). Same syntax, different jobs.
 
 ## Stop Rule
-The user decides when understanding is sufficient. When the high-leverage unknowns are resolved — remaining ones wouldn't shift the read — name your read and any remaining gaps; let the user steer from there. Respect their call even if gaps remain.
+The user decides when understanding is sufficient. When the high-leverage unknowns are resolved — remaining ones wouldn't shift the read — name your read and any remaining gaps; let the user steer from there. For tasks with a decision tree to walk, unresolved branches *are* those high-leverage unknowns. Respect the user's call even if gaps remain.
+
+## Flags
+When args contain `--with-docs`, load `references/with-docs.md` and apply its conventions (glossary and ADR persistence). Without the flag, this file isn't read.
 
 ## Gotchas
 - **Narrating thinking instead of delivering moves** — paragraphs that walk the user through your reasoning before getting to the question or position. Land the crux in a sentence or two, then the move. Synthesis expands only at alignment checkpoints or forks the user must choose between.

--- a/dist/gemini/skills/figure-out/references/with-docs.md
+++ b/dist/gemini/skills/figure-out/references/with-docs.md
@@ -1,0 +1,74 @@
+# figure-out: --with-docs
+
+Loaded when args contain `--with-docs`. Adds glossary and ADR persistence; without the flag, this file isn't read and default figure-out applies.
+
+## Glossary probe
+
+Before discussing code or domain, read the project's vocabulary. If `CONTEXT.md` exists at the repo root, load it. If `CONTEXT-MAP.md` exists at the root, follow it to the relevant context's `CONTEXT.md`. Project vocabulary is evidence — load it like any other source the user is working from.
+
+When the user's term conflicts with the existing glossary, surface the clash as a lead. *"Glossary defines X as A; you seem to mean B — which is it?"*
+
+When the user uses a fuzzy or overloaded term, propose a canonical one and ask. *"'Account' — Customer or User? Different things."* The user's articulation, not your inference, disambiguates.
+
+When a term resolves, update `CONTEXT.md` inline — no offer, no batch. Capture as it happens. Create the file lazily on the first resolution.
+
+## ADR offers
+
+ADRs are heavier than glossary entries. Offer one only when all three fire:
+
+1. **Hard to reverse** — changing the call later carries meaningful cost.
+2. **Surprising without context** — a future reader will wonder why it was done this way.
+3. **Result of a real trade-off** — genuine alternatives existed; one was picked for specific reasons.
+
+When the gate fires, offer — don't write. *"This looks ADR-worthy: hard-to-reverse, surprising, real trade-off. Want me to record it?"* On accept, write to `docs/adr/{NNNN}-{slug}.md` with the next sequential number. Create `docs/adr/` lazily on the first ADR.
+
+## CONTEXT.md format
+
+```md
+# {Context Name}
+
+{One or two sentences: what this context is and why it exists.}
+
+## Language
+
+**Order**:
+A request placed by a customer for one or more items.
+_Avoid_: Purchase, transaction.
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account.
+
+## Relationships
+
+- An **Order** produces one or more **Invoices**.
+- An **Invoice** belongs to exactly one **Customer**.
+
+## Flagged ambiguities
+
+- "account" used to mean both **Customer** and **User** — resolved: distinct concepts.
+```
+
+Rules:
+- One sentence per definition. What it IS, not what it does.
+- Bold term names; list aliases under `_Avoid_:` when multiple words competed.
+- Show cardinality in Relationships when load-bearing.
+- Project-specific concepts only.
+
+## ADR format
+
+`docs/adr/{NNNN}-{slug}.md` with sequential numbering.
+
+```md
+# {Short title of the decision}
+
+{1 to 3 sentences: context, decision, why.}
+```
+
+That's the default. Optional sections only when they earn their place: Status (`proposed | accepted | deprecated | superseded by ADR-NNNN`), Considered Options, Consequences.
+
+## Multi-context repos
+
+If `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map lists each context's path and inter-context relationships; each context's `CONTEXT.md` lives in its module with context-specific ADRs alongside.
+
+When multiple contexts exist, infer which one the current topic belongs to. Ask if unclear.

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "ea1aded5e8d500bc80225a6b593925d09c1f44f7",
+  "source_commit": "e1fc238c9adeb8e48acfd34755ad2d897be138c3",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-06T11:29:45Z"
+  "synced_at": "2026-05-08T21:28:27Z"
 }

--- a/dist/opencode/skills/figure-out/SKILL.md
+++ b/dist/opencode/skills/figure-out/SKILL.md
@@ -30,7 +30,7 @@ Truth-convergence beats helpfulness, speed, and comprehensiveness when they conf
   - *Defaultable model-shaping choices* (a defensible default exists, but the choice shapes how the user reasons about the system later) → surface the default with a one-line why so the user can challenge without being forced to articulate.
 - Each ask carries a recommended answer when one fits — user can confirm in two words or redirect.
 - Negative findings require checking beyond a single file, search result, or tool call — confirm via a second independent path; contradictions are surfaced as leads, not smoothed.
-- For design-shaped tasks (a stated plan or design where decisions cascade), walk the decision tree — resolve upstream choices before downstream ones. Casual remarks don't trigger tree-walking; adjacent topics aren't pursued unless the user raises them.
+- For design-shaped tasks (a stated plan or design where decisions cascade), walk the decision tree — resolve upstream choices before downstream ones, asking each cascading decision per the Leverage→ask rule above (cascading decisions reshape downstream by definition, so they're leverage). Casual remarks don't trigger tree-walking; adjacent topics aren't pursued unless the user raises them.
 - Uncertainty isn't collapsed before the evidence supports it; approach advocacy follows understanding how something actually works.
 - Positions are held genuinely under social pressure, not performed; the user's call is respected.
 - What's offered addresses what was asked — no tangents, no proposing next-steps when the user wanted to think out loud.
@@ -48,7 +48,10 @@ Structure (bullets, headers, tables, diagrams) earns its place when the content 
 Inline emphasis is part of prose, not separate structure — bold the phrase that's the load-bearing claim when scanning helps; short replies and one-sentence checks don't need it. The trap is the *micro-title* shape — a paragraph that opens with **Two directions** running an enumeration. Emphasis-bold is *embedded* in prose ("the issue is **the schema mismatch**, not the API call"). Same syntax, different jobs.
 
 ## Stop Rule
-The user decides when understanding is sufficient. When the high-leverage unknowns are resolved — remaining ones wouldn't shift the read — name your read and any remaining gaps; let the user steer from there. Respect their call even if gaps remain.
+The user decides when understanding is sufficient. When the high-leverage unknowns are resolved — remaining ones wouldn't shift the read — name your read and any remaining gaps; let the user steer from there. For tasks with a decision tree to walk, unresolved branches *are* those high-leverage unknowns. Respect the user's call even if gaps remain.
+
+## Flags
+When args contain `--with-docs`, load `references/with-docs.md` and apply its conventions (glossary and ADR persistence). Without the flag, this file isn't read.
 
 ## Gotchas
 - **Narrating thinking instead of delivering moves** — paragraphs that walk the user through your reasoning before getting to the question or position. Land the crux in a sentence or two, then the move. Synthesis expands only at alignment checkpoints or forks the user must choose between.

--- a/dist/opencode/skills/figure-out/references/with-docs.md
+++ b/dist/opencode/skills/figure-out/references/with-docs.md
@@ -1,0 +1,74 @@
+# figure-out: --with-docs
+
+Loaded when args contain `--with-docs`. Adds glossary and ADR persistence; without the flag, this file isn't read and default figure-out applies.
+
+## Glossary probe
+
+Before discussing code or domain, read the project's vocabulary. If `CONTEXT.md` exists at the repo root, load it. If `CONTEXT-MAP.md` exists at the root, follow it to the relevant context's `CONTEXT.md`. Project vocabulary is evidence — load it like any other source the user is working from.
+
+When the user's term conflicts with the existing glossary, surface the clash as a lead. *"Glossary defines X as A; you seem to mean B — which is it?"*
+
+When the user uses a fuzzy or overloaded term, propose a canonical one and ask. *"'Account' — Customer or User? Different things."* The user's articulation, not your inference, disambiguates.
+
+When a term resolves, update `CONTEXT.md` inline — no offer, no batch. Capture as it happens. Create the file lazily on the first resolution.
+
+## ADR offers
+
+ADRs are heavier than glossary entries. Offer one only when all three fire:
+
+1. **Hard to reverse** — changing the call later carries meaningful cost.
+2. **Surprising without context** — a future reader will wonder why it was done this way.
+3. **Result of a real trade-off** — genuine alternatives existed; one was picked for specific reasons.
+
+When the gate fires, offer — don't write. *"This looks ADR-worthy: hard-to-reverse, surprising, real trade-off. Want me to record it?"* On accept, write to `docs/adr/{NNNN}-{slug}.md` with the next sequential number. Create `docs/adr/` lazily on the first ADR.
+
+## CONTEXT.md format
+
+```md
+# {Context Name}
+
+{One or two sentences: what this context is and why it exists.}
+
+## Language
+
+**Order**:
+A request placed by a customer for one or more items.
+_Avoid_: Purchase, transaction.
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account.
+
+## Relationships
+
+- An **Order** produces one or more **Invoices**.
+- An **Invoice** belongs to exactly one **Customer**.
+
+## Flagged ambiguities
+
+- "account" used to mean both **Customer** and **User** — resolved: distinct concepts.
+```
+
+Rules:
+- One sentence per definition. What it IS, not what it does.
+- Bold term names; list aliases under `_Avoid_:` when multiple words competed.
+- Show cardinality in Relationships when load-bearing.
+- Project-specific concepts only.
+
+## ADR format
+
+`docs/adr/{NNNN}-{slug}.md` with sequential numbering.
+
+```md
+# {Short title of the decision}
+
+{1 to 3 sentences: context, decision, why.}
+```
+
+That's the default. Optional sections only when they earn their place: Status (`proposed | accepted | deprecated | superseded by ADR-NNNN`), Considered Options, Consequences.
+
+## Multi-context repos
+
+If `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The map lists each context's path and inter-context relationships; each context's `CONTEXT.md` lives in its module with context-specific ADRs alongside.
+
+When multiple contexts exist, infer which one the current topic belongs to. Ask if unclear.


### PR DESCRIPTION
## Summary

Delta sync of PR #127's `figure-out` changes into the three CLI distributions.

- Source delta: `skills/figure-out/SKILL.md` modified (cascading-decisions clarification, Stop Rule expansion, new Flags section), plus new `skills/figure-out/references/with-docs.md` (74 lines).
- No substitutions applied. Both files contain no operational `CLAUDE.md` references, no execution-mode model names (haiku/sonnet/opus), and no session-file paths — they copy byte-for-byte to `dist/{gemini,opencode,codex}/skills/figure-out/`.
- Skill set unchanged → context files (`GEMINI.md` / `AGENTS.md`) and README component tables not regenerated. `install.sh` / `install_helpers.py` untouched (no component count change).
- `.sync-meta.json` bumped to HEAD (`e1fc238`) for all three CLIs.

The recorded `source_commit` (`ea1aded`) was PR #126's pre-squash branch tip, so it's not a direct ancestor of `main` after squash-merge — but the diff range still produces the correctly-scoped delta (PR #127 only), and the substitution rule files (`SKILL.md`, `references/{cli}-cli.md`) didn't change in the range. Delta sync over full re-sync was safe and chosen.

## Test plan

- [x] `diff -q` confirms each `dist/{cli}/skills/figure-out/SKILL.md` and `references/with-docs.md` is byte-identical to source.
- [x] `dist/{cli}/.sync-meta.json` updated to new HEAD with fresh UTC timestamp.
- [x] No drift in `commands/figure-out.md` (OpenCode wrapper just delegates `Invoke the manifest-dev:figure-out skill`).
- [ ] CI green on the branch.

https://claude.ai/code/session_01JrdapPZ4sm8X8dHdEm3Zg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrdapPZ4sm8X8dHdEm3Zg7)_