### PR TITLE
fix: add review-pr cycle summaries

### DIFF
--- a/claude-plugins/manifest-dev-tools/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev-tools",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Tools for working with prompts and PRs alongside the manifest workflow. ADR synthesis from session transcripts, collaborative PR walkthroughs, autonomous PR review with per-comment verification, PR babysitting via manifest-dev, gap-calibrated prompt engineering, and cross-boundary context handoff.",
   "keywords": [
     "adr",

--- a/claude-plugins/manifest-dev-tools/skills/review-pr/SKILL.md
+++ b/claude-plugins/manifest-dev-tools/skills/review-pr/SKILL.md
@@ -15,7 +15,7 @@ Every invocation, including non-`--loop`, performs one complete PR-state advance
 
 1. **Advance our existing threads.** For every unresolved thread we authored or replied to, run the per-comment verifier below. Post needed thread replies, resolve terminal threads, and leave genuinely pending threads open.
 2. **Review new code.** Determine the review range from durable GitHub state: if we have a prior review on this PR, use that review's commit/head SHA as the lower bound and review `last-reviewed-by-us..current-head`; otherwise review the full PR diff. If the head is unchanged from our latest review, skip the reviewer fleet only after thread advancement has run.
-3. **Post outcomes.** Submit new surviving findings as a single GitHub review with decision `comment`. Thread replies are posted on their existing threads, not as new review comments.
+3. **Post outcomes.** Submit new surviving findings as a single GitHub review with decision `comment`. Thread replies are posted on their existing threads, not as new review comments. End with the cycle summary below.
 
 The one-shot pass is CI-shaped: it must make useful progress from only GitHub state and the current checkout. Do not rely on session memory such as `last-reviewed-sha`; derive it from our prior review/comment metadata and the PR history each run.
 
@@ -71,9 +71,18 @@ Structural defaults: prose, not bullets, for a single suggestion; no markdown he
 
 Target voice: *"Empty input skips the null check — `if (input?.value)` at `parser.ts:42` short-circuits before the parse at `parser.ts:47`, so `{}` reaches `parse()` without the guard. Tighten to `if (input?.value != null)`, or move the `parse()` call inside the existing branch."*
 
-**Posting.** When the holistic pass returns comments to post, submit a single GitHub PR review with decision `comment` — all comments batched atomically. In interactive sessions, briefly report what was posted (comment count, anchors, reviewed range, truncation if any, dropped-findings tally). In CI or non-interactive contexts, do not wait for approval.
+**Posting.** When the holistic pass returns comments to post, submit a single GitHub PR review with decision `comment` — all comments batched atomically. In CI or non-interactive contexts, do not wait for approval.
 
 **Zero comments to post.** When the holistic pass returns nothing and all our existing threads reached terminal disposition, report clean. In interactive sessions only, ask: `"Looks good to me. Post as approval on the PR?"`. Approve → submit decision `approve` with body `Looks good to me.`; decline → take no PR action. In CI or non-interactive contexts, take no approval action.
+
+**Cycle summary.** Every one-shot pass ends with an operator-facing summary, whether it posted comments, resolved threads, asked for approval, or found nothing to do. Keep it compact but complete:
+
+- Reviewed range/head and concrete PR actions taken: new review comment count and anchors, thread replies, resolved threads, approval prompt/action, or no PR action.
+- Per-comment verifier subagents: one line per thread naming the anchor, disposition, and the verifier's short reason.
+- Reviewer fleet subagents: one line per spawned reviewer naming its actionable findings count and the substance of what it found, or `none`.
+- Holistic coherence pass: surviving comments, dedupes/merges, pruned findings with dominant reasons, range-bounding decisions, summary header if any, and truncation notes.
+
+The cycle summary is for the operator transcript or run log only. Do not paste it into PR review bodies, thread replies, or approval text; the only posted summary-like text is the voice-compliant summary header returned by the holistic pass.
 
 **Gotchas.**
 

--- a/claude-plugins/manifest-dev-tools/skills/review-pr/references/LOOP.md
+++ b/claude-plugins/manifest-dev-tools/skills/review-pr/references/LOOP.md
@@ -2,7 +2,7 @@
 
 `--loop` is scheduling around the SKILL.md one-shot pass, not a separate review brain.
 
-Bypass interactive approval prompts. Run one full one-shot pass immediately: advance our existing threads, review the relevant range, post comments/replies/resolutions, and record what happened from GitHub state. Then watch for PR activity or wait with backoff and run the same one-shot pass again.
+Bypass interactive approval prompts. Run one full one-shot pass immediately: advance our existing threads, review the relevant range, post comments/replies/resolutions, and emit the SKILL.md cycle summary from GitHub state. Then watch for PR activity or wait with backoff and run the same one-shot pass again.
 
 ## Watch Cadence
 
@@ -16,7 +16,7 @@ Exit when a one-shot pass reports:
 - the current head has no unreviewed range since our latest review,
 - the latest one-shot review produced no surviving findings.
 
-Exit clean without posting an approval. `--loop` bypasses interactive approval prompts; an approval review requires an explicit operator request outside the loop.
+Exit clean after emitting the final one-shot cycle summary, without posting an approval. `--loop` bypasses interactive approval prompts; an approval review requires an explicit operator request outside the loop.
 
 ## Termini
 
@@ -26,4 +26,4 @@ First to fire wins:
 2. **24h wall-clock backstop** from initial post.
 3. The longest wait interval (~2h) elapses with our comments still pending and no new PR activity.
 
-On (2) or (3): silent unsubscribe from PR activity if subscribed + chat summary to the user (latest reviewed head, current head, which comments remain unaddressed, which dispositions were applied). **Never post a bump comment on the PR** — the cap is "I'm done watching," not "I escalate."
+On (2) or (3): silent unsubscribe from PR activity if subscribed + chat summary to the user with the final one-shot cycle summary, latest reviewed head, current head, which comments remain unaddressed, and which dispositions were applied across the loop. **Never post a bump comment on the PR** — the cap is "I'm done watching," not "I escalate."

--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "3bd6e6ffaa039a155bb2c7f86be44e945f31affc",
+  "source_commit": "606b14059621ff74a3951ec93be4337ca37ee4a7",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-05-28T16:25:59Z"
+  "synced_at": "2026-06-01T10:01:01Z"
 }

