### PR TITLE
fix: dist sync-meta pointer, opencode agent count, ADR index + verify installs function

### DIFF
--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "67a41b72920335408ce75adfbfc14cc4855b8596",
+  "source_commit": "50b2beaac024a6e47628bc779416c0e4fc9735e1",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-06-06T09:51:00Z"
+  "synced_at": "2026-06-06T10:47:53Z"
 }

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "67a41b72920335408ce75adfbfc14cc4855b8596",
+  "source_commit": "50b2beaac024a6e47628bc779416c0e4fc9735e1",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-06-06T09:52:24Z"
+  "synced_at": "2026-06-06T10:47:53Z"
 }

--- a/dist/opencode/install.sh
+++ b/dist/opencode/install.sh
@@ -130,7 +130,7 @@ echo ""
 echo "Components installed to $TARGET/:"
 
 skill_count=$(find "$TARGET/skills" -maxdepth 1 \( -name "*-manifest-dev" -o -name "*-manifest-dev-tools" \) -type d 2>/dev/null | wc -l)
-agent_count=$(find "$TARGET/agents" -maxdepth 1 -name "*-manifest-dev.md" -type f 2>/dev/null | wc -l)
+agent_count=$(find "$TARGET/agents" -maxdepth 1 \( -name "*-manifest-dev.md" -o -name "*-manifest-dev-tools.md" \) -type f 2>/dev/null | wc -l)
 command_count=$(find "$TARGET/commands" -maxdepth 1 \( -name "*-manifest-dev.md" -o -name "*-manifest-dev-tools.md" \) -type f 2>/dev/null | wc -l)
 
 echo "  Skills:   $skill_count"

--- a/dist/pi/.sync-meta.json
+++ b/dist/pi/.sync-meta.json
@@ -1,11 +1,11 @@
 {
-  "source_commit": "67a41b72920335408ce75adfbfc14cc4855b8596",
+  "source_commit": "50b2beaac024a6e47628bc779416c0e4fc9735e1",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
   "target": "pi",
-  "synced_at": "2026-06-06T09:51:11Z",
+  "synced_at": "2026-06-06T10:47:53Z",
   "notes": "Full re-sync (prior recorded SHA 6d34069 unreachable from HEAD; sync-tools SKILL.md and references/pi-cli.md changed since). Pi package target ships shared skills under dist/pi/skills/ plus a source-owned Harness-level Do extension. Runtime owns verifier fanout/outcomes internally, keeps /manifest-do executor prompts implementation-focused, records clean verification orchestration attempts, injects failed gates as follow-up repair work, honors verify.agent/model/phase, multi-repo prompt prepend, durable freshness-bound done gating, resumable blockers, and Pi-native verifier configuration. No dist/pi/agents resource: reviewer/verifier agent prompts are extension-private and source-owned; package.json and pi/extensions/ are source-owned and untouched."
 }

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,5 +13,6 @@ Accepted design decisions for manifest-dev. ADRs are append-only records of why 
 | 2026-06-02 | [Use CI one-shot cadence for babysit-pr](20260602-use-ci-one-shot-cadence-for-babysit-pr.md) | Accepted | PR lifecycle |
 | 2026-06-04 | [figure-out owns domain probing via mirrored probe task files](20260604-figure-out-owns-domain-probing-via-mirrored-task-files.md) | Accepted | Task guidance |
 | 2026-06-05 | [Pi-native runtime package as a source surface](20260605-pi-native-runtime-package-source-surface.md) | Accepted | Pi distribution |
+| 2026-06-05 | [Runtime owns Harness-level Do verification trigger](20260605-runtime-owns-harness-do-verification-trigger.md) | Accepted | Pi runtime |
 | 2026-06-06 | [figure-out provides process trust, kept distinct from define→do's artifact trust](20260606-figure-out-process-trust-vs-define-do-artifact-trust.md) | Accepted | figure-out |
 | 2026-06-06 | [Harden figure-out truth-seeking via inline general-case rigor; defer the independent verification pass](20260606-harden-figure-out-truth-seeking-inline-defer-independent-pass.md) | Accepted | figure-out |


### PR DESCRIPTION
Closes the loose ends flagged after #179 and verifies the CLI distributions actually install and function. **No source files touched** — changes are confined to `dist/` and the ADR index.

## Gaps fixed

1. **`sync-meta` pointed at a squashed-away SHA.** #179 was squash-merged, so the committed `dist/*/.sync-meta.json` `source_commit` (`67a41b7`) is unreachable from `main` — which would force a needless full re-sync next time and breaks the diff-first path. Re-pointed all three CLIs to `50b2bea` (already permanent on `main`, so it survives future squash-merges). Verified **zero source drift** since that SHA → dist is genuinely fully in sync with source.

2. **OpenCode `install.sh` undercounted agents.** `agent_count` globbed only `*-manifest-dev.md`, missing the one `-manifest-dev-tools` agent (`prompt-reviewer`) — printed `Agents: 16` when 17 actually install. Now uses the same two-suffix form as `skill_count`/`command_count` (Codex was already correct). Display-only bug; the install itself always placed all 17.

3. **ADR index missing an entry.** Added `20260605-runtime-owns-harness-do-verification-trigger` to `docs/adr/README.md`.

## Functioning verified

- **Dry-run installs** of OpenCode and Codex into temp roots land 13/17/11 and 13/17 with **correct printed counts**; idempotent re-runs and Codex config-merge/backup work.
- All **TOML / JSON / YAML-frontmatter** parse (62 frontmatters, all agent TOMLs, all `component-namespaces.json` + `.sync-meta.json`).
- **Namespace metadata** covers every distributed component exactly once on all three CLIs (no missing).
- `install.sh` scripts pass `bash -n`; `install_helpers.py` compiles.
- Repo `ruff`/`black`/`mypy` clean.

## Deliberately out of scope

The figure-out design features you chose to defer earlier (independent unanchored pass at autonomous convergence; non-convergence→`/define` router) are **not** touched here — those are a product deferral, not gaps. Say the word if you want them picked up separately.

https://claude.ai/code/session_01Agp2zR84m2eba8bhYJVZZ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Agp2zR84m2eba8bhYJVZZ1)_