### PR TITLE
Add argument-hint frontmatter to user-invocable skills

### DIFF
--- a/claude-plugins/PLUGIN_TEMPLATE/.claude-plugin/plugin.json
+++ b/claude-plugins/PLUGIN_TEMPLATE/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-template",
   "description": "A template for creating new Claude Code plugins",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Your Name",
     "email": "your.email@example.com"

--- a/claude-plugins/PLUGIN_TEMPLATE/skills/example/SKILL.md
+++ b/claude-plugins/PLUGIN_TEMPLATE/skills/example/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: example
 description: 'Analyzes the current project structure and tech stack. Use when asked to explore, understand, or summarize a project. Trigger terms: project overview, analyze codebase, what is this project.'
+argument-hint: '<input>'
 ---
 
 # Example Skill

--- a/claude-plugins/manifest-dev-experimental/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev-experimental/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev-experimental",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Experimental parallel rework of manifest-dev's skills. Radically slim prompts that trust model capability — every word steers, not scaffolds. Drops multi-mode budgeting and prescriptive HOW in favor of WHAT/WHY. Lives alongside manifest-dev until promotion. Same skills (figure-out, define, do, verify, done, escalate, auto), same hooks, same agents.",
   "keywords": [
     "experimental",

--- a/claude-plugins/manifest-dev-experimental/skills/auto/SKILL.md
+++ b/claude-plugins/manifest-dev-experimental/skills/auto/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auto
 description: 'Experimental. End-to-end autonomous execution: figure-out (when needed) → define → do, chained without manual approval gates. Add --babysit <pr-url> to tend an existing PR through review and CI. Use when you want to define and execute without intervention during planning. Triggers: auto, autonomous, end-to-end, just build it, tend pr, babysit pr.'
+argument-hint: '[task] [--babysit <pr-url>] [--platform <name>] [--canvas]'
 user-invocable: true
 ---
 

--- a/claude-plugins/manifest-dev-experimental/skills/define/SKILL.md
+++ b/claude-plugins/manifest-dev-experimental/skills/define/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: define
 description: 'Experimental. Manifest builder. Turns shared understanding into a verifiable Manifest with Deliverables, Acceptance Criteria, Global Invariants, and Approach. Auto-invokes /figure-out when the transcript lacks understanding. Use when planning features, scoping refactors, debugging complex issues, or whenever a task needs structured thinking before coding. Triggers: define, manifest, scope, plan, spec out, break down.'
+argument-hint: '[task] [--babysit <pr-url>] [--platform <name>] [--canvas]'
 user-invocable: true
 ---
 

--- a/claude-plugins/manifest-dev-experimental/skills/do/SKILL.md
+++ b/claude-plugins/manifest-dev-experimental/skills/do/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: do
 description: 'Experimental. Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies via /verify. Use when executing a manifest, running a plan, implementing a defined task.'
+argument-hint: '<manifest-path> [--scope <ids>]'
 user-invocable: true
 ---
 

--- a/claude-plugins/manifest-dev-experimental/skills/figure-out/SKILL.md
+++ b/claude-plugins/manifest-dev-experimental/skills/figure-out/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: figure-out
 description: 'Experimental. Figure things out together — any topic, problem, or idea. Probes a topic relentlessly until shared understanding is reached: walks every branch of the decision tree (design choices, diagnostic hypotheses, commitment questions), tackles the next load-bearing question first, returns to dropped threads, gives recommended answers. Use when you need to understand something before acting, or when figuring it out IS the goal. Triggers: figure out, help me think through, dig deeper, probe this, what is really going on, investigate, work through, why does.'
+argument-hint: '[topic] [--with-docs]'
 user-invocable: true
 ---
 

--- a/claude-plugins/manifest-dev-experimental/skills/verify/SKILL.md
+++ b/claude-plugins/manifest-dev-experimental/skills/verify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: verify
 description: 'Experimental. Runs verifiers for Global Invariants and Acceptance Criteria from a Manifest. Spawns verifier agents in parallel within each phase, aggregates, routes outcome to /done or /escalate. Normally invoked by /do; users invoke directly to verify an existing manifest.'
+argument-hint: '<manifest-path> [--scope <ids>]'
 user-invocable: true
 ---
 

--- a/claude-plugins/manifest-dev-tools/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev-tools",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Tools for working with prompts and PRs alongside the manifest workflow. ADR synthesis from session transcripts, collaborative PR walkthroughs, slim-discipline prompt engineering, and cross-boundary context handoff.",
   "keywords": [
     "adr",

--- a/claude-plugins/manifest-dev-tools/skills/adr/SKILL.md
+++ b/claude-plugins/manifest-dev-tools/skills/adr/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: adr
 description: 'Synthesize Architecture Decision Records from session transcripts. Extracts decisions via multi-agent pipeline and writes MADR files to a specified directory. Use after completing a /define or /do session to capture architectural decisions as durable records.'
+argument-hint: '<manifest-path> <output-dir> --session <transcript-path>'
 user-invocable: true
 ---
 

--- a/claude-plugins/manifest-dev-tools/skills/handoff/SKILL.md
+++ b/claude-plugins/manifest-dev-tools/skills/handoff/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: handoff
 description: 'Produce a self-contained context payload for cross-boundary handoff — switching tools (Claude Code ↔ Codex), starting a clean session, or handing off to another agent. Captures epistemic state (decisions, alternatives, verified facts, open threads) rather than session chronology, so the receiving agent inherits the same grounding without re-deriving understanding. Use when in-tool session continuation isn''t available. Triggers: handoff, cross-tool handoff, context payload, hand off context, fresh session bootstrap, transfer to a new agent.'
+argument-hint: '[prior-handoff-path]'
 user-invocable: true
 ---
 

--- a/claude-plugins/manifest-dev-tools/skills/prompt-engineering/SKILL.md
+++ b/claude-plugins/manifest-dev-tools/skills/prompt-engineering/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: prompt-engineering
 description: 'Create, update, slim, or review LLM prompts in the slim discipline — every word steers (behavior the model wouldn''t reach on its own) or scaffolds (preempts a failure the clean posture handles); cut scaffold. 1-3 paragraphs of essence in SKILL.md, contracts in references. Use when writing, slimming, reviewing, or diagnosing a prompt. Triggers: write a prompt, slim a prompt, edit a prompt, review a prompt, improve a prompt, diagnose prompt failure, fix failing prompt, system prompt, skill, agent.'
+argument-hint: '<request>'
 user-invocable: true
 ---
 

--- a/claude-plugins/manifest-dev-tools/skills/walk-pr/SKILL.md
+++ b/claude-plugins/manifest-dev-tools/skills/walk-pr/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: walk-pr
 description: 'Walk through a PR or large diff together — your own or someone else''s — one sub-changeset at a time and one review topic at a time within it. Verbatim quotes from both sides, section-by-section mapping of what survived / cut / moved, honest trade-offs with a recommended call. At the end, present a plan of the comments captured during the walk; on approval, post them as a PR review. Optional --canvas runs the walk in a live HTML artifact that replaces chat as the review surface. Use when reviewing a substantive PR collaboratively or walking a large refactor. Triggers: walk pr, walk diff, walk me through, pr walkthrough, review collaboratively, review this change with me.'
+argument-hint: '[pr-url-or-range] [--canvas]'
 user-invocable: true
 ---
 

--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "0.111.0",
+  "version": "0.111.1",
   "description": "Manifest workflows for structured task execution with verification gates. PR-lifecycle work composes the github-pr-lifecycle agent through PR_LIFECYCLE.md task guidance; /define --babysit synthesizes a lifecycle manifest from an existing PR. Supports multi-repo changesets via a shared canonical manifest.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/skills/auto/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/auto/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auto
 description: 'End-to-end autonomous execution: /define → auto-approve → /do in a single command. Infers task from conversation context when no arguments provided. Add --babysit <pr-url> to tend an existing PR through review and CI without manifest-dev setup. Use when you want to define and execute a task without manual intervention during planning. Triggers: auto, autonomous define and do, end-to-end, just build it, tend pr, babysit pr.'
+argument-hint: '[task] [--mode <level>] [--platform <name>] [--babysit <pr-url>]'
 user-invocable: true
 ---
 

--- a/claude-plugins/manifest-dev/skills/define/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/define/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: define
 description: 'Manifest builder. Plan work, scope tasks, spec out requirements, break down complex tasks before implementation. Converts needs into Deliverables + Invariants with verification criteria. Use when planning features, debugging complex issues, scoping refactors, or whenever a task needs structured thinking before coding.'
+argument-hint: '[task] [--mode <level>] [--interview <style>] [--amend <path>] [--babysit <pr-url>] [--platform <name>] [--canvas]'
 ---
 
 # /define - Manifest Builder

--- a/claude-plugins/manifest-dev/skills/do/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/do/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: do
 description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Optional --mode efficient|balanced|thorough controls verification intensity (default: thorough). Use when executing a manifest, running a plan, implementing a defined task.'
+argument-hint: '<manifest-path> [--mode <level>] [--scope <ids>]'
 ---
 
 # /do - Manifest Executor

--- a/claude-plugins/manifest-dev/skills/figure-out/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/figure-out/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: figure-out
 description: 'Figure things out together — any topic, problem, or idea. Collaborative thinking partner that investigates before claiming, builds shared truth through evidence not inference. Use when you need to truly understand something before acting, or when figuring it out IS the goal. Triggers: figure out, help me think through, dig deeper, what is really going on, investigate, understand, why does, work through.'
+argument-hint: '[topic] [--with-docs]'
 user-invocable: true
 ---
 

--- a/claude-plugins/manifest-dev/skills/verify/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/verify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: verify
 description: 'Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest. Normally invoked by /do; users invoke directly via /verify --deferred to run user-triggered deferred-auto criteria.'
+argument-hint: '<manifest-path> [--mode <level>] [--scope <ids>] [--deferred]'
 user-invocable: true
 ---
 

--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "c002e3ed70fae4ce579cf4269d517218ba33f5a1",
+  "source_commit": "830ffab67a7280be42b0b848fbcadb7e83f54bd8",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-14T11:32:52Z"
+  "synced_at": "2026-05-15T07:48:07Z"
 }

--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "830ffab67a7280be42b0b848fbcadb7e83f54bd8",
+  "source_commit": "2fab186ad250f0b0a7e871c2e0a92d476ddecdc9",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-15T07:48:07Z"
+  "synced_at": "2026-05-15T07:57:17Z"
 }

