### PR TITLE
refine(review): apply auto-optimize-prompt convergence pass

### DIFF
--- a/claude-plugins/manifest-dev-tools/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev-tools",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Tools for working with prompts and PRs alongside the manifest workflow. ADR synthesis from session transcripts, collaborative PR walkthroughs, autonomous PR review with per-comment verification, gap-calibrated prompt engineering, and cross-boundary context handoff.",
   "keywords": [
     "adr",

--- a/claude-plugins/manifest-dev-tools/skills/review/SKILL.md
+++ b/claude-plugins/manifest-dev-tools/skills/review/SKILL.md
@@ -5,15 +5,22 @@ argument-hint: '[pr-url] [--manifest <path>] [--bundle <urls>] [--loop]'
 user-invocable: true
 ---
 
-High-signal autonomous PR review posted under your account. The goal is a review you'd be comfortable putting your name on — concrete, honest, no AI tells, no false positives. Precision over coverage.
+High-signal autonomous PR review posted under your account. A review you'd put your name on — precision over coverage.
 
-**Inputs.** `pr-url` from the arg or the current branch's upstream PR; no PR → abort with a reason. `--manifest <path>` opts into grounding against the author's intent; the skill does not auto-discover from any folder convention. `--bundle <urls>` plus PR-description linked-PR parsing (`Depends on #N`, `Stack:`, `Co-changes:`, GitHub PR URLs) provides cross-PR context for coupled changes; cap 5.
+**Inputs.** `pr-url` from the arg or the current branch's upstream PR. `--manifest <path>` opts into grounding against the author's intent; the skill does not auto-discover from any folder convention. `--bundle <urls>` plus PR-description linked-PR parsing (`Depends on #N`, `Stack:`, `Co-changes:`, GitHub PR URLs) provides cross-PR context for coupled changes.
 
-**Reviewer fleet.** Spawn in parallel. Always-on: `change-intent-reviewer`, `code-bugs-reviewer`, `code-design-reviewer`, `code-maintainability-reviewer`, `code-simplicity-reviewer`, `context-file-adherence-reviewer`. Add when the diff fits: `type-safety-reviewer` on typed code; `test-quality-reviewer` and `code-testability-reviewer` on source; `contracts-reviewer` on API surfaces; `operational-readiness-reviewer` on CI/infra/env/migrations/workers/queues/secrets; `docs-reviewer` and `prose-value-reviewer` on prose; `prompt-reviewer` (with `prompt-token-efficiency-verifier`, `prompt-compression-verifier`) on prompts/skills/agents. Forward the manifest to every spawned reviewer when present. Filter findings to Medium+; drop Low.
+**Reviewer fleet.** Spawn in parallel. Always-on: `change-intent-reviewer`, `code-bugs-reviewer`, `code-design-reviewer`, `code-maintainability-reviewer`, `code-simplicity-reviewer`, `context-file-adherence-reviewer`. Add when the diff fits: `type-safety-reviewer` on typed code; `test-quality-reviewer` and `code-testability-reviewer` on source; `contracts-reviewer` on API surfaces; `operational-readiness-reviewer` on CI/infra/env/migrations/workers/queues/secrets; `docs-reviewer` and `prose-value-reviewer` on prose; `prompt-reviewer` (with `prompt-token-efficiency-verifier`, `prompt-compression-verifier`) on prompts/skills/agents. Forward the manifest to every spawned reviewer when present.
 
 **Narrow-lens reviewers.** Reviewer agents never receive PR conversation, linked-PR diffs, or linked-PR conversation. That context flows only to the holistic pass — narrow lens is what keeps each reviewer precise.
 
-**Holistic coherence pass.** Spawn one subagent with the Medium+ findings plus PR history (most recent ~50 review/conversation comments, all unresolved threads regardless of recency, the author's last 5 commit messages on the branch, the PR description), bundle context (≤5 linked PRs: diff, description, top-level conversation — no inline review comments from linked PRs), and the manifest if present. Carry forward any truncation the caller did. The subagent:
+**Holistic coherence pass.** Collect findings from the fleet, drop Low severity, and spawn one subagent with what remains plus:
+
+- PR history: recent review/conversation comments, all unresolved threads, the author's recent commit messages on the branch, the PR description.
+- Bundle context for each linked PR: diff, description, top-level conversation. No inline review comments from linked PRs.
+- The manifest if present.
+- Any truncation the caller did, carried forward.
+
+The subagent:
 
 - **Prunes** findings already raised by another reviewer in the existing PR conversation, already discussed/conceded by the author, contradicting manifest intent, contradicted by the author's prior explanation in a comment / commit message / PR-description note, or piling on an active thread.
 - **Dedupes** across reviewers: merge into one comment when same file + overlapping line range + same underlying concern.
@@ -25,13 +32,15 @@ Returns: comments to post (anchor + voice-compliant body), summary header text i
 
 **Voice.** Each comment is one thought: state the problem, point to evidence inline (file:line, short code excerpt when load-bearing), suggest the fix. Direct, concrete, no softeners.
 
-Never in a posted body, header, or thread reply: severity labels (`[High]`, `⚠️`, `Critical:`); markdown headers or bold-the-takeaway in single-thought comments; emoji of any kind; em-dash rhetorical flourishes ("It's not just X — it's Y" / "not just A, but B"); bulleted recommendation lists for a single suggestion; softeners ("I think", "I recommend", "It seems", "Perhaps consider"); opener boilerplate ("Great PR!", "Nice change, but..."); "at the location above" / "as mentioned" (always name file:line inline); AI disclosure footer.
+Never in a posted body, header, or thread reply: severity labels (`[High]`, `⚠️`, `Critical:`); emoji of any kind; em-dash rhetorical flourishes ("It's not just X — it's Y" / "not just A, but B"); softeners ("I think", "I recommend", "It seems", "Perhaps consider"); opener boilerplate ("Great PR!", "Nice change, but..."); "at the location above" / "as mentioned" (always name file:line inline); AI disclosure footer.
+
+Structural defaults: prose, not bullets, for a single suggestion; no markdown headers or bold-the-takeaway when the comment is one thought. Headers and bullets are fine when a comment genuinely covers multiple distinct thoughts or parallel items.
 
 Target voice: *"Empty input skips the null check — `if (input?.value)` at `parser.ts:42` short-circuits before the parse at `parser.ts:47`, so `{}` reaches `parse()` without the guard. Tighten to `if (input?.value != null)`, or move the `parse()` call inside the existing branch."*
 
-**Posting.** Plan via ExitPlanMode (comments + anchors, what was loaded as context, any truncation, dropped-findings tally). On approval, submit a single GitHub PR review with decision `comment` — all comments batched atomically.
+**Posting.** When the holistic pass returns comments to post, present the plan for user approval (comments + anchors, what was loaded as context, any truncation, dropped-findings tally). On approval, submit a single GitHub PR review with decision `comment` — all comments batched atomically.
 
-**Zero Medium+ findings.** After the coherence pass, ask via AskUserQuestion — `"Looks good to me — post as approval on the PR?"`. Approve → submit decision `approve` with body `Looks good to me.`; decline → exit silent. No PR action otherwise.
+**Zero comments to post.** When the holistic pass returns nothing, skip plan presentation and ask via AskUserQuestion: `"Looks good to me. Post as approval on the PR?"`. Approve → submit decision `approve` with body `Looks good to me.`; decline → take no PR action. No PR action otherwise.
 
 **Gotchas.**
 
@@ -39,6 +48,6 @@ Target voice: *"Empty input skips the null check — `if (input?.value)` at `par
 - Never submit decision `request_changes` — this skill does not algorithmically block merges.
 - Never add an AI disclosure footer to a comment, summary, or reply. There is no flag for one.
 - Never forward PR conversation or bundle context to a reviewer agent. Only the holistic pass may see that context.
-- Never re-raise a finding the holistic pass already pruned in this cycle, and never re-raise (in a later cycle) something already in our own prior posted comments — dedupe via PR history.
+- Never re-raise a finding the holistic pass pruned in this run. When running under `--loop`, never re-raise in a later iteration something already in our own prior posted comments — dedupe via PR history.
 
 **`--loop`.** Load `references/LOOP.md`.

--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "8c21cd7c66f95eeb111cfb39480fc84727c1940e",
+  "source_commit": "44e3f59ec3f33a82ad53ff6338989637d2824a03",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-05-22T12:59:21Z"
+  "synced_at": "2026-05-22T13:47:24Z"
 }

--- a/dist/codex/skills/review/SKILL.md
+++ b/dist/codex/skills/review/SKILL.md
@@ -5,15 +5,22 @@ argument-hint: '[pr-url] [--manifest <path>] [--bundle <urls>] [--loop]'
 user-invocable: true
 ---
 
-High-signal autonomous PR review posted under your account. The goal is a review you'd be comfortable putting your name on — concrete, honest, no AI tells, no false positives. Precision over coverage.
+High-signal autonomous PR review posted under your account. A review you'd put your name on — precision over coverage.
 
-**Inputs.** `pr-url` from the arg or the current branch's upstream PR; no PR → abort with a reason. `--manifest <path>` opts into grounding against the author's intent; the skill does not auto-discover from any folder convention. `--bundle <urls>` plus PR-description linked-PR parsing (`Depends on #N`, `Stack:`, `Co-changes:`, GitHub PR URLs) provides cross-PR context for coupled changes; cap 5.
+**Inputs.** `pr-url` from the arg or the current branch's upstream PR. `--manifest <path>` opts into grounding against the author's intent; the skill does not auto-discover from any folder convention. `--bundle <urls>` plus PR-description linked-PR parsing (`Depends on #N`, `Stack:`, `Co-changes:`, GitHub PR URLs) provides cross-PR context for coupled changes.
 
-**Reviewer fleet.** Spawn in parallel. Always-on: `change-intent-reviewer`, `code-bugs-reviewer`, `code-design-reviewer`, `code-maintainability-reviewer`, `code-simplicity-reviewer`, `context-file-adherence-reviewer`. Add when the diff fits: `type-safety-reviewer` on typed code; `test-quality-reviewer` and `code-testability-reviewer` on source; `contracts-reviewer` on API surfaces; `operational-readiness-reviewer` on CI/infra/env/migrations/workers/queues/secrets; `docs-reviewer` and `prose-value-reviewer` on prose; `prompt-reviewer` (with `prompt-token-efficiency-verifier`, `prompt-compression-verifier`) on prompts/skills/agents. Forward the manifest to every spawned reviewer when present. Filter findings to Medium+; drop Low.
+**Reviewer fleet.** Spawn in parallel. Always-on: `change-intent-reviewer`, `code-bugs-reviewer`, `code-design-reviewer`, `code-maintainability-reviewer`, `code-simplicity-reviewer`, `context-file-adherence-reviewer`. Add when the diff fits: `type-safety-reviewer` on typed code; `test-quality-reviewer` and `code-testability-reviewer` on source; `contracts-reviewer` on API surfaces; `operational-readiness-reviewer` on CI/infra/env/migrations/workers/queues/secrets; `docs-reviewer` and `prose-value-reviewer` on prose; `prompt-reviewer` (with `prompt-token-efficiency-verifier`, `prompt-compression-verifier`) on prompts/skills/agents. Forward the manifest to every spawned reviewer when present.
 
 **Narrow-lens reviewers.** Reviewer agents never receive PR conversation, linked-PR diffs, or linked-PR conversation. That context flows only to the holistic pass — narrow lens is what keeps each reviewer precise.
 
-**Holistic coherence pass.** Spawn one subagent with the Medium+ findings plus PR history (most recent ~50 review/conversation comments, all unresolved threads regardless of recency, the author's last 5 commit messages on the branch, the PR description), bundle context (≤5 linked PRs: diff, description, top-level conversation — no inline review comments from linked PRs), and the manifest if present. Carry forward any truncation the caller did. The subagent:
+**Holistic coherence pass.** Collect findings from the fleet, drop Low severity, and spawn one subagent with what remains plus:
+
+- PR history: recent review/conversation comments, all unresolved threads, the author's recent commit messages on the branch, the PR description.
+- Bundle context for each linked PR: diff, description, top-level conversation. No inline review comments from linked PRs.
+- The manifest if present.
+- Any truncation the caller did, carried forward.
+
+The subagent:
 
 - **Prunes** findings already raised by another reviewer in the existing PR conversation, already discussed/conceded by the author, contradicting manifest intent, contradicted by the author's prior explanation in a comment / commit message / PR-description note, or piling on an active thread.
 - **Dedupes** across reviewers: merge into one comment when same file + overlapping line range + same underlying concern.
@@ -25,13 +32,15 @@ Returns: comments to post (anchor + voice-compliant body), summary header text i
 
 **Voice.** Each comment is one thought: state the problem, point to evidence inline (file:line, short code excerpt when load-bearing), suggest the fix. Direct, concrete, no softeners.
 
-Never in a posted body, header, or thread reply: severity labels (`[High]`, `⚠️`, `Critical:`); markdown headers or bold-the-takeaway in single-thought comments; emoji of any kind; em-dash rhetorical flourishes ("It's not just X — it's Y" / "not just A, but B"); bulleted recommendation lists for a single suggestion; softeners ("I think", "I recommend", "It seems", "Perhaps consider"); opener boilerplate ("Great PR!", "Nice change, but..."); "at the location above" / "as mentioned" (always name file:line inline); AI disclosure footer.
+Never in a posted body, header, or thread reply: severity labels (`[High]`, `⚠️`, `Critical:`); emoji of any kind; em-dash rhetorical flourishes ("It's not just X — it's Y" / "not just A, but B"); softeners ("I think", "I recommend", "It seems", "Perhaps consider"); opener boilerplate ("Great PR!", "Nice change, but..."); "at the location above" / "as mentioned" (always name file:line inline); AI disclosure footer.
+
+Structural defaults: prose, not bullets, for a single suggestion; no markdown headers or bold-the-takeaway when the comment is one thought. Headers and bullets are fine when a comment genuinely covers multiple distinct thoughts or parallel items.
 
 Target voice: *"Empty input skips the null check — `if (input?.value)` at `parser.ts:42` short-circuits before the parse at `parser.ts:47`, so `{}` reaches `parse()` without the guard. Tighten to `if (input?.value != null)`, or move the `parse()` call inside the existing branch."*
 
-**Posting.** Plan via ExitPlanMode (comments + anchors, what was loaded as context, any truncation, dropped-findings tally). On approval, submit a single GitHub PR review with decision `comment` — all comments batched atomically.
+**Posting.** When the holistic pass returns comments to post, present the plan for user approval (comments + anchors, what was loaded as context, any truncation, dropped-findings tally). On approval, submit a single GitHub PR review with decision `comment` — all comments batched atomically.
 
-**Zero Medium+ findings.** After the coherence pass, ask via AskUserQuestion — `"Looks good to me — post as approval on the PR?"`. Approve → submit decision `approve` with body `Looks good to me.`; decline → exit silent. No PR action otherwise.
+**Zero comments to post.** When the holistic pass returns nothing, skip plan presentation and ask via AskUserQuestion: `"Looks good to me. Post as approval on the PR?"`. Approve → submit decision `approve` with body `Looks good to me.`; decline → take no PR action. No PR action otherwise.
 
 **Gotchas.**
 
@@ -39,6 +48,6 @@ Target voice: *"Empty input skips the null check — `if (input?.value)` at `par
 - Never submit decision `request_changes` — this skill does not algorithmically block merges.
 - Never add an AI disclosure footer to a comment, summary, or reply. There is no flag for one.
 - Never forward PR conversation or bundle context to a reviewer agent. Only the holistic pass may see that context.
-- Never re-raise a finding the holistic pass already pruned in this cycle, and never re-raise (in a later cycle) something already in our own prior posted comments — dedupe via PR history.
+- Never re-raise a finding the holistic pass pruned in this run. When running under `--loop`, never re-raise in a later iteration something already in our own prior posted comments — dedupe via PR history.
 
 **`--loop`.** Load `references/LOOP.md`.

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "8c21cd7c66f95eeb111cfb39480fc84727c1940e",
+  "source_commit": "44e3f59ec3f33a82ad53ff6338989637d2824a03",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-05-22T12:59:21Z"
+  "synced_at": "2026-05-22T13:47:24Z"
 }

--- a/dist/opencode/skills/review/SKILL.md
+++ b/dist/opencode/skills/review/SKILL.md
@@ -5,15 +5,22 @@ argument-hint: '[pr-url] [--manifest <path>] [--bundle <urls>] [--loop]'
 user-invocable: true
 ---
 
-High-signal autonomous PR review posted under your account. The goal is a review you'd be comfortable putting your name on — concrete, honest, no AI tells, no false positives. Precision over coverage.
+High-signal autonomous PR review posted under your account. A review you'd put your name on — precision over coverage.
 
-**Inputs.** `pr-url` from the arg or the current branch's upstream PR; no PR → abort with a reason. `--manifest <path>` opts into grounding against the author's intent; the skill does not auto-discover from any folder convention. `--bundle <urls>` plus PR-description linked-PR parsing (`Depends on #N`, `Stack:`, `Co-changes:`, GitHub PR URLs) provides cross-PR context for coupled changes; cap 5.
+**Inputs.** `pr-url` from the arg or the current branch's upstream PR. `--manifest <path>` opts into grounding against the author's intent; the skill does not auto-discover from any folder convention. `--bundle <urls>` plus PR-description linked-PR parsing (`Depends on #N`, `Stack:`, `Co-changes:`, GitHub PR URLs) provides cross-PR context for coupled changes.
 
-**Reviewer fleet.** Spawn in parallel. Always-on: `change-intent-reviewer`, `code-bugs-reviewer`, `code-design-reviewer`, `code-maintainability-reviewer`, `code-simplicity-reviewer`, `context-file-adherence-reviewer`. Add when the diff fits: `type-safety-reviewer` on typed code; `test-quality-reviewer` and `code-testability-reviewer` on source; `contracts-reviewer` on API surfaces; `operational-readiness-reviewer` on CI/infra/env/migrations/workers/queues/secrets; `docs-reviewer` and `prose-value-reviewer` on prose; `prompt-reviewer` (with `prompt-token-efficiency-verifier`, `prompt-compression-verifier`) on prompts/skills/agents. Forward the manifest to every spawned reviewer when present. Filter findings to Medium+; drop Low.
+**Reviewer fleet.** Spawn in parallel. Always-on: `change-intent-reviewer`, `code-bugs-reviewer`, `code-design-reviewer`, `code-maintainability-reviewer`, `code-simplicity-reviewer`, `context-file-adherence-reviewer`. Add when the diff fits: `type-safety-reviewer` on typed code; `test-quality-reviewer` and `code-testability-reviewer` on source; `contracts-reviewer` on API surfaces; `operational-readiness-reviewer` on CI/infra/env/migrations/workers/queues/secrets; `docs-reviewer` and `prose-value-reviewer` on prose; `prompt-reviewer` (with `prompt-token-efficiency-verifier`, `prompt-compression-verifier`) on prompts/skills/agents. Forward the manifest to every spawned reviewer when present.
 
 **Narrow-lens reviewers.** Reviewer agents never receive PR conversation, linked-PR diffs, or linked-PR conversation. That context flows only to the holistic pass — narrow lens is what keeps each reviewer precise.
 
-**Holistic coherence pass.** Spawn one subagent with the Medium+ findings plus PR history (most recent ~50 review/conversation comments, all unresolved threads regardless of recency, the author's last 5 commit messages on the branch, the PR description), bundle context (≤5 linked PRs: diff, description, top-level conversation — no inline review comments from linked PRs), and the manifest if present. Carry forward any truncation the caller did. The subagent:
+**Holistic coherence pass.** Collect findings from the fleet, drop Low severity, and spawn one subagent with what remains plus:
+
+- PR history: recent review/conversation comments, all unresolved threads, the author's recent commit messages on the branch, the PR description.
+- Bundle context for each linked PR: diff, description, top-level conversation. No inline review comments from linked PRs.
+- The manifest if present.
+- Any truncation the caller did, carried forward.
+
+The subagent:
 
 - **Prunes** findings already raised by another reviewer in the existing PR conversation, already discussed/conceded by the author, contradicting manifest intent, contradicted by the author's prior explanation in a comment / commit message / PR-description note, or piling on an active thread.
 - **Dedupes** across reviewers: merge into one comment when same file + overlapping line range + same underlying concern.
@@ -25,13 +32,15 @@ Returns: comments to post (anchor + voice-compliant body), summary header text i
 
 **Voice.** Each comment is one thought: state the problem, point to evidence inline (file:line, short code excerpt when load-bearing), suggest the fix. Direct, concrete, no softeners.
 
-Never in a posted body, header, or thread reply: severity labels (`[High]`, `⚠️`, `Critical:`); markdown headers or bold-the-takeaway in single-thought comments; emoji of any kind; em-dash rhetorical flourishes ("It's not just X — it's Y" / "not just A, but B"); bulleted recommendation lists for a single suggestion; softeners ("I think", "I recommend", "It seems", "Perhaps consider"); opener boilerplate ("Great PR!", "Nice change, but..."); "at the location above" / "as mentioned" (always name file:line inline); AI disclosure footer.
+Never in a posted body, header, or thread reply: severity labels (`[High]`, `⚠️`, `Critical:`); emoji of any kind; em-dash rhetorical flourishes ("It's not just X — it's Y" / "not just A, but B"); softeners ("I think", "I recommend", "It seems", "Perhaps consider"); opener boilerplate ("Great PR!", "Nice change, but..."); "at the location above" / "as mentioned" (always name file:line inline); AI disclosure footer.
+
+Structural defaults: prose, not bullets, for a single suggestion; no markdown headers or bold-the-takeaway when the comment is one thought. Headers and bullets are fine when a comment genuinely covers multiple distinct thoughts or parallel items.
 
 Target voice: *"Empty input skips the null check — `if (input?.value)` at `parser.ts:42` short-circuits before the parse at `parser.ts:47`, so `{}` reaches `parse()` without the guard. Tighten to `if (input?.value != null)`, or move the `parse()` call inside the existing branch."*
 
-**Posting.** Plan via ExitPlanMode (comments + anchors, what was loaded as context, any truncation, dropped-findings tally). On approval, submit a single GitHub PR review with decision `comment` — all comments batched atomically.
+**Posting.** When the holistic pass returns comments to post, present the plan for user approval (comments + anchors, what was loaded as context, any truncation, dropped-findings tally). On approval, submit a single GitHub PR review with decision `comment` — all comments batched atomically.
 
-**Zero Medium+ findings.** After the coherence pass, ask via AskUserQuestion — `"Looks good to me — post as approval on the PR?"`. Approve → submit decision `approve` with body `Looks good to me.`; decline → exit silent. No PR action otherwise.
+**Zero comments to post.** When the holistic pass returns nothing, skip plan presentation and ask via AskUserQuestion: `"Looks good to me. Post as approval on the PR?"`. Approve → submit decision `approve` with body `Looks good to me.`; decline → take no PR action. No PR action otherwise.
 
 **Gotchas.**
 
@@ -39,6 +48,6 @@ Target voice: *"Empty input skips the null check — `if (input?.value)` at `par
 - Never submit decision `request_changes` — this skill does not algorithmically block merges.
 - Never add an AI disclosure footer to a comment, summary, or reply. There is no flag for one.
 - Never forward PR conversation or bundle context to a reviewer agent. Only the holistic pass may see that context.
-- Never re-raise a finding the holistic pass already pruned in this cycle, and never re-raise (in a later cycle) something already in our own prior posted comments — dedupe via PR history.
+- Never re-raise a finding the holistic pass pruned in this run. When running under `--loop`, never re-raise in a later iteration something already in our own prior posted comments — dedupe via PR history.
 
 **`--loop`.** Load `references/LOOP.md`.


### PR DESCRIPTION
## Summary

Ran `/auto-optimize-prompt` to convergence (3 iterations) on the `review` skill in `manifest-dev-tools`. Each pass invoked `prompt-reviewer`; user-resolved items came back to clarify intent; auto-fixable items applied directly.

## Changes to `claude-plugins/manifest-dev-tools/skills/review/SKILL.md`

User-resolved ambiguities:
- **Filter ownership**: orchestrator drops Low severity between fleet and holistic pass (was ambiguous between reviewers and orchestrator).
- **Arbitrary caps removed**: dropped `--bundle` cap of 5 and `~50` recent-comments heuristic. Trust the model's context judgment.
- **Capability-neutral planning**: replaced `ExitPlanMode` reference with "present the plan for user approval" so the skill doesn't depend on a tool that may not be in every invocation context.
- **Posting vs zero-findings flow**: disambiguated. When holistic returns nothing, the lgtm prompt replaces plan presentation entirely.
- **"exit silent"**: replaced with concrete "take no PR action".

Auto-fixable polish:
- Split structural defaults (no headers/bullets for single-thought comments) out of the absolute-ban list into a decision rule — judgment calls shouldn't masquerade as absolutes.
- Removed em-dash from user-facing AskUserQuestion string for internal consistency.
- Defined "cycle" terminology in terms of `--loop` iterations.
- Reformatted holistic-pass inputs as a list (was one long sentence).
- Trimmed opening framing prose that restated the description.
- Removed `no PR → abort with a reason` boilerplate (model default behavior).

Bumped `manifest-dev-tools` to `0.11.1`.

## Test plan

- [ ] Manual: run `/review` against a small PR, confirm holistic-pass behavior is unchanged
- [ ] Manual: run `/review` against a PR with no Medium+ findings, confirm lgtm prompt fires without plan presentation first
- [ ] Verify symlink at `.claude/skills/review/SKILL.md` resolves to the updated file

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfbGxQwo23LnqoqMjcRhXc)_