### PR TITLE
slack-mrkdwn: correct list guidance, per-send-path strikethrough

### DIFF
--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Tell Claude what done looks like, let it work, check the result. /define interviews you and writes a Manifest \u2014 Deliverables with Acceptance Criteria, Global Invariants, Approach. /do executes the Manifest and verifies inline by spawning a subagent per Acceptance Criterion and Global Invariant. For unattended runs, establish a host-native goal-setting backstop whose completion contract is a manifest gate ledger with fresh PASS evidence for every Acceptance Criterion and Global Invariant; /do owns the manifest-completion backstop when invoked standalone; parent workflows such as /auto own broader continuation contracts whose terminal success is outcome-gated by the manifest and /do verifier ledger, with the autonomous Read bar carried as a phase checkpoint when figure-out runs. /figure-out is the truth-convergent thinking partner /define auto-invokes when the problem space is foggy. /figure-out-team extends that discipline to multi-party async Slack conversations. Verify blocks are three fields \u2014 prompt, model, phase \u2014 verified by a general-purpose subagent that can activate a skill. /auto chains the whole flow autonomously; --babysit <pr-url> tends an existing PR to mergeable without local manifest-dev setup.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/skills/figure-out/references/slack-mrkdwn.md
+++ b/claude-plugins/manifest-dev/skills/figure-out/references/slack-mrkdwn.md
@@ -8,15 +8,15 @@ Slack messages render via `mrkdwn`, not GitHub-flavored markdown. The flavors di
 |--------|--------------|------------------------|
 | Bold | `*bold*` | `**bold**` |
 | Italic | `_italic_` | `*italic*` |
-| Strikethrough | `~strike~` | `~~strike~~` |
+| Strikethrough | `~strike~` — but rendering varies by send path, so verify it in your setup (some paths render `~~strike~~`) | assuming one form works on every send path |
 | Inline code | `` `code` `` | same |
 | Code block | ```` ```code``` ```` (triple backticks) | same |
 | Link with label | `<https://example.com\|label>` | `[label](https://example.com)` |
 | Bare link | `<https://example.com>` or just the URL | bare URL works too |
 | Section title | `*Title*` on its own line (bold; no header syntax) | `# Title`, `## Title` |
 | Blockquote | `> quoted line` | same |
-| Bullet list | `- item` on its own line | same (no special syntax — just hyphens + newlines) |
-| Numbered list | `1. item` on its own line | same |
+| Bullet list | `- item`, each item on its own physical line | items run together on one line — `•` or `-` mid-line is just text |
+| Numbered list | `1. item`, each item on its own physical line | relying on `1.` being parsed — there is no list parsing in mrkdwn |
 | User mention | `<@U123ABC>` | n/a |
 | Channel mention | `<#C123ABC\|name>` | n/a |
 | User group ping | `<!subteam^S123ABC>` | n/a |
@@ -31,6 +31,8 @@ Slack messages render via `mrkdwn`, not GitHub-flavored markdown. The flavors di
 - **GitHub link syntax renders verbatim.** `[label](url)` shows the brackets and parens literally. Use `<url|label>`.
 - **No nested formatting in links.** `<url|*bold label*>` does not render the inner bold; the label is plain text.
 - **Newlines are literal `\n`.** Markdown's two-trailing-spaces newline does not apply; emit real newline characters.