--- a/dist/codex/skills/review-pr/SKILL.md
+++ b/dist/codex/skills/review-pr/SKILL.md
@@ -15,7 +15,7 @@ Every invocation, including non-`--loop`, performs one complete PR-state advance
 
 1. **Advance our existing threads.** For every unresolved thread we authored or replied to, run the per-comment verifier below. Post needed thread replies, resolve terminal threads, and leave genuinely pending threads open.
 2. **Review new code.** Determine the review range from durable GitHub state: if we have a prior review on this PR, use that review's commit/head SHA as the lower bound and review `last-reviewed-by-us..current-head`; otherwise review the full PR diff. If the head is unchanged from our latest review, skip the reviewer fleet only after thread advancement has run.
-3. **Post outcomes.** Submit new surviving findings as a single GitHub review with decision `comment`. Thread replies are posted on their existing threads, not as new review comments.
+3. **Post outcomes.** Submit new surviving findings as a single GitHub review with decision `comment`. Thread replies are posted on their existing threads, not as new review comments. End with the cycle summary below.
 
 The one-shot pass is CI-shaped: it must make useful progress from only GitHub state and the current checkout. Do not rely on session memory such as `last-reviewed-sha`; derive it from our prior review/comment metadata and the PR history each run.
 
@@ -71,9 +71,18 @@ Structural defaults: prose, not bullets, for a single suggestion; no markdown he
 
 Target voice: *"Empty input skips the null check — `if (input?.value)` at `parser.ts:42` short-circuits before the parse at `parser.ts:47`, so `{}` reaches `parse()` without the guard. Tighten to `if (input?.value != null)`, or move the `parse()` call inside the existing branch."*
 
