### PR TITLE
review-pr: harness-portable wait + universal dedupe

### DIFF
--- a/claude-plugins/manifest-dev-tools/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev-tools",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Tools for working with prompts and PRs alongside the manifest workflow. ADR synthesis from session transcripts, collaborative PR walkthroughs, autonomous PR review with per-comment verification, gap-calibrated prompt engineering, and cross-boundary context handoff.",
   "keywords": [
     "adr",

--- a/claude-plugins/manifest-dev-tools/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev-tools",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Tools for working with prompts and PRs alongside the manifest workflow. ADR synthesis from session transcripts, collaborative PR walkthroughs, autonomous PR review with per-comment verification, gap-calibrated prompt engineering, and cross-boundary context handoff.",
   "keywords": [
     "adr",

--- a/claude-plugins/manifest-dev-tools/agents/prompt-reviewer.md
+++ b/claude-plugins/manifest-dev-tools/agents/prompt-reviewer.md
@@ -27,7 +27,7 @@ Report format:
 
 **Severity**:
 - **High** — the prompt actively misbehaves or breaks a contract. Examples: contradiction between two rules that can't both hold; missing the goal entirely; absolute used on a judgment call that observably misfires; the agent declares a need for a tool it doesn't have, or omits a tool it actually uses.
-- **Medium** — the prompt works but drifts toward known failure modes. Examples: vague directive that produces inconsistent behavior across runs; restated model default adding noise the model has to wade through; missing a gap-closer that the discipline says should be there; arbitrary numbers without a rubric.
+- **Medium** — the prompt works but drifts toward known failure modes. Examples: vague directive that produces inconsistent behavior across runs; restated model default adding noise the model has to wade through; missing a gap-closer that the discipline says should be there; arbitrary numbers without a rubric; boundary failures — naming a harness-bound primitive, a rule-scope qualifier that silently excludes valid cases, mechanism stated as the only path, or one principle split across multiple places.
 - **Low** — minor friction with no functional impact. Examples: duplication that doesn't change behavior; awkward phrasing where the meaning is still unambiguous; stylistic-only cleanup.
 
 **Tag** (parsed as control flow by `/auto-optimize-prompt` — do not rename or repurpose):

--- a/claude-plugins/manifest-dev-tools/skills/prompt-engineering/SKILL.md
+++ b/claude-plugins/manifest-dev-tools/skills/prompt-engineering/SKILL.md
@@ -5,9 +5,9 @@ argument-hint: '<request>'
 user-invocable: true
 ---
 
-A prompt earns its place where natural model behavior misses what's needed. State the goal and the expected outcome; trust the model for everything else. Lines belong only when they close a real gap — observed gotchas, non-obvious behavior, knowledge the model doesn't have, or edge cases it gets wrong by default. Length follows the gap, not a number. On update, calibrate both directions: add what closes the new gap, and prune what no longer earns its place. A prompt stays in balance over time; it doesn't accrete.
+A prompt earns its place where natural model behavior misses what's needed. State the goal and the expected outcome; trust the model for everything else. Lines belong only when they close a real gap — observed gotchas, non-obvious behavior, knowledge the model doesn't have, or edge cases it gets wrong by default. Each line must also hold at the edges of where the prompt runs: name principles, not harness-bound primitives; scope rules to the principle's natural reach, not narrower; unify split restatements of the same rule. Length follows the gap, not a number. On update, calibrate both directions: add what closes the new gap, and prune what no longer earns its place. A prompt stays in balance over time; it doesn't accrete.
 
-Branch on intent. *Creating*: discover the goal, audience, and the specific gap; draft the minimum that closes it. *Updating*: find each existing line's gap before changing anything around it — patches that replace often beat patches that add. *Reviewing*: of each line ask *"would the model do this without it?"* — flag the no's. *Diagnosing a failing prompt*: see `references/metaprompting.md` — find the line driving the symptom before patching.
+Branch on intent. *Creating*: discover the goal, audience, and the specific gap; draft the minimum that closes it. *Updating*: find each existing line's gap before changing anything around it — patches that replace often beat patches that add. *Reviewing*: of each line ask both *"would the model do this without it?"* and *"does this hold at the edges?"* — flag the no's. *Diagnosing a failing prompt*: see `references/metaprompting.md` — find the line driving the symptom before patching.
 
 References load on demand. Load only the ones whose trigger fires:
 

--- a/claude-plugins/manifest-dev-tools/skills/prompt-engineering/references/review.md
+++ b/claude-plugins/manifest-dev-tools/skills/prompt-engineering/references/review.md
@@ -10,6 +10,21 @@ Update is the same audit applied to a specific change. Find the new gap; close i
 
 Apply it to every line. The line earns its place if and only if the answer is *no, the model wouldn't reach this on its own*.
 
+## The boundary check
+
+> *Does this line still hold at the edges of where this prompt will run?*
+
+A line can earn its place locally and still be brittle. The earn-your-place question is point-wise; the boundary check tests each line against the conditions it'll actually meet. Run both — they catch different failures.
+
+| Edge | Symptom | Fix |
+|------|---------|-----|
+| **Harness** | Names a primitive bound to one harness (`AskUserQuestion`, `subscribe_pr_activity`, `ExitPlanMode`, an MCP tool by name) | State the principle; let the model pick whatever tool the harness exposes |
+| **Scope qualifier** | Rule has a qualifier (`by another reviewer`, `under --loop only`, `in mode X`) that excludes cases the principle should also cover | Drop the qualifier or broaden it to match the principle's reach |
+| **Mechanism-as-prescription** | Specific numbers or a fixed sequence stated as the only path (`15→30→60→120 min`, `Max 3 iterations`, a hardcoded tool chain) | State the principle; numbers and sequences become defaults, not the rule |
+| **Split of same rule** | Same principle restated in multiple places with slight variations (one general, one mode-specific) | Unify into one rule, delete the splits |
+
+A line that passes earn-your-place but fails boundary is fragile — works today, breaks the first time the prompt runs in a different harness, mode, or scope. Boundary fixes usually *reword* the line rather than delete it.
+
 ## Anti-patterns
 
 | Anti-pattern | Example | Fix |

--- a/claude-plugins/manifest-dev-tools/skills/review-pr/SKILL.md
+++ b/claude-plugins/manifest-dev-tools/skills/review-pr/SKILL.md
@@ -9,21 +9,21 @@ High-signal autonomous PR review posted under your account. A review you'd put y
 
 **Inputs.** `pr-url` from the arg or the current branch's upstream PR. `--manifest <path>` opts into grounding against the author's intent; the skill does not auto-discover from any folder convention. `--bundle <urls>` plus PR-description linked-PR parsing (`Depends on #N`, `Stack:`, `Co-changes:`, GitHub PR URLs) provides cross-PR context for coupled changes.
 
-**Reviewer fleet.** Spawn in parallel. Always-on: `change-intent-reviewer`, `code-bugs-reviewer`, `code-design-reviewer`, `code-maintainability-reviewer`, `code-simplicity-reviewer`, `context-file-adherence-reviewer`. Add when the diff fits: `type-safety-reviewer` on typed code; `test-quality-reviewer` and `code-testability-reviewer` on source; `contracts-reviewer` on API surfaces; `operational-readiness-reviewer` on CI/infra/env/migrations/workers/queues/secrets; `docs-reviewer` and `prose-value-reviewer` on prose; `prompt-reviewer` (with `prompt-token-efficiency-verifier`, `prompt-compression-verifier`) on prompts/skills/agents. Forward the manifest to every spawned reviewer when present.
+**Reviewer fleet.** Always-on: `change-intent-reviewer`, `code-bugs-reviewer`, `code-design-reviewer`, `code-maintainability-reviewer`, `code-simplicity-reviewer`, `context-file-adherence-reviewer`. Add when the diff fits: `type-safety-reviewer` on typed code; `test-quality-reviewer` and `code-testability-reviewer` on source; `contracts-reviewer` on API surfaces; `operational-readiness-reviewer` on CI/infra/env/migrations/workers/queues/secrets; `docs-reviewer` and `prose-value-reviewer` on prose; `prompt-reviewer` (with `prompt-token-efficiency-verifier`, `prompt-compression-verifier`) on prompts/skills/agents. Forward the manifest to every spawned reviewer when present.
 
 **Narrow-lens reviewers.** Reviewer agents never receive PR conversation, linked-PR diffs, or linked-PR conversation. That context flows only to the holistic pass — narrow lens is what keeps each reviewer precise.
 
 **Holistic coherence pass.** Collect findings from the fleet, drop Low severity, and spawn one subagent with what remains plus:
 
-- PR history: recent review/conversation comments, all unresolved threads, the author's recent commit messages on the branch, the PR description.
+- PR history: all comments and threads on the PR (including our own from any prior review pass), the author's recent commit messages on the branch, the PR description.
 - Bundle context for each linked PR: diff, description, top-level conversation. No inline review comments from linked PRs.
 - The manifest if present.
 - Any truncation the caller did, carried forward.
 
 The subagent:
 
-- **Prunes** findings already raised by another reviewer in the existing PR conversation, already discussed/conceded by the author, contradicting manifest intent, contradicted by the author's prior explanation in a comment / commit message / PR-description note, or piling on an active thread.
-- **Dedupes** across reviewers: merge into one comment when same file + overlapping line range + same underlying concern.
+- **Prunes** any finding already covered on the PR: any prior comment (ours from a previous run, or another reviewer's), any concession or rebuttal on an existing thread, anything contradicted by the manifest, a commit message, or the PR description, or piling on an active thread.
+- **Dedupes** across reviewers: merge near-duplicates into one comment when they raise the same underlying concern.
 - **Anchors** each surviving finding to exactly one of inline file:line (default), file-level (whole-file concern), or PR-level (cross-cutting, no specific anchor).
 - **Rewrites** every comment body and any drafted reply in the voice profile below.
 - **Omits a summary header by default** — adds one only when there's a real overall take the per-comment list misses (one short sentence, voice-compliant, no boilerplate).
@@ -40,7 +40,7 @@ Target voice: *"Empty input skips the null check — `if (input?.value)` at `par
 
 **Posting.** When the holistic pass returns comments to post, present the plan for user approval (comments + anchors, what was loaded as context, any truncation, dropped-findings tally). On approval, submit a single GitHub PR review with decision `comment` — all comments batched atomically.
 
-**Zero comments to post.** When the holistic pass returns nothing, skip plan presentation and ask via AskUserQuestion: `"Looks good to me. Post as approval on the PR?"`. Approve → submit decision `approve` with body `Looks good to me.`; decline → take no PR action. No PR action otherwise.
+**Zero comments to post.** When the holistic pass returns nothing, skip plan presentation and ask the user: `"Looks good to me. Post as approval on the PR?"`. Approve → submit decision `approve` with body `Looks good to me.`; decline → take no PR action. No PR action otherwise.
 
 **Gotchas.**
 
@@ -48,6 +48,6 @@ Target voice: *"Empty input skips the null check — `if (input?.value)` at `par
 - Never submit decision `request_changes` — this skill does not algorithmically block merges.
 - Never add an AI disclosure footer to a comment, summary, or reply. There is no flag for one.
 - Never forward PR conversation or bundle context to a reviewer agent. Only the holistic pass may see that context.
-- Never re-raise a finding the holistic pass pruned in this run. When running under `--loop`, never re-raise in a later iteration something already in our own prior posted comments — dedupe via PR history.
+- Never re-raise a finding the holistic pass pruned in this run.
 
 **`--loop`.** Load `references/LOOP.md`.

--- a/claude-plugins/manifest-dev-tools/skills/review-pr/references/LOOP.md
+++ b/claude-plugins/manifest-dev-tools/skills/review-pr/references/LOOP.md
@@ -4,7 +4,7 @@ Bypass the approval gate entirely — initial post and every rerun run autonomou
 
 ## Initial post + watch
 
-Run the default pipeline (resolve inputs → fleet → holistic pass → submit `comment` review), but skip the ExitPlanMode approval. After posting, `subscribe_pr_activity` for this PR and enter the wait phase. Wait backoff per round: **15 → 30 → 60 → 120 minutes**. PR activity events resolve the wait early (a commit pushed, a thread reply received). At the end of each round, advance the verifier.
+Run the default pipeline (resolve inputs → fleet → holistic pass → submit `comment` review), but skip the approval gate. After posting, wait between checks with escalating intervals (~15 min → 2 hours). If the harness delivers PR activity events that wake the session, subscribe so a commit push or thread reply resolves the wait early; otherwise blocking `sleep`. At the end of each round, advance the verifier.
 
 ## Per-comment verifier (each wake)
 
@@ -20,36 +20,27 @@ For every comment we posted that is still pending (not yet judged resolved), spa
 
 The subagent returns exactly one disposition:
 
-- **`addressed-by-fix`** — A commit after our review modified the line range AND the modification removes the concrete failure mode our comment raised. Verify against the post-fix code: trace the original problem; check that the current code no longer exhibits it. Lines touched without addressing the underlying concern do NOT qualify.
-- **`addressed-by-valid-reply`** — The author replied (on this or another thread) with an argument that fairly defeats our concern: correct factual context we missed, a deliberate design choice with valid rationale, an out-of-scope acknowledgment to accept, or the concern being already addressed by code elsewhere we hadn't seen. "Valid" means a fair-minded human reviewer would concede. Tone is irrelevant.
-- **`needs-our-pushback`** — Neither of the above. The author hasn't addressed the concern via commit and either hasn't replied or has replied with an argument that doesn't defeat the concern (dismissal without rebuttal, restating the code, agreeing-to-disagree without engaging substance).
+- **`addressed-by-fix`** — A commit after our review modified the line range AND the modification removes the concrete failure mode our comment raised. Verify against the post-fix code: trace the original problem; check that the current code no longer exhibits it. Lines touched without addressing the underlying concern do NOT qualify. **Mark the comment resolved.**
+- **`addressed-by-valid-reply`** — The author replied (on this or another thread) with an argument that fairly defeats our concern: correct factual context we missed, a deliberate design choice with valid rationale, an out-of-scope acknowledgment to accept, or the concern being already addressed by code elsewhere we hadn't seen. "Valid" means a fair-minded human reviewer would concede. Tone is irrelevant. **Mark the comment resolved.**
+- **`needs-our-pushback`** — Neither of the above. The author hasn't addressed the concern via commit and either hasn't replied or has replied with an argument that doesn't defeat the concern (dismissal without rebuttal, restating the code, agreeing-to-disagree without engaging substance). **If `drop: false`, post the drafted reply on the existing thread; if `drop: true`, silently drop the thread.**
 
 ## Pushback drafting and the one-round rule
 
-If pushback history says we have already posted a pushback reply on this thread, the verifier returns with `drop: true` and the caller silently drops the thread. **One round of pushback per thread, total** — no comment wars.
+If pushback history says we have already posted a pushback reply on this thread, the verifier returns with `drop: true`. **One round of pushback per thread, total** — no comment wars.
 
 Otherwise the verifier drafts a short thread-reply body in the SKILL.md voice profile. Stay on the specific point under contention; don't restate the original concern in full; address whatever the author actually said (or didn't say). The reply is posted as a thread reply on the existing comment, **not** a new review.
 
-## Acting on dispositions
-
-For each pending comment:
-
-- `addressed-by-fix` or `addressed-by-valid-reply` → mark resolved.
-- `needs-our-pushback` with `drop: false` → post the drafted reply on the existing thread.
-- `needs-our-pushback` with `drop: true` → silently drop the thread.
-
-If any comments remain pending after acting on this wake's dispositions, advance the wait backoff to the next tier and wait again.
+After acting on this wake's dispositions, if any comments remain pending, advance to the next wait interval and wait again.
 
 ## Success path: rerun on full resolution
 
-When every comment is resolved (by fix, valid reply, or one-round pushback that ended in a drop), rerun the full pipeline (default mode in SKILL.md) on the new PR state — the holistic pass dedupes the new findings against our own prior posted comments via PR history, so the same concern won't be re-raised. Reset the wait backoff to 15 min for the new cycle.
+When every comment is resolved (by fix, valid reply, or one-round pushback that ended in a drop), rerun the full pipeline (default mode in SKILL.md) on the new PR state. Reset to the shortest wait interval for the new cycle.
 
 ## Termini (first to fire wins)
 
-1. Clean rerun + zero new Medium+ findings + user approves the lgtm prompt → submit `approve` review with body `Looks good to me.`, exit.
-2. Clean rerun + zero new findings + user declines the lgtm prompt → exit silent.
-3. **3 cycles total** (initial post + 2 reruns).
-4. **24h wall-clock backstop** from initial post.
-5. The 4-tier wait cap (120 min) elapses with comments still pending.
+1. Clean rerun returns no surviving findings → run the SKILL.md lgtm prompt. Approve → submit `approve` review with body `Looks good to me.`, exit. Decline → exit silent.
+2. **3 cycles total** (initial post + 2 reruns).
+3. **24h wall-clock backstop** from initial post.
+4. The longest wait interval (~2h) elapses with comments still pending.
 
-On (3), (4), or (5): silent unsubscribe from PR activity + chat summary to the user (which cycles completed, which comments remain unaddressed, which dispositions were applied). **Never post a bump comment on the PR** — the cap is "I'm done watching," not "I escalate."
+On (2), (3), or (4): silent unsubscribe from PR activity if subscribed + chat summary to the user (which cycles completed, which comments remain unaddressed, which dispositions were applied). **Never post a bump comment on the PR** — the cap is "I'm done watching," not "I escalate."

--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "321a692faad091d4874cf808bdd319863d9efdaa",
+  "source_commit": "0af2caec24178f3b595f11cd2937bac725a77677",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-05-24T14:03:24Z"
+  "synced_at": "2026-05-24T14:18:21Z"
 }

--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "29ef57e6f3a0cff7ad7a0ec5caa9e535c5ddefd9",
+  "source_commit": "321a692faad091d4874cf808bdd319863d9efdaa",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-05-24T06:58:16Z"
+  "synced_at": "2026-05-24T14:03:24Z"
 }

