### PR TITLE
fix: add figure-out belief register

### DIFF
--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Tell Claude what done looks like, let it work, check the result. /define interviews you and writes a Manifest — Deliverables with Acceptance Criteria, Global Invariants, Approach. /do executes the Manifest and verifies inline by spawning a subagent per Acceptance Criterion and Global Invariant. /goal /do <manifest> is the recommended unattended execution wrapper. /figure-out is the truth-convergent thinking partner /define auto-invokes when the problem space is foggy. /figure-out-team extends that discipline to multi-party async Slack conversations. Verify blocks are four fields — prompt, agent, model, phase. /auto chains the whole flow autonomously; --babysit <pr-url> tends an existing PR to mergeable without local manifest-dev setup.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/skills/figure-out/SKILL.md
+++ b/claude-plugins/manifest-dev/skills/figure-out/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: figure-out
 description: 'Figure things out together — any topic, problem, or idea. Presses relentlessly until shared understanding is reached. Use when you need to understand before acting, when figuring it out is the goal, or when the user asks to think through a decision, dig deeper, press an assumption, investigate why something is happening, or work through a problem.'
-argument-hint: '[topic] [--with-docs] [--log [path]]'
+argument-hint: '[topic] [--with-docs] [--log [path]] [--autonomous]'
 user-invocable: true
 ---
 
@@ -12,6 +12,8 @@ Per turn: lead with one question and your recommended answer. Cut empty preamble
 Don't drop threads — when investigation pulls you elsewhere, return to the original question.
 
 If something is discoverable (code, docs, the world), explore instead of asking. Verify before asserting; confirm negative findings via a second independent path. Hold positions under pushback when evidence still supports them.
+
+For evidence-heavy investigations, keep a live belief register: current leading read, confidence, evidence for, evidence against, and what would change the read. Update it whenever evidence shifts. Do not stop at the first coherent explanation; keep pressing plausible alternatives until remaining unknowns would not materially change the read.
 
 Clarifying answers feed exploration, not action. Don't leap to the implied move — not the edit, not even the proposal. Before naming the read, press any remaining branch whose answer would still shift the read. Name the read only when nothing left would meaningfully shift it.
 

--- a/claude-plugins/manifest-dev/skills/figure-out/references/LOG.md
+++ b/claude-plugins/manifest-dev/skills/figure-out/references/LOG.md
@@ -35,9 +35,11 @@ Recommended shape:
 ```md
 ## {UTC timestamp} — {short title}
 
+**Current belief:** {leading read + confidence, when there is one}
 **Evidence:** {refs or quotes}
+**Evidence against / limits:** {disconfirming evidence, weak spots, or why confidence is bounded}
 **Finding / surprise:** {what changed or was learned}
-**Reasoning shift:** {why this matters; omit if unchanged}
+**Belief update:** {how the read shifted; omit if unchanged}
 **Open threads:** {what remains unresolved; omit if none}
 **Next crux:** {the next load-bearing question; omit if not yet clear}
 ```

--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "606b14059621ff74a3951ec93be4337ca37ee4a7",
+  "source_commit": "f9b15229d749d81539508fe7a2e1e308e0287d2f",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-06-01T10:01:01Z"
+  "synced_at": "2026-06-01T11:26:59Z"
 }

--- a/dist/codex/skills/figure-out/SKILL.md
+++ b/dist/codex/skills/figure-out/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: figure-out
 description: 'Figure things out together — any topic, problem, or idea. Presses relentlessly until shared understanding is reached. Use when you need to understand before acting, when figuring it out is the goal, or when the user asks to think through a decision, dig deeper, press an assumption, investigate why something is happening, or work through a problem.'
-argument-hint: '[topic] [--with-docs] [--log [path]]'
+argument-hint: '[topic] [--with-docs] [--log [path]] [--autonomous]'
 user-invocable: true
 ---
 
