### PR TITLE
chore(dist): bump sync-meta SHA (no source changes)

### DIFF
--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "e1fc238c9adeb8e48acfd34755ad2d897be138c3",
+  "source_commit": "c31c631fb2d15cc35d2a90f5d593f1ec7a70072f",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-08T21:28:27Z"
+  "synced_at": "2026-05-11T11:55:36Z"
 }

--- a/dist/gemini/.sync-meta.json
+++ b/dist/gemini/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "e1fc238c9adeb8e48acfd34755ad2d897be138c3",
+  "source_commit": "c31c631fb2d15cc35d2a90f5d593f1ec7a70072f",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-08T21:28:27Z"
+  "synced_at": "2026-05-11T11:55:36Z"
 }

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "e1fc238c9adeb8e48acfd34755ad2d897be138c3",
+  "source_commit": "c31c631fb2d15cc35d2a90f5d593f1ec7a70072f",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-08T21:28:27Z"
+  "synced_at": "2026-05-11T11:55:36Z"
 }


### PR DESCRIPTION
## Summary

- Ran `/sync-tools` (diff-first). `git diff e1fc238..HEAD -- claude-plugins/manifest-dev/ .claude/skills/sync-tools/` returned empty — the only intervening commit (`c31c631`) modified `dist/` files only.
- No skill/agent/hook content to re-sync.
- Advanced `dist/{gemini,opencode,codex}/.sync-meta.json` SHA → `c31c631` and `synced_at` → `2026-05-11T11:55:36Z`, per the "always update meta" constraint, so next run's diff-first path keys off the right commit.

## Test plan

- [ ] Confirm no files outside `dist/{gemini,opencode,codex}/.sync-meta.json` changed in this PR.
- [ ] Next `/sync-tools` invocation reads the new recorded SHA and does a clean delta from `c31c631`.

https://claude.ai/code/session_014tRtPrJmmWaN8aoDWWe1YN

---
_Generated by [Claude Code](https://claude.ai/code/session_014tRtPrJmmWaN8aoDWWe1YN)_