--- a/dist/codex/skills/auto/SKILL.md
+++ b/dist/codex/skills/auto/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auto
 description: 'End-to-end autonomous execution: /define → auto-approve → /do in a single command. Infers task from conversation context when no arguments provided. Add --babysit <pr-url> to tend an existing PR through review and CI without manifest-dev setup. Use when you want to define and execute a task without manual intervention during planning. Triggers: auto, autonomous define and do, end-to-end, just build it, tend pr, babysit pr.'
+argument-hint: '[task] [--mode <level>] [--platform <name>] [--babysit <pr-url>]'
 user-invocable: true
 ---
 

--- a/dist/codex/skills/define/SKILL.md
+++ b/dist/codex/skills/define/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: define
 description: 'Manifest builder. Plan work, scope tasks, spec out requirements, break down complex tasks before implementation. Converts needs into Deliverables + Invariants with verification criteria. Use when planning features, debugging complex issues, scoping refactors, or whenever a task needs structured thinking before coding.'
+argument-hint: '[task] [--mode <level>] [--interview <style>] [--amend <path>] [--babysit <pr-url>] [--platform <name>] [--canvas]'
 ---
 
 # /define - Manifest Builder

--- a/dist/codex/skills/do/SKILL.md
+++ b/dist/codex/skills/do/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: do
 description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Optional --mode efficient|balanced|thorough controls verification intensity (default: thorough). Use when executing a manifest, running a plan, implementing a defined task.'