@@ -12,6 +12,8 @@ Per turn: lead with one question and your recommended answer. Cut empty preamble
 Don't drop threads — when investigation pulls you elsewhere, return to the original question.
 
 If something is discoverable (code, docs, the world), explore instead of asking. Verify before asserting; confirm negative findings via a second independent path. Hold positions under pushback when evidence still supports them.
+
+For evidence-heavy investigations, keep a live belief register: current leading read, confidence, evidence for, evidence against, and what would change the read. Update it whenever evidence shifts. Do not stop at the first coherent explanation; keep pressing plausible alternatives until remaining unknowns would not materially change the read.
 
 Clarifying answers feed exploration, not action. Don't leap to the implied move — not the edit, not even the proposal. Before naming the read, press any remaining branch whose answer would still shift the read. Name the read only when nothing left would meaningfully shift it.
 

--- a/dist/codex/skills/figure-out/references/LOG.md
+++ b/dist/codex/skills/figure-out/references/LOG.md
@@ -35,9 +35,11 @@ Recommended shape:
 ```md
 ## {UTC timestamp} — {short title}
 
+**Current belief:** {leading read + confidence, when there is one}
 **Evidence:** {refs or quotes}
+**Evidence against / limits:** {disconfirming evidence, weak spots, or why confidence is bounded}
 **Finding / surprise:** {what changed or was learned}
-**Reasoning shift:** {why this matters; omit if unchanged}
+**Belief update:** {how the read shifted; omit if unchanged}
 **Open threads:** {what remains unresolved; omit if none}
 **Next crux:** {the next load-bearing question; omit if not yet clear}
 ```

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "606b14059621ff74a3951ec93be4337ca37ee4a7",
+  "source_commit": "f9b15229d749d81539508fe7a2e1e308e0287d2f",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-06-01T10:01:01Z"
+  "synced_at": "2026-06-01T11:26:59Z"
 }

--- a/dist/opencode/skills/figure-out/SKILL.md
+++ b/dist/opencode/skills/figure-out/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: figure-out
 description: 'Figure things out together — any topic, problem, or idea. Presses relentlessly until shared understanding is reached. Use when you need to understand before acting, when figuring it out is the goal, or when the user asks to think through a decision, dig deeper, press an assumption, investigate why something is happening, or work through a problem.'
-argument-hint: '[topic] [--with-docs] [--log [path]]'
+argument-hint: '[topic] [--with-docs] [--log [path]] [--autonomous]'
 user-invocable: true
 ---
 
@@ -12,6 +12,8 @@ Per turn: lead with one question and your recommended answer. Cut empty preamble
 Don't drop threads — when investigation pulls you elsewhere, return to the original question.
 
 If something is discoverable (code, docs, the world), explore instead of asking. Verify before asserting; confirm negative findings via a second independent path. Hold positions under pushback when evidence still supports them.
+
+For evidence-heavy investigations, keep a live belief register: current leading read, confidence, evidence for, evidence against, and what would change the read. Update it whenever evidence shifts. Do not stop at the first coherent explanation; keep pressing plausible alternatives until remaining unknowns would not materially change the read.
 
 Clarifying answers feed exploration, not action. Don't leap to the implied move — not the edit, not even the proposal. Before naming the read, press any remaining branch whose answer would still shift the read. Name the read only when nothing left would meaningfully shift it.
 

--- a/dist/opencode/skills/figure-out/references/LOG.md
+++ b/dist/opencode/skills/figure-out/references/LOG.md
@@ -35,9 +35,11 @@ Recommended shape:
 ```md
 ## {UTC timestamp} — {short title}
 
+**Current belief:** {leading read + confidence, when there is one}
 **Evidence:** {refs or quotes}
+**Evidence against / limits:** {disconfirming evidence, weak spots, or why confidence is bounded}
 **Finding / surprise:** {what changed or was learned}
-**Reasoning shift:** {why this matters; omit if unchanged}
+**Belief update:** {how the read shifted; omit if unchanged}
 **Open threads:** {what remains unresolved; omit if none}
 **Next crux:** {the next load-bearing question; omit if not yet clear}
 ```


### PR DESCRIPTION
## Summary