--- a/dist/codex/agents/prompt-reviewer.toml
+++ b/dist/codex/agents/prompt-reviewer.toml
@@ -24,7 +24,7 @@ Report format:
 
 **Severity**:
 - **High** — the prompt actively misbehaves or breaks a contract. Examples: contradiction between two rules that can't both hold; missing the goal entirely; absolute used on a judgment call that observably misfires; the agent declares a need for a tool it doesn't have, or omits a tool it actually uses.
-- **Medium** — the prompt works but drifts toward known failure modes. Examples: vague directive that produces inconsistent behavior across runs; restated model default adding noise the model has to wade through; missing a gap-closer that the discipline says should be there; arbitrary numbers without a rubric.
+- **Medium** — the prompt works but drifts toward known failure modes. Examples: vague directive that produces inconsistent behavior across runs; restated model default adding noise the model has to wade through; missing a gap-closer that the discipline says should be there; arbitrary numbers without a rubric; boundary failures — naming a harness-bound primitive, a rule-scope qualifier that silently excludes valid cases, mechanism stated as the only path, or one principle split across multiple places.
 - **Low** — minor friction with no functional impact. Examples: duplication that doesn't change behavior; awkward phrasing where the meaning is still unambiguous; stylistic-only cleanup.
 
 **Tag** (parsed as control flow by `/auto-optimize-prompt` — do not rename or repurpose):