+argument-hint: '<manifest-path> [--mode <level>] [--scope <ids>]'
 ---
 
 # /do - Manifest Executor

--- a/dist/codex/skills/figure-out/SKILL.md
+++ b/dist/codex/skills/figure-out/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: figure-out
 description: 'Figure things out together — any topic, problem, or idea. Collaborative thinking partner that investigates before claiming, builds shared truth through evidence not inference. Use when you need to truly understand something before acting, or when figuring it out IS the goal. Triggers: figure out, help me think through, dig deeper, what is really going on, investigate, understand, why does, work through.'
+argument-hint: '[topic] [--with-docs]'
 user-invocable: true
 ---
 

--- a/dist/codex/skills/verify/SKILL.md
+++ b/dist/codex/skills/verify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: verify
 description: 'Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest. Normally invoked by /do; users invoke directly via /verify --deferred to run user-triggered deferred-auto criteria.'
+argument-hint: '<manifest-path> [--mode <level>] [--scope <ids>] [--deferred]'
 user-invocable: true
 ---
 

--- a/dist/gemini/.sync-meta.json
+++ b/dist/gemini/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "c002e3ed70fae4ce579cf4269d517218ba33f5a1",
+  "source_commit": "830ffab67a7280be42b0b848fbcadb7e83f54bd8",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-14T11:32:52Z"
+  "synced_at": "2026-05-15T07:48:07Z"
 }

