### PR TITLE
adr: align argument-hint with repo convention

### DIFF
--- a/claude-plugins/manifest-dev-tools/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev-tools",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Tools for working with prompts and PRs alongside the manifest workflow. ADR synthesis from session transcripts, collaborative PR walkthroughs, slim-discipline prompt engineering, and cross-boundary context handoff.",
   "keywords": [
     "adr",

--- a/claude-plugins/manifest-dev-tools/skills/adr/SKILL.md
+++ b/claude-plugins/manifest-dev-tools/skills/adr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: adr
 description: 'Synthesize Architecture Decision Records from session transcripts. Extracts decisions via multi-agent pipeline and writes MADR files to a specified directory. Use after completing a /define or /do session to capture architectural decisions as durable records.'
-argument-hint: '<manifest-path> <output-dir> --session <transcript-path>'
+argument-hint: '<manifest-path> <output-dir> <transcript-path>'
 user-invocable: true
 ---
 
@@ -13,18 +13,18 @@ Extract ADR-worthy decisions from a completed manifest workflow session and writ
 
 ## Input
 
-`$ARGUMENTS` = `<manifest-path> <output-dir> --session <transcript-path>`
+`$ARGUMENTS` = `<manifest-path> <output-dir> <transcript-path>`
 
-All three are required:
+All three are required positional arguments:
 - **manifest-path**: Path to the manifest file (primary structured input)
 - **output-dir**: Directory where ADR files will be written (created if needed)
-- **--session \<path\>**: Path to the session transcript JSONL file (primary raw input — `/define` outputs this path at completion)
+- **transcript-path**: Path to the session transcript JSONL file (primary raw input — `/define` outputs this path at completion)
 
 If any required argument is missing: error and halt with usage:
 ```
-Usage: /adr <manifest-path> <output-dir> --session <transcript-path>
+Usage: /adr <manifest-path> <output-dir> <transcript-path>
 
-Example: /adr /tmp/manifest-1234.md docs/adr/ --session ~/.claude/projects/.../session.jsonl
+Example: /adr /tmp/manifest-1234.md docs/adr/ ~/.claude/projects/.../session.jsonl
 ```
 
 ## Pipeline
@@ -63,7 +63,7 @@ A synthesis agent receives all candidates from Phase 1 and:
 
 ## Graceful Degradation
 
-If the session transcript at `--session <path>` is unreadable or missing:
+If the session transcript at `<transcript-path>` is unreadable or missing:
 - **Warn the user**: "Session transcript not found at <path>. Proceeding with manifest only — ADRs will be less detailed (no deliberation context)."
 - **Proceed with manifest**: Skip Phase 1 parallel extraction. Instead, extract decisions directly from the manifest's Approach section (Architecture, Trade-offs, Risk Areas). Apply the same worthiness criteria.
 - **Note in each ADR**: Add to the Source section: "Note: Synthesized from manifest only. Session transcript was unavailable — deliberation context may be incomplete."


### PR DESCRIPTION
## Summary

Fixes the one inconsistency in the repo's argument-hint convention: `adr` had a bare `--session <transcript-path>` (required flag) mixed with `<required>` positionals, breaking the `<required>` / `[optional]` bracket rule by exclusion.

Converted `--session <transcript-path>` → positional `<transcript-path>` so the hint reads cleanly as three required positionals. SKILL.md body updated to match (Input section, usage error, example, graceful-degradation reference).

## Audit context

Audited all 19 `SKILL.md` files. Every user-invocable skill has an `argument-hint`. Non-invocable skills (`done`, `escalate` × main + experimental) correctly omit it. After this PR, the `<>` vs `[]` convention is consistent across the repo.

## Changes

- `claude-plugins/manifest-dev-tools/skills/adr/SKILL.md` — argument-hint + body
- `claude-plugins/manifest-dev-tools/.claude-plugin/plugin.json` — version 0.6.1 → 0.6.2 (patch)

`sync-tools` skill not applicable (scoped to `claude-plugins/manifest-dev/`; this change is in `manifest-dev-tools/`). The `.claude/skills/adr` and `.agents/skills/adr` symlinks auto-reflect the change.

## Test plan

- [ ] Confirm `/adr` invocation form `<manifest-path> <output-dir> <transcript-path>` works end-to-end
- [ ] Verify usage error message renders correctly when args missing

https://claude.ai/code/session_01JuJY6FwHb9zUh6PhBuQVo3

---
_Generated by [Claude Code](https://claude.ai/code/session_01JuJY6FwHb9zUh6PhBuQVo3)_