### PR TITLE
harden-task-file: reconcile to two-parallel-sets model; re-anchor dist sync-meta

### DIFF
--- a/.claude/skills/harden-task-file/SKILL.md
+++ b/.claude/skills/harden-task-file/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harden-task-file
-description: 'Harden /define task guidance files for one-shot quality. Iterates: orthogonality gap analysis, user-approved additions, prompt review, fix, converge. Use when a task file needs comprehensive coverage or "harden task file".'
+description: 'Harden a manifest-dev task guidance file for one-shot quality — either /define''s quality-gate/Default set or figure-out''s probe set. Iterates: orthogonality gap analysis, user-approved additions, prompt review, fix, converge. Use when a task file needs comprehensive coverage or "harden task file".'
 user-invocable: true
 ---
 
@@ -12,18 +12,20 @@ If no arguments, ask which task file to harden.
 
 ## Context
 
-Task files live in `claude-plugins/manifest-dev/skills/define/tasks/` and supplement the /define interview with domain-specific guidance:
+Task files come in two parallel, decoupled sets, each keyed by task type and hardened for one-shot quality. Harden whichever set the target file belongs to:
 
-- **Quality Gates** — Verifiable output properties. Can split into baselines (always enforced) and selectable (meaningful rigor choices)
-- **Risks** — Process failure modes with probe questions
-- **Scenario Prompts** — Pre-mortem fuel: "imagine this deliverable was rejected — what went wrong?"
-- **Trade-offs** — Competing tensions the user resolves during the interview
+- **`/define`'s task files** (`claude-plugins/manifest-dev/skills/define/tasks/`) carry encoder data:
+  - **Quality Gates** — Verifiable output properties. Can split into baselines (always enforced) and selectable (meaningful rigor choices)
+  - **Defaults** — Non-verifiable process practices always worth doing, encoded as PG-* without probing
+- **figure-out's task files** (`claude-plugins/manifest-dev/skills/figure-out/tasks/`) carry probing fuel:
+  - **Blind-spot probes** — Non-natural angles the model skips by default (failure modes, pre-mortem fuel), phrased as the question that opens a branch
+  - **Forced trade-offs** — Competing tensions the model must drive to a decision
 
-New items must match the depth and structural conventions of the parent skill (`skills/define/SKILL.md`) and existing sibling task files.
+New items must match the depth and structural conventions of the owning skill (`define/SKILL.md` or `figure-out/SKILL.md`) and its existing sibling task files.
 
 ## Goal
 
-The task file should be comprehensive enough that a /define interview using it surfaces all criteria needed for one-shot quality. "One-shot" = the deliverable passes review without iteration.
+The task file should be comprehensive enough that a manifest built with it surfaces all criteria needed for one-shot quality — figure-out's probes surface the non-natural angles during understanding; /define's gates and Defaults encode the verifiable bar. "One-shot" = the deliverable passes review without iteration.
 
 ## Log
 
@@ -66,15 +68,15 @@ Converged when criteria in Convergence section met.
 
 ## Section Placement
 
-Each item belongs in exactly one section:
+Each item belongs in exactly one section. A file holds only its own set's sections — a `/define` file never carries probes/trade-offs, a figure-out file never carries gates/Defaults:
 
-| Section | What it checks | Test |
-|---------|---------------|------|
-| Quality Gate (baseline) | Output property that should always be true | Would omitting this ever be acceptable? No → baseline |
-| Quality Gate (selectable) | Output property representing a meaningful rigor choice | Reasonable to skip for some tasks? Yes → selectable |
-| Risk | Process failure mode during execution | About how the work was done, not the output? → risk |
-| Scenario Prompt | Specific way the deliverable fails or gets rejected | "Imagine the reader rejected this because..." → scenario |
-| Trade-off | Competing tension with no universal right answer | Both sides have legitimate merit? → trade-off |
+| Section | Set | What it checks | Test |
+|---------|-----|----------------|------|
+| Quality Gate (baseline) | /define | Output property that should always be true | Would omitting this ever be acceptable? No → baseline |
+| Quality Gate (selectable) | /define | Output property representing a meaningful rigor choice | Reasonable to skip for some tasks? Yes → selectable |
+| Default | /define | Non-verifiable process practice always worth doing | Can't verify from output but always sound? → Default (PG-*) |
+| Blind-spot probe | figure-out | A non-natural failure mode / pre-mortem angle the model skips by default | "Imagine this was rejected because..." AND a capable model wouldn't raise it unprompted? → probe |
+| Forced trade-off | figure-out | Competing tension with no universal right answer | Both sides have legitimate merit? → trade-off |
 
 A concern appears once, in its most natural section. When the same concern appears in multiple sections, keep the stronger version.
 

--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "d5932d4ba533edace79952c09bc1e52674e852b6",
+  "source_commit": "786c700e19edebc04cc7bb724ee1f4e0edc24147",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-06-04T21:39:30Z"
+  "synced_at": "2026-06-04T21:50:08Z"
 }

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "d5932d4ba533edace79952c09bc1e52674e852b6",
+  "source_commit": "786c700e19edebc04cc7bb724ee1f4e0edc24147",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-06-04T21:39:30Z"
+  "synced_at": "2026-06-04T21:50:08Z"
 }


### PR DESCRIPTION
Follow-up to #172 (figure-out domain probing). Two related cleanups flagged during that PR's review.

## harden-task-file reconciled to the two-parallel-sets model

`#172` moved Risks / Scenario Prompts / Trade-offs out of `/define`'s task files (they're now figure-out's **Blind-spot probes** + **Forced trade-offs**); `/define`'s files carry **Quality Gates** + **Defaults**. The `harden-task-file` skill still described the pre-pivot unified model. Updated:
- **description** — now "harden a manifest-dev task guidance file … either /define's quality-gate/Default set or figure-out's probe set".
- **Context** — documents the two parallel, decoupled sets and which content types each carries.
- **Goal** — a manifest built with the file surfaces one-shot-quality criteria (figure-out's probes surface angles; /define's gates+Defaults encode the bar).
- **Section Placement** — table now keyed by set: Quality Gate (baseline/selectable) + Default → `/define`; Blind-spot probe + Forced trade-off → figure-out. Notes that a file holds only its own set's sections.

This is a `.claude`-only skill (not a plugin component), so no version bump and no dist entry.

## Re-anchor dist sync-meta

The `#172` squash-merge left `dist/{opencode,codex}/.sync-meta.json` `source_commit` pointing at a branch SHA that no longer exists in history, which silently forces every future `sync-tools` run into a full re-sync. Verified the dist content is already fully consistent with source — every difference is a designed per-CLI substitution (scratch-path adaptation, agent frontmatter conversion, codex `.toml` agents), no content drift, no orphaned files, deleted `tasks/README.md` index files absent. Re-pointed `source_commit` at the reachable merge commit so diff-first sync works again.

## Verification
`ruff` / `black` / `mypy` clean (markdown-only). No stale pre-pivot terms remain in `harden-task-file`. dist orphan + deleted-file + namespace-completeness checks pass.

https://claude.ai/code/session_011iqfzZo1JLjfFvJ3wK1w6W

---
_Generated by [Claude Code](https://claude.ai/code/session_011iqfzZo1JLjfFvJ3wK1w6W)_