This tightens the `figure-out` skill’s evidence-heavy investigation behavior without turning it into a rigid checklist.

The core change is a compact “live belief register” rule: when an investigation depends on evidence, the agent should maintain its current leading read, confidence, evidence for, evidence against, and what would change the read. It should update that belief as evidence shifts and avoid stopping at the first coherent explanation while plausible alternatives could still materially change the conclusion.

This is meant to preserve the useful behavior observed in a recent complex investigation: the agent repeatedly revised its hypothesis as new evidence arrived instead of prematurely settling on the first plausible story.

## Changes

- Adds `--autonomous` to the `figure-out` skill argument hint, matching the already-supported runtime behavior documented in the skill body.
- Adds a concise live belief-register rule to `figure-out` for evidence-heavy investigations.
- Updates `figure-out` logging guidance so investigation logs can explicitly capture:
  - Current belief and confidence
  - Evidence
  - Evidence against / limits
  - Finding or surprise
  - Belief update
  - Open threads
  - Next crux
- Bumps the `manifest-dev` plugin version from `2.0.0` to `2.0.1`.
- Syncs the generated Codex and OpenCode distribution copies so they match the canonical Claude plugin source.

## Rationale

The existing `figure-out` skill already pushes for relentless branch exploration, verification before assertion, returning to dropped threads, and delaying synthesis until unresolved branches no longer matter.

The gap was narrower: in evidence-heavy investigations, the skill did not explicitly require belief revision. That matters because agents often converge too early once they find a coherent explanation. The added rule makes the Bayesian-ish loop explicit without adding a long operational procedure:

- keep a leading read,
- attach confidence,
- track supporting and disconfirming evidence,
- state what would change the read,
- update when evidence shifts,
- keep pressing plausible alternatives until remaining uncertainty is no longer decision-relevant.

This keeps the skill’s mentality as “relentless convergence” rather than “mechanical exhaustive enumeration.” It should improve debugging, incident analysis, research, and other evidence-heavy work while still preserving the skill’s usefulness for feature/design shared-understanding sessions.

## Why This Is Right-Sized

This intentionally avoids adding a harness-specific or incident-specific checklist such as querying specific systems, reading Slack, sampling warehouse rows, or inspecting particular services. The desired behavior is portable: belief tracking and evidence-based updating.

The new rule is scoped to “evidence-heavy investigations,” so normal feature-shaping conversations should still behave like collaborative shared-understanding work: identify the next load-bearing question, discuss design branches, surface assumptions, and converge on what should be built.

## Files Changed

- `claude-plugins/manifest-dev/skills/figure-out/SKILL.md`
- `claude-plugins/manifest-dev/skills/figure-out/references/LOG.md`
- `claude-plugins/manifest-dev/.claude-plugin/plugin.json`
- `dist/codex/skills/figure-out/SKILL.md`
- `dist/codex/skills/figure-out/references/LOG.md`
- `dist/codex/.sync-meta.json`
- `dist/opencode/skills/figure-out/SKILL.md`
- `dist/opencode/skills/figure-out/references/LOG.md`
- `dist/opencode/.sync-meta.json`

## Verification

- `.venv/bin/pytest` → `23 passed`
- `ruff check claude-plugins tests dist/codex/install_helpers.py dist/opencode/install_helpers.py` → passed
- `mypy` → passed
- `black --check claude-plugins tests dist/codex/install_helpers.py dist/opencode/install_helpers.py` → passed
- `git diff --check` → passed
- `git diff --cached --check` → passed before commit
- `python3 -m json.tool claude-plugins/manifest-dev/.claude-plugin/plugin.json` → passed
- `cmp` checks confirmed the edited source `figure-out` files are byte-identical to their Codex/OpenCode dist copies

## Notes For Reviewers

The main behavior question is whether the new belief-register sentence is broad enough for all evidence-heavy uses without making feature/design discussions feel over-instrumented. My read is yes: the scope qualifier keeps the Bayesian/evidence machinery out of lightweight shared-understanding conversations, while the existing skill text still covers design branches and commitment questions.