--- a/dist/codex/skills/prompt-engineering/SKILL.md
+++ b/dist/codex/skills/prompt-engineering/SKILL.md
@@ -5,9 +5,9 @@ argument-hint: '<request>'
 user-invocable: true
 ---
 
-A prompt earns its place where natural model behavior misses what's needed. State the goal and the expected outcome; trust the model for everything else. Lines belong only when they close a real gap — observed gotchas, non-obvious behavior, knowledge the model doesn't have, or edge cases it gets wrong by default. Length follows the gap, not a number. On update, calibrate both directions: add what closes the new gap, and prune what no longer earns its place. A prompt stays in balance over time; it doesn't accrete.
+A prompt earns its place where natural model behavior misses what's needed. State the goal and the expected outcome; trust the model for everything else. Lines belong only when they close a real gap — observed gotchas, non-obvious behavior, knowledge the model doesn't have, or edge cases it gets wrong by default. Each line must also hold at the edges of where the prompt runs: name principles, not harness-bound primitives; scope rules to the principle's natural reach, not narrower; unify split restatements of the same rule. Length follows the gap, not a number. On update, calibrate both directions: add what closes the new gap, and prune what no longer earns its place. A prompt stays in balance over time; it doesn't accrete.
 
-Branch on intent. *Creating*: discover the goal, audience, and the specific gap; draft the minimum that closes it. *Updating*: find each existing line's gap before changing anything around it — patches that replace often beat patches that add. *Reviewing*: of each line ask *"would the model do this without it?"* — flag the no's. *Diagnosing a failing prompt*: see `references/metaprompting.md` — find the line driving the symptom before patching.
+Branch on intent. *Creating*: discover the goal, audience, and the specific gap; draft the minimum that closes it. *Updating*: find each existing line's gap before changing anything around it — patches that replace often beat patches that add. *Reviewing*: of each line ask both *"would the model do this without it?"* and *"does this hold at the edges?"* — flag the no's. *Diagnosing a failing prompt*: see `references/metaprompting.md` — find the line driving the symptom before patching.
 
 References load on demand. Load only the ones whose trigger fires:
 