+- **mrkdwn has no list syntax at all.** Slack never parses `- `, `1. `, or `•` into formatted lists in app-published text — list markers are literal characters, and the entire visual list effect comes from real newlines. A marker mid-line does nothing: `_Locked:_• item one • item two` is one run-on blob, and no parser will reflow it. Emit each item as `- item` (or `1. item`) on its own physical line.
+- **Start every item on a fresh line, including the first.** A lead-in label like `*Need a human:*` followed inline by `1. ...` happens to read fine (it's all literal text), but item 1 then hangs off the label's line while items 2+ stand alone. End the label line with a newline, then start each item at the beginning of its own line.
 - **Pipes inside link labels need escaping.** In a link `<url|label>`, a literal `|` in the label breaks parsing — drop or replace it.
 
 ## Source

--- a/dist/codex/plugins/manifest-dev/skills/figure-out/references/slack-mrkdwn.md
+++ b/dist/codex/plugins/manifest-dev/skills/figure-out/references/slack-mrkdwn.md
@@ -8,15 +8,15 @@ Slack messages render via `mrkdwn`, not GitHub-flavored markdown. The flavors di
 |--------|--------------|------------------------|
 | Bold | `*bold*` | `**bold**` |
 | Italic | `_italic_` | `*italic*` |
-| Strikethrough | `~strike~` | `~~strike~~` |
+| Strikethrough | `~strike~` — but rendering varies by send path, so verify it in your setup (some paths render `~~strike~~`) | assuming one form works on every send path |
 | Inline code | `` `code` `` | same |
 | Code block | ```` ```code``` ```` (triple backticks) | same |
 | Link with label | `<https://example.com\|label>` | `[label](https://example.com)` |
 | Bare link | `<https://example.com>` or just the URL | bare URL works too |
 | Section title | `*Title*` on its own line (bold; no header syntax) | `# Title`, `## Title` |
 | Blockquote | `> quoted line` | same |
-| Bullet list | `- item` on its own line | same (no special syntax — just hyphens + newlines) |
-| Numbered list | `1. item` on its own line | same |
+| Bullet list | `- item`, each item on its own physical line | items run together on one line — `•` or `-` mid-line is just text |
+| Numbered list | `1. item`, each item on its own physical line | relying on `1.` being parsed — there is no list parsing in mrkdwn |
 | User mention | `<@U123ABC>` | n/a |
 | Channel mention | `<#C123ABC\|name>` | n/a |
 | User group ping | `<!subteam^S123ABC>` | n/a |
@@ -31,6 +31,8 @@ Slack messages render via `mrkdwn`, not GitHub-flavored markdown. The flavors di
 - **GitHub link syntax renders verbatim.** `[label](url)` shows the brackets and parens literally. Use `<url|label>`.
 - **No nested formatting in links.** `<url|*bold label*>` does not render the inner bold; the label is plain text.
 - **Newlines are literal `\n`.** Markdown's two-trailing-spaces newline does not apply; emit real newline characters.
+- **mrkdwn has no list syntax at all.** Slack never parses `- `, `1. `, or `•` into formatted lists in app-published text — list markers are literal characters, and the entire visual list effect comes from real newlines. A marker mid-line does nothing: `_Locked:_• item one • item two` is one run-on blob, and no parser will reflow it. Emit each item as `- item` (or `1. item`) on its own physical line.
+- **Start every item on a fresh line, including the first.** A lead-in label like `*Need a human:*` followed inline by `1. ...` happens to read fine (it's all literal text), but item 1 then hangs off the label's line while items 2+ stand alone. End the label line with a newline, then start each item at the beginning of its own line.
 - **Pipes inside link labels need escaping.** In a link `<url|label>`, a literal `|` in the label breaks parsing — drop or replace it.
 
 ## Source

--- a/dist/opencode/skills/figure-out/references/slack-mrkdwn.md
+++ b/dist/opencode/skills/figure-out/references/slack-mrkdwn.md
@@ -8,15 +8,15 @@ Slack messages render via `mrkdwn`, not GitHub-flavored markdown. The flavors di
 |--------|--------------|------------------------|
 | Bold | `*bold*` | `**bold**` |
 | Italic | `_italic_` | `*italic*` |
-| Strikethrough | `~strike~` | `~~strike~~` |
+| Strikethrough | `~strike~` — but rendering varies by send path, so verify it in your setup (some paths render `~~strike~~`) | assuming one form works on every send path |
 | Inline code | `` `code` `` | same |
 | Code block | ```` ```code``` ```` (triple backticks) | same |
 | Link with label | `<https://example.com\|label>` | `[label](https://example.com)` |
 | Bare link | `<https://example.com>` or just the URL | bare URL works too |
 | Section title | `*Title*` on its own line (bold; no header syntax) | `# Title`, `## Title` |
 | Blockquote | `> quoted line` | same |
-| Bullet list | `- item` on its own line | same (no special syntax — just hyphens + newlines) |
-| Numbered list | `1. item` on its own line | same |
+| Bullet list | `- item`, each item on its own physical line | items run together on one line — `•` or `-` mid-line is just text |
+| Numbered list | `1. item`, each item on its own physical line | relying on `1.` being parsed — there is no list parsing in mrkdwn |
 | User mention | `<@U123ABC>` | n/a |
 | Channel mention | `<#C123ABC\|name>` | n/a |
 | User group ping | `<!subteam^S123ABC>` | n/a |
@@ -31,6 +31,8 @@ Slack messages render via `mrkdwn`, not GitHub-flavored markdown. The flavors di
 - **GitHub link syntax renders verbatim.** `[label](url)` shows the brackets and parens literally. Use `<url|label>`.
 - **No nested formatting in links.** `<url|*bold label*>` does not render the inner bold; the label is plain text.
 - **Newlines are literal `\n`.** Markdown's two-trailing-spaces newline does not apply; emit real newline characters.
+- **mrkdwn has no list syntax at all.** Slack never parses `- `, `1. `, or `•` into formatted lists in app-published text — list markers are literal characters, and the entire visual list effect comes from real newlines. A marker mid-line does nothing: `_Locked:_• item one • item two` is one run-on blob, and no parser will reflow it. Emit each item as `- item` (or `1. item`) on its own physical line.
+- **Start every item on a fresh line, including the first.** A lead-in label like `*Need a human:*` followed inline by `1. ...` happens to read fine (it's all literal text), but item 1 then hangs off the label's line while items 2+ stand alone. End the label line with a newline, then start each item at the beginning of its own line.
 - **Pipes inside link labels need escaping.** In a link `<url|label>`, a literal `|` in the label breaks parsing — drop or replace it.
 
 ## Source

--- a/dist/pi/skills/figure-out/references/slack-mrkdwn.md
+++ b/dist/pi/skills/figure-out/references/slack-mrkdwn.md
@@ -8,15 +8,15 @@ Slack messages render via `mrkdwn`, not GitHub-flavored markdown. The flavors di
 |--------|--------------|------------------------|
 | Bold | `*bold*` | `**bold**` |
 | Italic | `_italic_` | `*italic*` |
-| Strikethrough | `~strike~` | `~~strike~~` |
+| Strikethrough | `~strike~` — but rendering varies by send path, so verify it in your setup (some paths render `~~strike~~`) | assuming one form works on every send path |
 | Inline code | `` `code` `` | same |
 | Code block | ```` ```code``` ```` (triple backticks) | same |
 | Link with label | `<https://example.com\|label>` | `[label](https://example.com)` |
 | Bare link | `<https://example.com>` or just the URL | bare URL works too |
 | Section title | `*Title*` on its own line (bold; no header syntax) | `# Title`, `## Title` |
 | Blockquote | `> quoted line` | same |
-| Bullet list | `- item` on its own line | same (no special syntax — just hyphens + newlines) |
-| Numbered list | `1. item` on its own line | same |
+| Bullet list | `- item`, each item on its own physical line | items run together on one line — `•` or `-` mid-line is just text |
+| Numbered list | `1. item`, each item on its own physical line | relying on `1.` being parsed — there is no list parsing in mrkdwn |
 | User mention | `<@U123ABC>` | n/a |
 | Channel mention | `<#C123ABC\|name>` | n/a |
 | User group ping | `<!subteam^S123ABC>` | n/a |
@@ -31,6 +31,8 @@ Slack messages render via `mrkdwn`, not GitHub-flavored markdown. The flavors di
 - **GitHub link syntax renders verbatim.** `[label](url)` shows the brackets and parens literally. Use `<url|label>`.
 - **No nested formatting in links.** `<url|*bold label*>` does not render the inner bold; the label is plain text.
 - **Newlines are literal `\n`.** Markdown's two-trailing-spaces newline does not apply; emit real newline characters.
+- **mrkdwn has no list syntax at all.** Slack never parses `- `, `1. `, or `•` into formatted lists in app-published text — list markers are literal characters, and the entire visual list effect comes from real newlines. A marker mid-line does nothing: `_Locked:_• item one • item two` is one run-on blob, and no parser will reflow it. Emit each item as `- item` (or `1. item`) on its own physical line.
+- **Start every item on a fresh line, including the first.** A lead-in label like `*Need a human:*` followed inline by `1. ...` happens to read fine (it's all literal text), but item 1 then hangs off the label's line while items 2+ stand alone. End the label line with a newline, then start each item at the beginning of its own line.
 - **Pipes inside link labels need escaping.** In a link `<url|label>`, a literal `|` in the label breaks parsing — drop or replace it.
 
 ## Source


### PR DESCRIPTION
Correction to the slack mrkdwn instructions, following manual testing.