-**Posting.** When the holistic pass returns comments to post, submit a single GitHub PR review with decision `comment` — all comments batched atomically. In interactive sessions, briefly report what was posted (comment count, anchors, reviewed range, truncation if any, dropped-findings tally). In CI or non-interactive contexts, do not wait for approval.
+**Posting.** When the holistic pass returns comments to post, submit a single GitHub PR review with decision `comment` — all comments batched atomically. In CI or non-interactive contexts, do not wait for approval.
 
 **Zero comments to post.** When the holistic pass returns nothing and all our existing threads reached terminal disposition, report clean. In interactive sessions only, ask: `"Looks good to me. Post as approval on the PR?"`. Approve → submit decision `approve` with body `Looks good to me.`; decline → take no PR action. In CI or non-interactive contexts, take no approval action.
+
+**Cycle summary.** Every one-shot pass ends with an operator-facing summary, whether it posted comments, resolved threads, asked for approval, or found nothing to do. Keep it compact but complete:
+
+- Reviewed range/head and concrete PR actions taken: new review comment count and anchors, thread replies, resolved threads, approval prompt/action, or no PR action.
+- Per-comment verifier subagents: one line per thread naming the anchor, disposition, and the verifier's short reason.
+- Reviewer fleet subagents: one line per spawned reviewer naming its actionable findings count and the substance of what it found, or `none`.
+- Holistic coherence pass: surviving comments, dedupes/merges, pruned findings with dominant reasons, range-bounding decisions, summary header if any, and truncation notes.
+
+The cycle summary is for the operator transcript or run log only. Do not paste it into PR review bodies, thread replies, or approval text; the only posted summary-like text is the voice-compliant summary header returned by the holistic pass.
 
 **Gotchas.**
 

--- a/dist/codex/skills/review-pr/references/LOOP.md
+++ b/dist/codex/skills/review-pr/references/LOOP.md
@@ -2,7 +2,7 @@
 
 `--loop` is scheduling around the SKILL.md one-shot pass, not a separate review brain.
 
-Bypass interactive approval prompts. Run one full one-shot pass immediately: advance our existing threads, review the relevant range, post comments/replies/resolutions, and record what happened from GitHub state. Then watch for PR activity or wait with backoff and run the same one-shot pass again.
+Bypass interactive approval prompts. Run one full one-shot pass immediately: advance our existing threads, review the relevant range, post comments/replies/resolutions, and emit the SKILL.md cycle summary from GitHub state. Then watch for PR activity or wait with backoff and run the same one-shot pass again.
 
 ## Watch Cadence
 
@@ -16,7 +16,7 @@ Exit when a one-shot pass reports:
 - the current head has no unreviewed range since our latest review,
 - the latest one-shot review produced no surviving findings.
 
-Exit clean without posting an approval. `--loop` bypasses interactive approval prompts; an approval review requires an explicit operator request outside the loop.
+Exit clean after emitting the final one-shot cycle summary, without posting an approval. `--loop` bypasses interactive approval prompts; an approval review requires an explicit operator request outside the loop.
 
 ## Termini
 
@@ -26,4 +26,4 @@ First to fire wins:
 2. **24h wall-clock backstop** from initial post.
 3. The longest wait interval (~2h) elapses with our comments still pending and no new PR activity.
 
-On (2) or (3): silent unsubscribe from PR activity if subscribed + chat summary to the user (latest reviewed head, current head, which comments remain unaddressed, which dispositions were applied). **Never post a bump comment on the PR** — the cap is "I'm done watching," not "I escalate."
+On (2) or (3): silent unsubscribe from PR activity if subscribed + chat summary to the user with the final one-shot cycle summary, latest reviewed head, current head, which comments remain unaddressed, and which dispositions were applied across the loop. **Never post a bump comment on the PR** — the cap is "I'm done watching," not "I escalate."

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "3bd6e6ffaa039a155bb2c7f86be44e945f31affc",
+  "source_commit": "606b14059621ff74a3951ec93be4337ca37ee4a7",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-05-28T16:25:59Z"
+  "synced_at": "2026-06-01T10:01:01Z"
 }