--- a/dist/codex/skills/prompt-engineering/references/review.md
+++ b/dist/codex/skills/prompt-engineering/references/review.md
@@ -10,6 +10,21 @@ Update is the same audit applied to a specific change. Find the new gap; close i
 
 Apply it to every line. The line earns its place if and only if the answer is *no, the model wouldn't reach this on its own*.
 
+## The boundary check
+
+> *Does this line still hold at the edges of where this prompt will run?*
+
+A line can earn its place locally and still be brittle. The earn-your-place question is point-wise; the boundary check tests each line against the conditions it'll actually meet. Run both — they catch different failures.
+
+| Edge | Symptom | Fix |
+|------|---------|-----|
+| **Harness** | Names a primitive bound to one harness (`AskUserQuestion`, `subscribe_pr_activity`, `ExitPlanMode`, an MCP tool by name) | State the principle; let the model pick whatever tool the harness exposes |
+| **Scope qualifier** | Rule has a qualifier (`by another reviewer`, `under --loop only`, `in mode X`) that excludes cases the principle should also cover | Drop the qualifier or broaden it to match the principle's reach |
+| **Mechanism-as-prescription** | Specific numbers or a fixed sequence stated as the only path (`15→30→60→120 min`, `Max 3 iterations`, a hardcoded tool chain) | State the principle; numbers and sequences become defaults, not the rule |
+| **Split of same rule** | Same principle restated in multiple places with slight variations (one general, one mode-specific) | Unify into one rule, delete the splits |
+
+A line that passes earn-your-place but fails boundary is fragile — works today, breaks the first time the prompt runs in a different harness, mode, or scope. Boundary fixes usually *reword* the line rather than delete it.
+
 ## Anti-patterns
 
 | Anti-pattern | Example | Fix |

--- a/dist/codex/skills/review-pr/SKILL.md
+++ b/dist/codex/skills/review-pr/SKILL.md
@@ -9,21 +9,21 @@ High-signal autonomous PR review posted under your account. A review you'd put y
 
 **Inputs.** `pr-url` from the arg or the current branch's upstream PR. `--manifest <path>` opts into grounding against the author's intent; the skill does not auto-discover from any folder convention. `--bundle <urls>` plus PR-description linked-PR parsing (`Depends on #N`, `Stack:`, `Co-changes:`, GitHub PR URLs) provides cross-PR context for coupled changes.
 
-**Reviewer fleet.** Spawn in parallel. Always-on: `change-intent-reviewer`, `code-bugs-reviewer`, `code-design-reviewer`, `code-maintainability-reviewer`, `code-simplicity-reviewer`, `context-file-adherence-reviewer`. Add when the diff fits: `type-safety-reviewer` on typed code; `test-quality-reviewer` and `code-testability-reviewer` on source; `contracts-reviewer` on API surfaces; `operational-readiness-reviewer` on CI/infra/env/migrations/workers/queues/secrets; `docs-reviewer` and `prose-value-reviewer` on prose; `prompt-reviewer` (with `prompt-token-efficiency-verifier`, `prompt-compression-verifier`) on prompts/skills/agents. Forward the manifest to every spawned reviewer when present.
+**Reviewer fleet.** Always-on: `change-intent-reviewer`, `code-bugs-reviewer`, `code-design-reviewer`, `code-maintainability-reviewer`, `code-simplicity-reviewer`, `context-file-adherence-reviewer`. Add when the diff fits: `type-safety-reviewer` on typed code; `test-quality-reviewer` and `code-testability-reviewer` on source; `contracts-reviewer` on API surfaces; `operational-readiness-reviewer` on CI/infra/env/migrations/workers/queues/secrets; `docs-reviewer` and `prose-value-reviewer` on prose; `prompt-reviewer` (with `prompt-token-efficiency-verifier`, `prompt-compression-verifier`) on prompts/skills/agents. Forward the manifest to every spawned reviewer when present.
 
 **Narrow-lens reviewers.** Reviewer agents never receive PR conversation, linked-PR diffs, or linked-PR conversation. That context flows only to the holistic pass — narrow lens is what keeps each reviewer precise.
 
 **Holistic coherence pass.** Collect findings from the fleet, drop Low severity, and spawn one subagent with what remains plus:
 
-- PR history: recent review/conversation comments, all unresolved threads, the author's recent commit messages on the branch, the PR description.
+- PR history: all comments and threads on the PR (including our own from any prior review pass), the author's recent commit messages on the branch, the PR description.
 - Bundle context for each linked PR: diff, description, top-level conversation. No inline review comments from linked PRs.
 - The manifest if present.
 - Any truncation the caller did, carried forward.
 
 The subagent:
 