--- a/dist/gemini/.sync-meta.json
+++ b/dist/gemini/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "830ffab67a7280be42b0b848fbcadb7e83f54bd8",
+  "source_commit": "2fab186ad250f0b0a7e871c2e0a92d476ddecdc9",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-15T07:48:07Z"
+  "synced_at": "2026-05-15T07:57:17Z"
 }

--- a/dist/gemini/skills/auto/SKILL.md
+++ b/dist/gemini/skills/auto/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auto
 description: 'End-to-end autonomous execution: /define → auto-approve → /do in a single command. Infers task from conversation context when no arguments provided. Add --babysit <pr-url> to tend an existing PR through review and CI without manifest-dev setup. Use when you want to define and execute a task without manual intervention during planning. Triggers: auto, autonomous define and do, end-to-end, just build it, tend pr, babysit pr.'
+argument-hint: '[task] [--mode <level>] [--platform <name>] [--babysit <pr-url>]'
 user-invocable: true
 ---
 

--- a/dist/gemini/skills/define/SKILL.md
+++ b/dist/gemini/skills/define/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: define
 description: 'Manifest builder. Plan work, scope tasks, spec out requirements, break down complex tasks before implementation. Converts needs into Deliverables + Invariants with verification criteria. Use when planning features, debugging complex issues, scoping refactors, or whenever a task needs structured thinking before coding.'
+argument-hint: '[task] [--mode <level>] [--interview <style>] [--amend <path>] [--babysit <pr-url>] [--platform <name>] [--canvas]'
 ---
 
 # /define - Manifest Builder

--- a/dist/gemini/skills/do/SKILL.md
+++ b/dist/gemini/skills/do/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: do
 description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Optional --mode efficient|balanced|thorough controls verification intensity (default: thorough). Use when executing a manifest, running a plan, implementing a defined task.'
+argument-hint: '<manifest-path> [--mode <level>] [--scope <ids>]'
 ---
 
 # /do - Manifest Executor

--- a/dist/gemini/skills/figure-out/SKILL.md
+++ b/dist/gemini/skills/figure-out/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: figure-out
 description: 'Figure things out together — any topic, problem, or idea. Collaborative thinking partner that investigates before claiming, builds shared truth through evidence not inference. Use when you need to truly understand something before acting, or when figuring it out IS the goal. Triggers: figure out, help me think through, dig deeper, what is really going on, investigate, understand, why does, work through.'
+argument-hint: '[topic] [--with-docs]'
 user-invocable: true
 ---
 

--- a/dist/gemini/skills/verify/SKILL.md
+++ b/dist/gemini/skills/verify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: verify
 description: 'Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest. Normally invoked by /do; users invoke directly via /verify --deferred to run user-triggered deferred-auto criteria.'
+argument-hint: '<manifest-path> [--mode <level>] [--scope <ids>] [--deferred]'
 user-invocable: true
 ---
 

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "c002e3ed70fae4ce579cf4269d517218ba33f5a1",
+  "source_commit": "830ffab67a7280be42b0b848fbcadb7e83f54bd8",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-14T11:32:52Z"
+  "synced_at": "2026-05-15T07:48:07Z"
 }

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "830ffab67a7280be42b0b848fbcadb7e83f54bd8",
+  "source_commit": "2fab186ad250f0b0a7e871c2e0a92d476ddecdc9",
   "source_path": "claude-plugins/manifest-dev",
-  "synced_at": "2026-05-15T07:48:07Z"
+  "synced_at": "2026-05-15T07:57:17Z"
 }

--- a/dist/opencode/skills/auto/SKILL.md
+++ b/dist/opencode/skills/auto/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: auto
 description: 'End-to-end autonomous execution: /define → auto-approve → /do in a single command. Infers task from conversation context when no arguments provided. Add --babysit <pr-url> to tend an existing PR through review and CI without manifest-dev setup. Use when you want to define and execute a task without manual intervention during planning. Triggers: auto, autonomous define and do, end-to-end, just build it, tend pr, babysit pr.'
+argument-hint: '[task] [--mode <level>] [--platform <name>] [--babysit <pr-url>]'
 user-invocable: true
 ---
 