--- a/dist/opencode/skills/review-pr/SKILL.md
+++ b/dist/opencode/skills/review-pr/SKILL.md
@@ -15,7 +15,7 @@ Every invocation, including non-`--loop`, performs one complete PR-state advance
 
 1. **Advance our existing threads.** For every unresolved thread we authored or replied to, run the per-comment verifier below. Post needed thread replies, resolve terminal threads, and leave genuinely pending threads open.
 2. **Review new code.** Determine the review range from durable GitHub state: if we have a prior review on this PR, use that review's commit/head SHA as the lower bound and review `last-reviewed-by-us..current-head`; otherwise review the full PR diff. If the head is unchanged from our latest review, skip the reviewer fleet only after thread advancement has run.
-3. **Post outcomes.** Submit new surviving findings as a single GitHub review with decision `comment`. Thread replies are posted on their existing threads, not as new review comments.
+3. **Post outcomes.** Submit new surviving findings as a single GitHub review with decision `comment`. Thread replies are posted on their existing threads, not as new review comments. End with the cycle summary below.
 
 The one-shot pass is CI-shaped: it must make useful progress from only GitHub state and the current checkout. Do not rely on session memory such as `last-reviewed-sha`; derive it from our prior review/comment metadata and the PR history each run.
 
@@ -71,9 +71,18 @@ Structural defaults: prose, not bullets, for a single suggestion; no markdown he
 
 Target voice: *"Empty input skips the null check — `if (input?.value)` at `parser.ts:42` short-circuits before the parse at `parser.ts:47`, so `{}` reaches `parse()` without the guard. Tighten to `if (input?.value != null)`, or move the `parse()` call inside the existing branch."*
 
-**Posting.** When the holistic pass returns comments to post, submit a single GitHub PR review with decision `comment` — all comments batched atomically. In interactive sessions, briefly report what was posted (comment count, anchors, reviewed range, truncation if any, dropped-findings tally). In CI or non-interactive contexts, do not wait for approval.
+**Posting.** When the holistic pass returns comments to post, submit a single GitHub PR review with decision `comment` — all comments batched atomically. In CI or non-interactive contexts, do not wait for approval.
 
 **Zero comments to post.** When the holistic pass returns nothing and all our existing threads reached terminal disposition, report clean. In interactive sessions only, ask: `"Looks good to me. Post as approval on the PR?"`. Approve → submit decision `approve` with body `Looks good to me.`; decline → take no PR action. In CI or non-interactive contexts, take no approval action.
+
+**Cycle summary.** Every one-shot pass ends with an operator-facing summary, whether it posted comments, resolved threads, asked for approval, or found nothing to do. Keep it compact but complete:
+
+- Reviewed range/head and concrete PR actions taken: new review comment count and anchors, thread replies, resolved threads, approval prompt/action, or no PR action.
+- Per-comment verifier subagents: one line per thread naming the anchor, disposition, and the verifier's short reason.
+- Reviewer fleet subagents: one line per spawned reviewer naming its actionable findings count and the substance of what it found, or `none`.
+- Holistic coherence pass: surviving comments, dedupes/merges, pruned findings with dominant reasons, range-bounding decisions, summary header if any, and truncation notes.
+
+The cycle summary is for the operator transcript or run log only. Do not paste it into PR review bodies, thread replies, or approval text; the only posted summary-like text is the voice-compliant summary header returned by the holistic pass.
 
 **Gotchas.**
 

--- a/dist/opencode/skills/review-pr/references/LOOP.md
+++ b/dist/opencode/skills/review-pr/references/LOOP.md
@@ -2,7 +2,7 @@
 
 `--loop` is scheduling around the SKILL.md one-shot pass, not a separate review brain.
 