-- **Prunes** findings already raised by another reviewer in the existing PR conversation, already discussed/conceded by the author, contradicting manifest intent, contradicted by the author's prior explanation in a comment / commit message / PR-description note, or piling on an active thread.
-- **Dedupes** across reviewers: merge into one comment when same file + overlapping line range + same underlying concern.
+- **Prunes** any finding already covered on the PR: any prior comment (ours from a previous run, or another reviewer's), any concession or rebuttal on an existing thread, anything contradicted by the manifest, a commit message, or the PR description, or piling on an active thread.
+- **Dedupes** across reviewers: merge near-duplicates into one comment when they raise the same underlying concern.
 - **Anchors** each surviving finding to exactly one of inline file:line (default), file-level (whole-file concern), or PR-level (cross-cutting, no specific anchor).
 - **Rewrites** every comment body and any drafted reply in the voice profile below.
 - **Omits a summary header by default** — adds one only when there's a real overall take the per-comment list misses (one short sentence, voice-compliant, no boilerplate).
@@ -40,7 +40,7 @@ Target voice: *"Empty input skips the null check — `if (input?.value)` at `par
 
 **Posting.** When the holistic pass returns comments to post, present the plan for user approval (comments + anchors, what was loaded as context, any truncation, dropped-findings tally). On approval, submit a single GitHub PR review with decision `comment` — all comments batched atomically.
 
-**Zero comments to post.** When the holistic pass returns nothing, skip plan presentation and ask via AskUserQuestion: `"Looks good to me. Post as approval on the PR?"`. Approve → submit decision `approve` with body `Looks good to me.`; decline → take no PR action. No PR action otherwise.
+**Zero comments to post.** When the holistic pass returns nothing, skip plan presentation and ask the user: `"Looks good to me. Post as approval on the PR?"`. Approve → submit decision `approve` with body `Looks good to me.`; decline → take no PR action. No PR action otherwise.
 
 **Gotchas.**
 
@@ -48,6 +48,6 @@ Target voice: *"Empty input skips the null check — `if (input?.value)` at `par
 - Never submit decision `request_changes` — this skill does not algorithmically block merges.
 - Never add an AI disclosure footer to a comment, summary, or reply. There is no flag for one.
 - Never forward PR conversation or bundle context to a reviewer agent. Only the holistic pass may see that context.
-- Never re-raise a finding the holistic pass pruned in this run. When running under `--loop`, never re-raise in a later iteration something already in our own prior posted comments — dedupe via PR history.
+- Never re-raise a finding the holistic pass pruned in this run.
 
 **`--loop`.** Load `references/LOOP.md`.

--- a/dist/codex/skills/review-pr/references/LOOP.md
+++ b/dist/codex/skills/review-pr/references/LOOP.md
@@ -4,7 +4,7 @@ Bypass the approval gate entirely — initial post and every rerun run autonomou
 
 ## Initial post + watch
 
-Run the default pipeline (resolve inputs → fleet → holistic pass → submit `comment` review), but skip the ExitPlanMode approval. After posting, `subscribe_pr_activity` for this PR and enter the wait phase. Wait backoff per round: **15 → 30 → 60 → 120 minutes**. PR activity events resolve the wait early (a commit pushed, a thread reply received). At the end of each round, advance the verifier.
+Run the default pipeline (resolve inputs → fleet → holistic pass → submit `comment` review), but skip the approval gate. After posting, wait between checks with escalating intervals (~15 min → 2 hours). If the harness delivers PR activity events that wake the session, subscribe so a commit push or thread reply resolves the wait early; otherwise blocking `sleep`. At the end of each round, advance the verifier.
 
 ## Per-comment verifier (each wake)
 
@@ -20,36 +20,27 @@ For every comment we posted that is still pending (not yet judged resolved), spa
 
 The subagent returns exactly one disposition:
 
-- **`addressed-by-fix`** — A commit after our review modified the line range AND the modification removes the concrete failure mode our comment raised. Verify against the post-fix code: trace the original problem; check that the current code no longer exhibits it. Lines touched without addressing the underlying concern do NOT qualify.
-- **`addressed-by-valid-reply`** — The author replied (on this or another thread) with an argument that fairly defeats our concern: correct factual context we missed, a deliberate design choice with valid rationale, an out-of-scope acknowledgment to accept, or the concern being already addressed by code elsewhere we hadn't seen. "Valid" means a fair-minded human reviewer would concede. Tone is irrelevant.
-- **`needs-our-pushback`** — Neither of the above. The author hasn't addressed the concern via commit and either hasn't replied or has replied with an argument that doesn't defeat the concern (dismissal without rebuttal, restating the code, agreeing-to-disagree without engaging substance).
+- **`addressed-by-fix`** — A commit after our review modified the line range AND the modification removes the concrete failure mode our comment raised. Verify against the post-fix code: trace the original problem; check that the current code no longer exhibits it. Lines touched without addressing the underlying concern do NOT qualify. **Mark the comment resolved.**
+- **`addressed-by-valid-reply`** — The author replied (on this or another thread) with an argument that fairly defeats our concern: correct factual context we missed, a deliberate design choice with valid rationale, an out-of-scope acknowledgment to accept, or the concern being already addressed by code elsewhere we hadn't seen. "Valid" means a fair-minded human reviewer would concede. Tone is irrelevant. **Mark the comment resolved.**
+- **`needs-our-pushback`** — Neither of the above. The author hasn't addressed the concern via commit and either hasn't replied or has replied with an argument that doesn't defeat the concern (dismissal without rebuttal, restating the code, agreeing-to-disagree without engaging substance). **If `drop: false`, post the drafted reply on the existing thread; if `drop: true`, silently drop the thread.**
 
 ## Pushback drafting and the one-round rule
 
-If pushback history says we have already posted a pushback reply on this thread, the verifier returns with `drop: true` and the caller silently drops the thread. **One round of pushback per thread, total** — no comment wars.
+If pushback history says we have already posted a pushback reply on this thread, the verifier returns with `drop: true`. **One round of pushback per thread, total** — no comment wars.
 
 Otherwise the verifier drafts a short thread-reply body in the SKILL.md voice profile. Stay on the specific point under contention; don't restate the original concern in full; address whatever the author actually said (or didn't say). The reply is posted as a thread reply on the existing comment, **not** a new review.
 
-## Acting on dispositions
-
-For each pending comment:
-
-- `addressed-by-fix` or `addressed-by-valid-reply` → mark resolved.
-- `needs-our-pushback` with `drop: false` → post the drafted reply on the existing thread.
-- `needs-our-pushback` with `drop: true` → silently drop the thread.
-
-If any comments remain pending after acting on this wake's dispositions, advance the wait backoff to the next tier and wait again.
+After acting on this wake's dispositions, if any comments remain pending, advance to the next wait interval and wait again.
 
 ## Success path: rerun on full resolution
 
-When every comment is resolved (by fix, valid reply, or one-round pushback that ended in a drop), rerun the full pipeline (default mode in SKILL.md) on the new PR state — the holistic pass dedupes the new findings against our own prior posted comments via PR history, so the same concern won't be re-raised. Reset the wait backoff to 15 min for the new cycle.
+When every comment is resolved (by fix, valid reply, or one-round pushback that ended in a drop), rerun the full pipeline (default mode in SKILL.md) on the new PR state. Reset to the shortest wait interval for the new cycle.
 
 ## Termini (first to fire wins)
 