--- a/dist/opencode/skills/define/SKILL.md
+++ b/dist/opencode/skills/define/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: define
 description: 'Manifest builder. Plan work, scope tasks, spec out requirements, break down complex tasks before implementation. Converts needs into Deliverables + Invariants with verification criteria. Use when planning features, debugging complex issues, scoping refactors, or whenever a task needs structured thinking before coding.'
+argument-hint: '[task] [--mode <level>] [--interview <style>] [--amend <path>] [--babysit <pr-url>] [--platform <name>] [--canvas]'
 ---
 
 # /define - Manifest Builder

--- a/dist/opencode/skills/do/SKILL.md
+++ b/dist/opencode/skills/do/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: do
 description: 'Manifest executor. Iterates through Deliverables satisfying Acceptance Criteria, then verifies all ACs and Global Invariants pass. Optional --mode efficient|balanced|thorough controls verification intensity (default: thorough). Use when executing a manifest, running a plan, implementing a defined task.'
+argument-hint: '<manifest-path> [--mode <level>] [--scope <ids>]'
 ---
 
 # /do - Manifest Executor

--- a/dist/opencode/skills/figure-out/SKILL.md
+++ b/dist/opencode/skills/figure-out/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: figure-out
 description: 'Figure things out together — any topic, problem, or idea. Collaborative thinking partner that investigates before claiming, builds shared truth through evidence not inference. Use when you need to truly understand something before acting, or when figuring it out IS the goal. Triggers: figure out, help me think through, dig deeper, what is really going on, investigate, understand, why does, work through.'
+argument-hint: '[topic] [--with-docs]'
 user-invocable: true
 ---
 

--- a/dist/opencode/skills/verify/SKILL.md
+++ b/dist/opencode/skills/verify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: verify
 description: 'Spawns parallel verifiers for Global Invariants and Acceptance Criteria from a Manifest. Normally invoked by /do; users invoke directly via /verify --deferred to run user-triggered deferred-auto criteria.'
+argument-hint: '<manifest-path> [--mode <level>] [--scope <ids>] [--deferred]'
 user-invocable: true
 ---
 


### PR DESCRIPTION
## Summary

Adds `argument-hint` to 15 SKILL.md frontmatters across four plugins so the `/` autocomplete UI surfaces expected positional and flag shape per the [Claude Code skills docs](https://code.claude.com/docs/en/skills#frontmatter-reference).

- Strict convention: `<required>` for required positionals, `[optional]` for everything else.
- Flag values shown as placeholders (`<level>`, `<name>`, `<ids>`, `<pr-url>`) rather than enums so hints stay readable in autocomplete; valid values are documented in each skill body and enforced by the skill's argument parser.
- `user-invocable: false` skills skipped (no autocomplete UI to render the hint).
- Patch version bump on each affected plugin (metadata-only change).
- `dist/{gemini,opencode,codex}` SKILL.md mirrors propagated; sync-meta advanced to track this sync.

### Hints by skill

| Skill | Hint |
|---|---|
| `do` | `<manifest-path> [--mode <level>] [--scope <ids>]` |
| `verify` | `<manifest-path> [--mode <level>] [--scope <ids>] [--deferred]` |
| `auto` | `[task] [--mode <level>] [--platform <name>] [--babysit <pr-url>]` |
| `define` | `[task] [--mode <level>] [--interview <style>] [--amend <path>] [--babysit <pr-url>] [--platform <name>] [--canvas]` |
| `figure-out` | `[topic] [--with-docs]` |
| `adr` | `<manifest-path> <output-dir> --session <transcript-path>` |
| `walk-pr` | `[pr-url-or-range] [--canvas]` |
| `prompt-engineering` | `<request>` |
| `handoff` | `[prior-handoff-path]` |
| experimental `auto` / `define` | `[task] [--babysit <pr-url>] [--platform <name>] [--canvas]` |
| experimental `do` / `verify` | `<manifest-path> [--scope <ids>]` |

## Test plan

- [ ] Type `/do `, `/auto `, `/define ` in Claude Code and confirm the hint renders in the autocomplete row
- [ ] YAML parses cleanly for all 15 SKILL.md (verified locally via `yaml.safe_load`)
- [ ] `ruff check claude-plugins/` passes
- [ ] No behavior changes — argument-hint is metadata only

https://claude.ai/code/session_01M6TPj5zNGZ6yo1jybaadBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6TPj5zNGZ6yo1jybaadBD)_