-Bypass interactive approval prompts. Run one full one-shot pass immediately: advance our existing threads, review the relevant range, post comments/replies/resolutions, and record what happened from GitHub state. Then watch for PR activity or wait with backoff and run the same one-shot pass again.
+Bypass interactive approval prompts. Run one full one-shot pass immediately: advance our existing threads, review the relevant range, post comments/replies/resolutions, and emit the SKILL.md cycle summary from GitHub state. Then watch for PR activity or wait with backoff and run the same one-shot pass again.
 
 ## Watch Cadence
 
@@ -16,7 +16,7 @@ Exit when a one-shot pass reports:
 - the current head has no unreviewed range since our latest review,
 - the latest one-shot review produced no surviving findings.
 
-Exit clean without posting an approval. `--loop` bypasses interactive approval prompts; an approval review requires an explicit operator request outside the loop.
+Exit clean after emitting the final one-shot cycle summary, without posting an approval. `--loop` bypasses interactive approval prompts; an approval review requires an explicit operator request outside the loop.
 
 ## Termini
 
@@ -26,4 +26,4 @@ First to fire wins:
 2. **24h wall-clock backstop** from initial post.
 3. The longest wait interval (~2h) elapses with our comments still pending and no new PR activity.
 
-On (2) or (3): silent unsubscribe from PR activity if subscribed + chat summary to the user (latest reviewed head, current head, which comments remain unaddressed, which dispositions were applied). **Never post a bump comment on the PR** — the cap is "I'm done watching," not "I escalate."
+On (2) or (3): silent unsubscribe from PR activity if subscribed + chat summary to the user with the final one-shot cycle summary, latest reviewed head, current head, which comments remain unaddressed, and which dispositions were applied across the loop. **Never post a bump comment on the PR** — the cap is "I'm done watching," not "I escalate."


### PR DESCRIPTION
## Summary

This updates `manifest-dev-tools:review-pr` so every completed review cycle leaves a compact but complete operator-facing summary. The summary now captures not just what was posted, but what each agent layer concluded: per-comment verifier dispositions, reviewer fleet findings, and the holistic coherence pass decisions.

Concretely:

- Adds a required `Cycle summary` contract to `review-pr/SKILL.md` for every one-shot pass, regardless of outcome: posted comments, resolved threads, approval prompt, clean pass, or no-op.
- Requires the summary to include the reviewed range/head, concrete PR actions taken, per-thread verifier disposition and reason, each spawned reviewer’s actionable finding count/substance, and the holistic coherence pass output.
- Makes the summary explicitly operator-only: it belongs in the transcript/run log and must not be pasted into PR review comments, thread replies, or approval text.
- Updates `--loop` behavior so looped runs emit the same one-shot cycle summary on each/final pass, and termination summaries include the final cycle summary plus unresolved comments/head state.
- Preserves existing posting semantics: no automatic approvals, no `request_changes`, no bump comments, and no leakage of internal agent/coherence audit detail into GitHub bodies.
- Bumps `manifest-dev-tools` from `0.16.0` to `0.16.1`.
- Syncs the generated `dist/opencode` and `dist/codex` copies of the `review-pr` skill and loop reference, including sync metadata.

## Why

Before this, `review-pr` had the right review architecture but a weak terminal report. It could post or skip comments correctly, but the operator did not reliably get a durable audit trail of what the verifier subagents said, what each reviewer agent found, or why the coherence pass pruned/merged/survived findings. That is especially painful under `--loop`, where the useful artifact is often the cycle trace, not just the final PR state.

This patch keeps the review intelligence where it already lives and only tightens the output contract: every cycle now tells the operator what happened across the subagent fleet and coherence layer without contaminating the human-facing GitHub review.

## Verification

Ran the dist/integration coverage for generated CLI payloads and install behavior:

```bash
.venv/bin/python -m pytest tests/test_dist_skill_references.py tests/test_dist_install_uninstall.py
```

Result: `23 passed in 21.77s`.