-1. Clean rerun + zero new Medium+ findings + user approves the lgtm prompt → submit `approve` review with body `Looks good to me.`, exit.
-2. Clean rerun + zero new findings + user declines the lgtm prompt → exit silent.
-3. **3 cycles total** (initial post + 2 reruns).
-4. **24h wall-clock backstop** from initial post.
-5. The 4-tier wait cap (120 min) elapses with comments still pending.
+1. Clean rerun returns no surviving findings → run the SKILL.md lgtm prompt. Approve → submit `approve` review with body `Looks good to me.`, exit. Decline → exit silent.
+2. **3 cycles total** (initial post + 2 reruns).
+3. **24h wall-clock backstop** from initial post.
+4. The longest wait interval (~2h) elapses with comments still pending.
 
-On (3), (4), or (5): silent unsubscribe from PR activity + chat summary to the user (which cycles completed, which comments remain unaddressed, which dispositions were applied). **Never post a bump comment on the PR** — the cap is "I'm done watching," not "I escalate."
+On (2), (3), or (4): silent unsubscribe from PR activity if subscribed + chat summary to the user (which cycles completed, which comments remain unaddressed, which dispositions were applied). **Never post a bump comment on the PR** — the cap is "I'm done watching," not "I escalate."

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "321a692faad091d4874cf808bdd319863d9efdaa",
+  "source_commit": "0af2caec24178f3b595f11cd2937bac725a77677",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-05-24T14:03:24Z"
+  "synced_at": "2026-05-24T14:18:21Z"
 }

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "29ef57e6f3a0cff7ad7a0ec5caa9e535c5ddefd9",
+  "source_commit": "321a692faad091d4874cf808bdd319863d9efdaa",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-05-24T06:58:16Z"
+  "synced_at": "2026-05-24T14:03:24Z"
 }

--- a/dist/opencode/agents/prompt-reviewer.md
+++ b/dist/opencode/agents/prompt-reviewer.md
@@ -31,7 +31,7 @@ Report format:
 
 **Severity**:
 - **High** — the prompt actively misbehaves or breaks a contract. Examples: contradiction between two rules that can't both hold; missing the goal entirely; absolute used on a judgment call that observably misfires; the agent declares a need for a tool it doesn't have, or omits a tool it actually uses.
-- **Medium** — the prompt works but drifts toward known failure modes. Examples: vague directive that produces inconsistent behavior across runs; restated model default adding noise the model has to wade through; missing a gap-closer that the discipline says should be there; arbitrary numbers without a rubric.
+- **Medium** — the prompt works but drifts toward known failure modes. Examples: vague directive that produces inconsistent behavior across runs; restated model default adding noise the model has to wade through; missing a gap-closer that the discipline says should be there; arbitrary numbers without a rubric; boundary failures — naming a harness-bound primitive, a rule-scope qualifier that silently excludes valid cases, mechanism stated as the only path, or one principle split across multiple places.
 - **Low** — minor friction with no functional impact. Examples: duplication that doesn't change behavior; awkward phrasing where the meaning is still unambiguous; stylistic-only cleanup.
 
 **Tag** (parsed as control flow by `/auto-optimize-prompt` — do not rename or repurpose):

--- a/dist/opencode/skills/prompt-engineering/SKILL.md
+++ b/dist/opencode/skills/prompt-engineering/SKILL.md
@@ -5,9 +5,9 @@ argument-hint: '<request>'
 user-invocable: true
 ---
 
-A prompt earns its place where natural model behavior misses what's needed. State the goal and the expected outcome; trust the model for everything else. Lines belong only when they close a real gap — observed gotchas, non-obvious behavior, knowledge the model doesn't have, or edge cases it gets wrong by default. Length follows the gap, not a number. On update, calibrate both directions: add what closes the new gap, and prune what no longer earns its place. A prompt stays in balance over time; it doesn't accrete.
+A prompt earns its place where natural model behavior misses what's needed. State the goal and the expected outcome; trust the model for everything else. Lines belong only when they close a real gap — observed gotchas, non-obvious behavior, knowledge the model doesn't have, or edge cases it gets wrong by default. Each line must also hold at the edges of where the prompt runs: name principles, not harness-bound primitives; scope rules to the principle's natural reach, not narrower; unify split restatements of the same rule. Length follows the gap, not a number. On update, calibrate both directions: add what closes the new gap, and prune what no longer earns its place. A prompt stays in balance over time; it doesn't accrete.
 
-Branch on intent. *Creating*: discover the goal, audience, and the specific gap; draft the minimum that closes it. *Updating*: find each existing line's gap before changing anything around it — patches that replace often beat patches that add. *Reviewing*: of each line ask *"would the model do this without it?"* — flag the no's. *Diagnosing a failing prompt*: see `references/metaprompting.md` — find the line driving the symptom before patching.
+Branch on intent. *Creating*: discover the goal, audience, and the specific gap; draft the minimum that closes it. *Updating*: find each existing line's gap before changing anything around it — patches that replace often beat patches that add. *Reviewing*: of each line ask both *"would the model do this without it?"* and *"does this hold at the edges?"* — flag the no's. *Diagnosing a failing prompt*: see `references/metaprompting.md` — find the line driving the symptom before patching.
 
 References load on demand. Load only the ones whose trigger fires:
 

--- a/dist/opencode/skills/prompt-engineering/references/review.md
+++ b/dist/opencode/skills/prompt-engineering/references/review.md
@@ -10,6 +10,21 @@ Update is the same audit applied to a specific change. Find the new gap; close i
 
 Apply it to every line. The line earns its place if and only if the answer is *no, the model wouldn't reach this on its own*.
 
+## The boundary check
+
+> *Does this line still hold at the edges of where this prompt will run?*
+
+A line can earn its place locally and still be brittle. The earn-your-place question is point-wise; the boundary check tests each line against the conditions it'll actually meet. Run both — they catch different failures.
+
+| Edge | Symptom | Fix |
+|------|---------|-----|
+| **Harness** | Names a primitive bound to one harness (`AskUserQuestion`, `subscribe_pr_activity`, `ExitPlanMode`, an MCP tool by name) | State the principle; let the model pick whatever tool the harness exposes |
+| **Scope qualifier** | Rule has a qualifier (`by another reviewer`, `under --loop only`, `in mode X`) that excludes cases the principle should also cover | Drop the qualifier or broaden it to match the principle's reach |
+| **Mechanism-as-prescription** | Specific numbers or a fixed sequence stated as the only path (`15→30→60→120 min`, `Max 3 iterations`, a hardcoded tool chain) | State the principle; numbers and sequences become defaults, not the rule |
+| **Split of same rule** | Same principle restated in multiple places with slight variations (one general, one mode-specific) | Unify into one rule, delete the splits |
+
+A line that passes earn-your-place but fails boundary is fragile — works today, breaks the first time the prompt runs in a different harness, mode, or scope. Boundary fixes usually *reword* the line rather than delete it.
+
 ## Anti-patterns
 
 | Anti-pattern | Example | Fix |

--- a/dist/opencode/skills/review-pr/SKILL.md
+++ b/dist/opencode/skills/review-pr/SKILL.md
@@ -9,21 +9,21 @@ High-signal autonomous PR review posted under your account. A review you'd put y
 
 **Inputs.** `pr-url` from the arg or the current branch's upstream PR. `--manifest <path>` opts into grounding against the author's intent; the skill does not auto-discover from any folder convention. `--bundle <urls>` plus PR-description linked-PR parsing (`Depends on #N`, `Stack:`, `Co-changes:`, GitHub PR URLs) provides cross-PR context for coupled changes.
 
-**Reviewer fleet.** Spawn in parallel. Always-on: `change-intent-reviewer`, `code-bugs-reviewer`, `code-design-reviewer`, `code-maintainability-reviewer`, `code-simplicity-reviewer`, `context-file-adherence-reviewer`. Add when the diff fits: `type-safety-reviewer` on typed code; `test-quality-reviewer` and `code-testability-reviewer` on source; `contracts-reviewer` on API surfaces; `operational-readiness-reviewer` on CI/infra/env/migrations/workers/queues/secrets; `docs-reviewer` and `prose-value-reviewer` on prose; `prompt-reviewer` (with `prompt-token-efficiency-verifier`, `prompt-compression-verifier`) on prompts/skills/agents. Forward the manifest to every spawned reviewer when present.
+**Reviewer fleet.** Always-on: `change-intent-reviewer`, `code-bugs-reviewer`, `code-design-reviewer`, `code-maintainability-reviewer`, `code-simplicity-reviewer`, `context-file-adherence-reviewer`. Add when the diff fits: `type-safety-reviewer` on typed code; `test-quality-reviewer` and `code-testability-reviewer` on source; `contracts-reviewer` on API surfaces; `operational-readiness-reviewer` on CI/infra/env/migrations/workers/queues/secrets; `docs-reviewer` and `prose-value-reviewer` on prose; `prompt-reviewer` (with `prompt-token-efficiency-verifier`, `prompt-compression-verifier`) on prompts/skills/agents. Forward the manifest to every spawned reviewer when present.
 
 **Narrow-lens reviewers.** Reviewer agents never receive PR conversation, linked-PR diffs, or linked-PR conversation. That context flows only to the holistic pass — narrow lens is what keeps each reviewer precise.
 
 **Holistic coherence pass.** Collect findings from the fleet, drop Low severity, and spawn one subagent with what remains plus:
 
-- PR history: recent review/conversation comments, all unresolved threads, the author's recent commit messages on the branch, the PR description.
+- PR history: all comments and threads on the PR (including our own from any prior review pass), the author's recent commit messages on the branch, the PR description.
 - Bundle context for each linked PR: diff, description, top-level conversation. No inline review comments from linked PRs.
 - The manifest if present.
 - Any truncation the caller did, carried forward.
 
 The subagent:
 
-- **Prunes** findings already raised by another reviewer in the existing PR conversation, already discussed/conceded by the author, contradicting manifest intent, contradicted by the author's prior explanation in a comment / commit message / PR-description note, or piling on an active thread.
-- **Dedupes** across reviewers: merge into one comment when same file + overlapping line range + same underlying concern.
+- **Prunes** any finding already covered on the PR: any prior comment (ours from a previous run, or another reviewer's), any concession or rebuttal on an existing thread, anything contradicted by the manifest, a commit message, or the PR description, or piling on an active thread.
+- **Dedupes** across reviewers: merge near-duplicates into one comment when they raise the same underlying concern.
 - **Anchors** each surviving finding to exactly one of inline file:line (default), file-level (whole-file concern), or PR-level (cross-cutting, no specific anchor).
 - **Rewrites** every comment body and any drafted reply in the voice profile below.
 - **Omits a summary header by default** — adds one only when there's a real overall take the per-comment list misses (one short sentence, voice-compliant, no boilerplate).
@@ -40,7 +40,7 @@ Target voice: *"Empty input skips the null check — `if (input?.value)` at `par
 
 **Posting.** When the holistic pass returns comments to post, present the plan for user approval (comments + anchors, what was loaded as context, any truncation, dropped-findings tally). On approval, submit a single GitHub PR review with decision `comment` — all comments batched atomically.
 
-**Zero comments to post.** When the holistic pass returns nothing, skip plan presentation and ask via AskUserQuestion: `"Looks good to me. Post as approval on the PR?"`. Approve → submit decision `approve` with body `Looks good to me.`; decline → take no PR action. No PR action otherwise.
+**Zero comments to post.** When the holistic pass returns nothing, skip plan presentation and ask the user: `"Looks good to me. Post as approval on the PR?"`. Approve → submit decision `approve` with body `Looks good to me.`; decline → take no PR action. No PR action otherwise.
 
 **Gotchas.**
 
@@ -48,6 +48,6 @@ Target voice: *"Empty input skips the null check — `if (input?.value)` at `par
 - Never submit decision `request_changes` — this skill does not algorithmically block merges.
 - Never add an AI disclosure footer to a comment, summary, or reply. There is no flag for one.
 - Never forward PR conversation or bundle context to a reviewer agent. Only the holistic pass may see that context.
-- Never re-raise a finding the holistic pass pruned in this run. When running under `--loop`, never re-raise in a later iteration something already in our own prior posted comments — dedupe via PR history.
+- Never re-raise a finding the holistic pass pruned in this run.
 
 **`--loop`.** Load `references/LOOP.md`.

--- a/dist/opencode/skills/review-pr/references/LOOP.md
+++ b/dist/opencode/skills/review-pr/references/LOOP.md
@@ -4,7 +4,7 @@ Bypass the approval gate entirely — initial post and every rerun run autonomou
 
 ## Initial post + watch
 
-Run the default pipeline (resolve inputs → fleet → holistic pass → submit `comment` review), but skip the ExitPlanMode approval. After posting, `subscribe_pr_activity` for this PR and enter the wait phase. Wait backoff per round: **15 → 30 → 60 → 120 minutes**. PR activity events resolve the wait early (a commit pushed, a thread reply received). At the end of each round, advance the verifier.
+Run the default pipeline (resolve inputs → fleet → holistic pass → submit `comment` review), but skip the approval gate. After posting, wait between checks with escalating intervals (~15 min → 2 hours). If the harness delivers PR activity events that wake the session, subscribe so a commit push or thread reply resolves the wait early; otherwise blocking `sleep`. At the end of each round, advance the verifier.
 
 ## Per-comment verifier (each wake)
 
@@ -20,36 +20,27 @@ For every comment we posted that is still pending (not yet judged resolved), spa
 
 The subagent returns exactly one disposition:
 
-- **`addressed-by-fix`** — A commit after our review modified the line range AND the modification removes the concrete failure mode our comment raised. Verify against the post-fix code: trace the original problem; check that the current code no longer exhibits it. Lines touched without addressing the underlying concern do NOT qualify.
-- **`addressed-by-valid-reply`** — The author replied (on this or another thread) with an argument that fairly defeats our concern: correct factual context we missed, a deliberate design choice with valid rationale, an out-of-scope acknowledgment to accept, or the concern being already addressed by code elsewhere we hadn't seen. "Valid" means a fair-minded human reviewer would concede. Tone is irrelevant.
-- **`needs-our-pushback`** — Neither of the above. The author hasn't addressed the concern via commit and either hasn't replied or has replied with an argument that doesn't defeat the concern (dismissal without rebuttal, restating the code, agreeing-to-disagree without engaging substance).
+- **`addressed-by-fix`** — A commit after our review modified the line range AND the modification removes the concrete failure mode our comment raised. Verify against the post-fix code: trace the original problem; check that the current code no longer exhibits it. Lines touched without addressing the underlying concern do NOT qualify. **Mark the comment resolved.**
+- **`addressed-by-valid-reply`** — The author replied (on this or another thread) with an argument that fairly defeats our concern: correct factual context we missed, a deliberate design choice with valid rationale, an out-of-scope acknowledgment to accept, or the concern being already addressed by code elsewhere we hadn't seen. "Valid" means a fair-minded human reviewer would concede. Tone is irrelevant. **Mark the comment resolved.**
+- **`needs-our-pushback`** — Neither of the above. The author hasn't addressed the concern via commit and either hasn't replied or has replied with an argument that doesn't defeat the concern (dismissal without rebuttal, restating the code, agreeing-to-disagree without engaging substance). **If `drop: false`, post the drafted reply on the existing thread; if `drop: true`, silently drop the thread.**
 
 ## Pushback drafting and the one-round rule
 
-If pushback history says we have already posted a pushback reply on this thread, the verifier returns with `drop: true` and the caller silently drops the thread. **One round of pushback per thread, total** — no comment wars.
+If pushback history says we have already posted a pushback reply on this thread, the verifier returns with `drop: true`. **One round of pushback per thread, total** — no comment wars.
 
 Otherwise the verifier drafts a short thread-reply body in the SKILL.md voice profile. Stay on the specific point under contention; don't restate the original concern in full; address whatever the author actually said (or didn't say). The reply is posted as a thread reply on the existing comment, **not** a new review.
 
-## Acting on dispositions
-
-For each pending comment:
-
-- `addressed-by-fix` or `addressed-by-valid-reply` → mark resolved.
-- `needs-our-pushback` with `drop: false` → post the drafted reply on the existing thread.
-- `needs-our-pushback` with `drop: true` → silently drop the thread.
-
-If any comments remain pending after acting on this wake's dispositions, advance the wait backoff to the next tier and wait again.
+After acting on this wake's dispositions, if any comments remain pending, advance to the next wait interval and wait again.
 
 ## Success path: rerun on full resolution
 
-When every comment is resolved (by fix, valid reply, or one-round pushback that ended in a drop), rerun the full pipeline (default mode in SKILL.md) on the new PR state — the holistic pass dedupes the new findings against our own prior posted comments via PR history, so the same concern won't be re-raised. Reset the wait backoff to 15 min for the new cycle.
+When every comment is resolved (by fix, valid reply, or one-round pushback that ended in a drop), rerun the full pipeline (default mode in SKILL.md) on the new PR state. Reset to the shortest wait interval for the new cycle.
 
 ## Termini (first to fire wins)
 
-1. Clean rerun + zero new Medium+ findings + user approves the lgtm prompt → submit `approve` review with body `Looks good to me.`, exit.
-2. Clean rerun + zero new findings + user declines the lgtm prompt → exit silent.
-3. **3 cycles total** (initial post + 2 reruns).
-4. **24h wall-clock backstop** from initial post.
-5. The 4-tier wait cap (120 min) elapses with comments still pending.
+1. Clean rerun returns no surviving findings → run the SKILL.md lgtm prompt. Approve → submit `approve` review with body `Looks good to me.`, exit. Decline → exit silent.
+2. **3 cycles total** (initial post + 2 reruns).
+3. **24h wall-clock backstop** from initial post.
+4. The longest wait interval (~2h) elapses with comments still pending.
 
-On (3), (4), or (5): silent unsubscribe from PR activity + chat summary to the user (which cycles completed, which comments remain unaddressed, which dispositions were applied). **Never post a bump comment on the PR** — the cap is "I'm done watching," not "I escalate."
+On (2), (3), or (4): silent unsubscribe from PR activity if subscribed + chat summary to the user (which cycles completed, which comments remain unaddressed, which dispositions were applied). **Never post a bump comment on the PR** — the cap is "I'm done watching," not "I escalate."


### PR DESCRIPTION
## Summary

- **Loop wait is now harness-portable.** `LOOP.md` replaces the named `subscribe_pr_activity` + fixed 15/30/60/120-min backoff with the underlying principle (escalating waits ~15 min → 2h; wake early on activity events if the harness delivers them; otherwise blocking `sleep`). `--loop` now runs in opencode and other harnesses where webhook wake-up has no transport, instead of stalling on a wait that never resolves.
- **Dedupe is universal.** SKILL.md's holistic prune rule no longer scopes to "another reviewer" — our own prior comments are deduped on the same path. The `--loop`-specific dedupe sentence in the Gotchas list is folded into the one universal rule. Holistic-pass context loader bumped from "recent" comments to all PR comments, so the dedupe actually has the evidence to fire.
- **Prompt-engineering audit pass.** Dropped restating-the-default ("Spawn in parallel"), the over-specified merge predicate (same file + overlapping line range), and harness-bound tool names (`AskUserQuestion`, `ExitPlanMode`). Folded per-disposition action into each disposition's own line and removed the redundant "Acting on dispositions" section. Combined terminus (1)/(2) into one user-prompt branch.

Bumps `manifest-dev-tools` to 0.14.0 and syncs OpenCode/Codex dists.

## Test plan

- [ ] `/review-pr --loop <pr>` in Claude Code: subscribe + early-wake on activity still works; full pipeline still posts.
- [ ] `/review-pr --loop <pr>` in opencode: falls back to blocking sleep between checks; verifier still advances per round.
- [ ] Two manual `/review-pr` runs on the same PR: second run dedupes against the first run's posted comments.
- [ ] Holistic pass on a PR with prior reviewer comments: still prunes findings already raised by other reviewers.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KiypP8FYTNsHDixiBfDWTf)_