### PR TITLE
feat(manifest-dev): default-press runtime exercise in verification

### DIFF
--- a/.manifest/verification-by-exercise-2026-06-22.md
+++ b/.manifest/verification-by-exercise-2026-06-22.md
@@ -1,0 +1,174 @@
+# Definition: Verification-by-exercise — task-file encoding
+
+## 1. Intent & Context
+- **Goal:** Make "actually run the new behavior" a default expectation in manifest-dev's workflow, by (a) elevating the verification-design angle to a default press in figure-out's feature/code probes, (b) adding an additive default "exercise" gate to /define's FEATURE task file, and (c) refining /define's CODING E2E encoding rule from blunt "every case → INV-G" to scope-driven granularity. Prompt/guidance-only change to task files — no new skills, no plan-file, no manifest-as-test-list.
+- **Mental Model:** Two surfaces compose. figure-out (understanding) reflexively establishes the *exercise approach* — booted how, risky new paths, test seam present or needed — but NOT the enumerated plan. /define (encoding) turns that approach into gates: an exercise gate alongside the existing inspect gates, with AC-vs-INV chosen by scope. The existing project test-run gate owns breadth; manifest criteria are for what you want independently fix-targeted.
+
+## 2. Approach
+*Initial direction, not rigid plan.*
+
+- **Architecture:** Four task-file edits (markdown), a plugin version bump, README/dist sync. All edits land on the `claude-plugins/manifest-dev/` source files; `.claude/` paths resolve to the same files via symlink. dist/ is regenerated, not hand-edited.
+- **Execution Order:**
+  - D1 (figure-out probes) → D2 (/define FEATURE gate) → D3 (/define CODING rule) → D4 (version + READMEs + dist regen)
+  - Rationale: content edits first so the sync/regen in D4 captures all of them; version bump and dist regen are the closing housekeeping.
+- **Risk Areas:**
+  - [R-1] Over-reach in figure-out probes — turning an awareness probe into a planning agenda, breaking the understanding→encoding boundary. | Detect: change-intent / review-prompt flags scope creep; probe files should stay terse "angles," not steps.
+  - [R-2] FEATURE exercise gate worded as a hard always-on requirement, failing pure-logic/library changes with no runnable surface. | Detect: gate text must carry the conditional-but-default + BLOCKED-when-unbootable shape.
+  - [R-3] dist/ drift — task files changed but dist/ regen skipped, leaving Codex/Pi/OpenCode copies stale. | Detect: post-regen `git status` shows dist/ updated; clean diff after a second regen.
+- **Trade-offs:**
+  - [T-1] Reflex vs cost → Prefer making exercise a *default-when-runnable* expectation (cheap smoke) over a heavy always-comprehensive gate, because comprehensive E2E is too expensive to default and breadth belongs in the suite.
+  - [T-2] figure-out scope → Prefer figure-out establishing *approach only* over producing the full test plan, because the enumerated plan is /define's encoding job and the project guards that boundary.
+
+## 3. Global Invariants
+
+- [INV-G1] Changed task-file guidance is high-quality prompt text (clear, no conflicts, terse, no prescriptive-HOW creep, edges hold).
+  ```yaml
+  verify:
+    prompt: |
+      Activate the manifest-dev-tools:review-prompt skill. Review ONLY the changed task files in this diff:
+      claude-plugins/manifest-dev/skills/figure-out/tasks/{FEATURE,CODING}.md and
+      claude-plugins/manifest-dev/skills/define/tasks/{FEATURE,CODING}.md (git diff origin/main...HEAD).
+      Judge them as guidance prompts: the figure-out probe edits must read as terse awareness angles (not a step-by-step
+      planning agenda), and the /define edits must read as clean encoder data (Quality Gate rows / encoding rules).
+      PASS only if no MEDIUM-or-higher findings. If review-prompt is unavailable, report BLOCKED.
+    phase: 1
+  ```
+- [INV-G2] The change does exactly what the manifest intends — no scope drift, no unrelated edits, no contradiction with the established Read.
+  ```yaml
+  verify:
+    prompt: |
+      Activate the manifest-dev:review-code skill with dimension=change-intent and review the change
+      (git diff origin/main...HEAD). The intended change is THREE things only: (1) elevate verification-design
+      from optional probe to default-press for runnable surfaces in figure-out's FEATURE.md/CODING.md probes
+      (approach only, not full plans); (2) ADD an additive, conditional-but-default "exercise the new behavior"
+      Quality Gate to /define's FEATURE.md — alongside, not replacing, the existing inspect gates; (3) refine
+      /define's CODING.md E2E rule to scope-driven granularity (single-deliverable→AC, cross-cutting→INV-G,
+      broad matrix→suite). PASS only if no LOW-or-higher findings (the diff matches this intent and nothing else
+      material). Report findings with severity.
+    phase: 1
+  ```
+- [INV-G3] Repo conventions honored: edits on `claude-plugins/` source (not `.claude/` copies), manifest-dev plugin version bumped (minor), READMEs synced per the CLAUDE.md checklist where components/capability changed.
+  ```yaml
+  verify:
+    prompt: |
+      Activate the manifest-dev:review-code skill with dimension=context-file-adherence and review the change
+      (git diff origin/main...HEAD) against CLAUDE.md. Confirm: (a) task-file edits are to claude-plugins/manifest-dev/
+      paths, not duplicated direct edits of .claude/ targets; (b) claude-plugins/manifest-dev/.claude-plugin/plugin.json
+      version is bumped by a minor increment from 2.12.0; (c) README sync checklist applied as needed (these are
+      guidance-content changes within existing task files — no new/renamed/removed components — so READMEs may legitimately
+      need no change; flag only a genuine omission). PASS only if no MEDIUM-or-higher findings.
+    phase: 1
+  ```
+- [INV-G4] Lint, format, and typecheck pass.
+  ```yaml
+  verify:
+    prompt: |
+      Run: ruff check claude-plugins/ && black --check claude-plugins/ && mypy
+      PASS only if all three exit clean. On failure, report the failing command and output. BLOCKED if a tool
+      is not installed/available.
+    phase: 2
+  ```
+- [INV-G5] dist/ is regenerated and in sync with the changed source task files (no stale Codex/Pi/OpenCode copies).
+  ```yaml
+  verify:
+    prompt: |
+      Verify dist/ reflects the source task-file changes. The figure-out tasks/FEATURE.md and tasks/CODING.md and the
+      define tasks/FEATURE.md and tasks/CODING.md changes that propagate into dist/ must be present in the corresponding
+      dist/ copies (e.g. dist/codex/plugins/manifest-dev/, dist/pi/, dist/opencode/ as applicable). Method: run the
+      manifest-dev:sync-tools regeneration, then `git status --porcelain dist/` — PASS if, after the executor's own
+      regen, a fresh regen produces NO further dist/ changes (i.e. dist/ is already in sync). FAIL if a fresh regen
+      mutates dist/ (means the executor left it stale). BLOCKED if sync-tools cannot run.
+    phase: 2
+  ```
+
+## 4. Process Guidance
+- [PG-1] Edit the `claude-plugins/manifest-dev/` versions; the `.claude/` paths are symlinks to the same files. Do not duplicate edits.
+- [PG-2] Keep figure-out probe files terse — angles/awareness phrased as the question that opens a branch, not instructions for how to do the work. Strengthen the existing "Verification design" / "Beyond the happy path" hooks; do not add a planning agenda.
+- [PG-3] The new FEATURE exercise gate is additive — leave Requirements traceability / Behavior completeness / Error experience rows intact and unworded-over.
+- [PG-4] Run existing tooling before committing; regenerate dist via sync-tools rather than hand-editing dist/ files.
+- [PG-5] Commit on branch `claude/manifest-dev-verification-bgpkum`; push and open a PR when gates pass.
+
+## 5. Known Assumptions
+- [ASM-1] (auto) Domain encoded as PROMPTING (task-file/guidance prompt edits), not CODING — no executable code changes. | Default: PROMPTING gates (review-prompt + change-intent + context-file-adherence). | Impact if wrong: a code-quality dimension might be under-applied, but the diff is markdown + a version-string bump.
+- [ASM-2] (auto) Minor version bump (2.12.0 → 2.13.0) per CLAUDE.md "new features" tier — task-file capability change. | Default: 2.13.0. | Impact if wrong: wrong semver tier; trivially corrected.
+- [ASM-3] (auto) READMEs likely need no change (no component added/renamed/removed; capability lives inside existing task files). | Default: update only if a genuine reference goes stale. | Impact if wrong: a README sentence drifts; low blast radius.
+- [ASM-4] (auto) Pi package version (`package.json`) NOT bumped — change is shared task-file guidance, not Pi runtime code or Pi-distributed assets. | Default: leave package.json untouched. | Impact if wrong: a stale Pi package version; correctable.
+
+## 6. Deliverables
+
+### Deliverable 1: figure-out probes default-press verification-design
+Strengthen `claude-plugins/manifest-dev/skills/figure-out/tasks/FEATURE.md` and `.../CODING.md` so the verification/exercise angle is a default press before naming a read on a runnable surface — approach only, not a plan.
+
+**Acceptance Criteria:**
+- [AC-1.1] CODING.md probe's "Verification design" and FEATURE.md probe's "Beyond the happy path" are elevated from one optional angle among many to a default press for changes with a runnable surface, establishing the *exercise approach* (booted how, risky new paths, test seam present/needed) while staying terse awareness — not a step-by-step planning agenda, and not the enumerated test plan.
+  ```yaml
+  verify:
+    prompt: |
+      Read claude-plugins/manifest-dev/skills/figure-out/tasks/FEATURE.md and tasks/CODING.md (and the diff,
+      git diff origin/main...HEAD). PASS only if ALL hold: (1) the verification-design / beyond-the-happy-path angle
+      is now framed as a default press for runnable-surface changes (e.g. "by default, before naming the read" or
+      equivalent), not merely one optional probe; (2) it asks for the exercise APPROACH (how the surface is booted /
+      driven, which new paths are risky, whether a test seam exists or must be built) — NOT a full enumerated test
+      plan; (3) the files remain terse awareness angles phrased as questions, not procedural steps (no planning agenda).
+      FAIL if exercise is still just-one-angle, if it prescribes producing the full plan, or if the probe became a
+      step list. Report findings with severity.
+    phase: 1
+  ```
+
+### Deliverable 2: /define FEATURE adds the additive exercise gate
+Add a default Quality Gate to `claude-plugins/manifest-dev/skills/define/tasks/FEATURE.md` requiring the new behavior to be exercised, sitting alongside the existing inspect gates.
+
+**Acceptance Criteria:**
+- [AC-2.1] A new Quality Gate row/entry requires the new behavior to be *exercised* (run the new path, assert the outcome) rather than only confirmed present in the diff; it is additive (the three existing inspect-gate rows remain verbatim); conditional-but-default (fires when a runnable surface exists, auto-skips for pure-logic/library changes with no bootable surface); modality-agnostic (a new integration test that boots+drives the new path is the canonical satisfier, live verifier drive is the fallback); and returns BLOCKED when the surface cannot be booted rather than silently falling back to inspection.
+  ```yaml
+  verify:
+    prompt: |
+      Read claude-plugins/manifest-dev/skills/define/tasks/FEATURE.md (and the diff). PASS only if ALL hold:
+      (1) a NEW Quality Gate exists whose verb is exercise/run-and-assert-outcome, distinct from "implemented/present";
+      (2) the three existing rows (Requirements traceability, Behavior completeness, Error experience) are unchanged
+      (additive, not reworded/replaced); (3) the new gate is explicitly conditional-but-default — default-on when a
+      runnable surface exists, skipped when there is none; (4) it states integration-test-that-boots-the-new-path as
+      canonical satisfier with live drive as fallback; (5) it specifies BLOCKED (not silent inspection) when the surface
+      can't be booted. FAIL if any are missing or if an existing row was reworded. Report findings with severity.
+    phase: 1
+  ```
+
+### Deliverable 3: /define CODING E2E rule → scope-driven granularity
+Replace the blunt "each e2e case → INV-G" rule in `claude-plugins/manifest-dev/skills/define/tasks/CODING.md` with scope-driven granularity.
+
+**Acceptance Criteria:**
+- [AC-3.1] The E2E Verification section no longer says every e2e case gets its own INV-G; instead it routes by scope: single-deliverable behavioral check → deliverable AC (not INV-G); genuinely cross-cutting e2e spanning deliverables → INV-G; comprehensive edge-case matrix → test code under the existing project test-run gate, not enumerated as manifest criteria — and states the principle that manifest criteria are for what you want independently fix-targeted while the suite carries breadth (don't turn the manifest into a test-case list).
+  ```yaml
+  verify:
+    prompt: |
+      Read claude-plugins/manifest-dev/skills/define/tasks/CODING.md (and the diff). PASS only if ALL hold:
+      (1) the old blanket "each e2e test case gets its own INV-G*" guidance is gone/replaced; (2) the new rule routes by
+      SCOPE — single-deliverable behavioral check → deliverable AC; cross-cutting e2e (spans deliverables) → INV-G;
+      broad edge-case matrix → test code under the existing test-run gate, not enumerated manifest criteria;
+      (3) it states the principle "criteria are for what you want independently fix-targeted; the suite is for breadth /
+      don't turn the manifest into a test-case list" (or clear equivalent); (4) E2E phasing guidance (slow/later-phase)
+      is preserved. FAIL if the blunt rule remains or scope routing is absent. Report findings with severity.
+    phase: 1
+  ```
+
+### Deliverable 4: Version bump, README/dist sync
+Close out repo housekeeping so the change is shippable.
+
+**Acceptance Criteria:**
+- [AC-4.1] `claude-plugins/manifest-dev/.claude-plugin/plugin.json` version is bumped one minor step (2.12.0 → 2.13.0).
+  ```yaml
+  verify:
+    prompt: |
+      Read claude-plugins/manifest-dev/.claude-plugin/plugin.json. PASS only if "version" is "2.13.0" (a single minor
+      bump from 2.12.0). FAIL otherwise.
+    phase: 1
+  ```
+- [AC-4.2] dist/ regenerated via sync-tools so downstream CLI copies reflect the source task-file changes; no stale copies remain.
+  ```yaml
+  verify:
+    prompt: |
+      Run the manifest-dev:sync-tools regeneration, then `git status --porcelain dist/`. PASS if a fresh regen leaves
+      dist/ unchanged (already in sync, reflecting the four edited task files where they propagate). FAIL if the fresh
+      regen mutates dist/ (executor left it stale). BLOCKED if sync-tools cannot run.
+    phase: 2
+  ```

--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Tell Claude what done looks like, let it work, check the result. /define interviews you and writes a Manifest — Deliverables with Acceptance Criteria, Global Invariants, Approach. /do executes the Manifest and verifies inline by spawning a subagent per Acceptance Criterion and Global Invariant. For unattended runs, wrap execution in a /goal whose argument is a completion condition (all Acceptance Criteria and Global Invariants PASS) so the host's fresh-model evaluator re-runs turns until done; /define prints a ready-to-copy one. /figure-out is the truth-convergent thinking partner /define auto-invokes when the problem space is foggy. /figure-out-team extends that discipline to multi-party async Slack conversations. Verify blocks are three fields — prompt, model, phase — verified by a general-purpose subagent that can activate a skill. /auto chains the whole flow autonomously; --babysit <pr-url> tends an existing PR to mergeable without local manifest-dev setup.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/skills/define/tasks/CODING.md
+++ b/claude-plugins/manifest-dev/skills/define/tasks/CODING.md
@@ -39,7 +39,13 @@ CLAUDE.md specifies project gates (typecheck, lint, test, format). These become 
 
 ## E2E Verification
 
-**E2E encoding**: E2E verification encodes as Global Invariants (INV-G*), not as deliverable ACs or separate deliverables. Each e2e test case gets its own INV-G*, specifying the scenario and expected outcome.
+**E2E encoding — route by scope, not blanket INV-G**: don't enumerate every e2e case as its own INV-G. Match the encoding to what you want independently fix-targeted:
+
+- **Single-deliverable behavioral check** (the new path of one Deliverable, run end-to-end) → a **deliverable AC** on that Deliverable, not a Global Invariant. It accepts that deliverable's behavior; it isn't a property spanning the whole manifest.
+- **Genuinely cross-cutting e2e** (a scenario that spans multiple Deliverables) → an **INV-G***, specifying the scenario and expected outcome.
+- **Comprehensive edge-case matrix** → **test code under the existing project test-run gate**, not enumerated as manifest criteria.
+
+Principle: **manifest criteria are for what you want independently fix-targeted; the suite is for breadth.** Encode a scenario as its own criterion when an isolated PASS/FAIL gives precise repair targeting; otherwise let the suite carry it. Don't turn the manifest into a test-case list.
 
 **E2E phasing**: E2e tests are slow and often deploy-dependent — assign them a later phase than fast automated checks. Manual e2e goes in an even later phase. Only use manual when automated E2E is truly not feasible and user confirms no test data exists.
 

--- a/claude-plugins/manifest-dev/skills/define/tasks/FEATURE.md
+++ b/claude-plugins/manifest-dev/skills/define/tasks/FEATURE.md
@@ -9,6 +9,9 @@ New functionality: features, APIs, enhancements.
 | Requirements traceability | general-purpose | no MEDIUM+ — every specified requirement maps to implementation; nothing lost between spec and code |
 | Behavior completeness | general-purpose | no MEDIUM+ — all specified use cases and interactions implemented, not just the happy path |
 | Error experience | general-purpose | no MEDIUM+ — feature failures produce clear, actionable feedback to the user, not silent failures or raw stack traces |
+| Behavioral exercise | general-purpose | no MEDIUM+ — the new path is *exercised* (run, asserting the outcome), not just confirmed present in the diff |
+
+The first three gates *inspect* the artifact; **Behavioral exercise** *runs* it — additive, not a substitute, since they catch different failure modes (a case never implemented vs. one implemented but wired wrong / doesn't run). Encode it **conditional-but-default**: emit it by default when the feature has a runnable surface (HTTP/UI/CLI/callable entry point), and skip it for pure-logic or library changes with no bootable surface. It is **modality-agnostic** — a new integration test that boots and drives the new path is the canonical way to satisfy it (durable, preferred); a live verifier drive (boot, exercise, assert, discard) is the fallback for thin-suite repos or bugs that only surface in the real wiring. The verifier returns **BLOCKED** (not a silent fall-back to inspection) when the surface cannot be booted, so the unmet exercise is visible and routed rather than hidden.
 
 ## Defaults
 

--- a/claude-plugins/manifest-dev/skills/figure-out/tasks/CODING.md
+++ b/claude-plugins/manifest-dev/skills/figure-out/tasks/CODING.md
@@ -3,7 +3,7 @@
 Angles that are easy to under-weight on code tasks. Considerations, not an agenda — most won't apply to a given task. Surface the load-bearing ones; ignore the rest. Priority stays yours.
 
 ## Blind-spot probes
-- **Verification design** — How will we know this works? Does the design need a test seam, hook, or observability it doesn't have yet — and would adding that change what we build? (If it's self-verifying, say so and move on.)
+- **Verification design** *(default press when there's a runnable surface)* — Before naming the read, settle the *exercise approach*: how does the new behavior actually get run — booted how, driven how — and which new paths are risky enough to need it? Does the design need a test seam, hook, or observability it doesn't have yet — and would adding that change what we build? Establish the approach, not the enumerated test plan (that's /define's to encode). (Self-verifying, or no runnable surface — say so and move on.)
 - **Failure visibility** — When this breaks in production, how would anyone know? Is there a metric, log, or alert, or does it fail silently?
 - **Consumer blast radius** — Who depends on what's changing, and how do they find out it changed?
 - **Silent regression** — What behavior could change while the existing tests still pass?

--- a/claude-plugins/manifest-dev/skills/figure-out/tasks/FEATURE.md
+++ b/claude-plugins/manifest-dev/skills/figure-out/tasks/FEATURE.md
@@ -3,7 +3,7 @@
 Angles that are easy to under-weight on new functionality. Considerations, not an agenda — most won't apply. Press the load-bearing ones; priority stays yours. Composes with `CODING.md`.
 
 ## Blind-spot probes
-- **Beyond the happy path** — Sharpens the base's verification probe: does the verification cover the feature's real use cases, or just the demo flow?
+- **Beyond the happy path** *(default press when there's a runnable surface)* — Sharpens the base's verification-design probe: is the feature *exercised* — run end-to-end against its real use cases — or only inspected as present in the diff? Settle which new paths get driven, not just the demo flow. Approach, not the enumerated plan.
 - **Partial failure** — What state is left behind if it fails halfway through?
 - **Orphaned resources** — Does this create data or state that grows unbounded with no cleanup path?
 - **Rollback** — If this ships and goes wrong, how is it reversed — flag, migration rollback, manual revert?

--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "fff02a04ed0b4754501f6f890f0168061ce9b02f",
+  "source_commit": "7182baff42c06790853053dd2a336612399e505e",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-06-20T13:47:19Z"
+  "synced_at": "2026-06-22T05:37:58Z"
 }

--- a/dist/codex/plugins/manifest-dev/skills/define/tasks/CODING.md
+++ b/dist/codex/plugins/manifest-dev/skills/define/tasks/CODING.md
@@ -39,7 +39,13 @@ AGENTS.md specifies project gates (typecheck, lint, test, format). These become 
 
 ## E2E Verification
 
-**E2E encoding**: E2E verification encodes as Global Invariants (INV-G*), not as deliverable ACs or separate deliverables. Each e2e test case gets its own INV-G*, specifying the scenario and expected outcome.
+**E2E encoding — route by scope, not blanket INV-G**: don't enumerate every e2e case as its own INV-G. Match the encoding to what you want independently fix-targeted:
+
+- **Single-deliverable behavioral check** (the new path of one Deliverable, run end-to-end) → a **deliverable AC** on that Deliverable, not a Global Invariant. It accepts that deliverable's behavior; it isn't a property spanning the whole manifest.
+- **Genuinely cross-cutting e2e** (a scenario that spans multiple Deliverables) → an **INV-G***, specifying the scenario and expected outcome.
+- **Comprehensive edge-case matrix** → **test code under the existing project test-run gate**, not enumerated as manifest criteria.
+
+Principle: **manifest criteria are for what you want independently fix-targeted; the suite is for breadth.** Encode a scenario as its own criterion when an isolated PASS/FAIL gives precise repair targeting; otherwise let the suite carry it. Don't turn the manifest into a test-case list.
 
 **E2E phasing**: E2e tests are slow and often deploy-dependent — assign them a later phase than fast automated checks. Manual e2e goes in an even later phase. Only use manual when automated E2E is truly not feasible and user confirms no test data exists.
 

--- a/dist/codex/plugins/manifest-dev/skills/define/tasks/FEATURE.md
+++ b/dist/codex/plugins/manifest-dev/skills/define/tasks/FEATURE.md
@@ -9,6 +9,9 @@ New functionality: features, APIs, enhancements.
 | Requirements traceability | general-purpose | no MEDIUM+ — every specified requirement maps to implementation; nothing lost between spec and code |
 | Behavior completeness | general-purpose | no MEDIUM+ — all specified use cases and interactions implemented, not just the happy path |
 | Error experience | general-purpose | no MEDIUM+ — feature failures produce clear, actionable feedback to the user, not silent failures or raw stack traces |
+| Behavioral exercise | general-purpose | no MEDIUM+ — the new path is *exercised* (run, asserting the outcome), not just confirmed present in the diff |
+
+The first three gates *inspect* the artifact; **Behavioral exercise** *runs* it — additive, not a substitute, since they catch different failure modes (a case never implemented vs. one implemented but wired wrong / doesn't run). Encode it **conditional-but-default**: emit it by default when the feature has a runnable surface (HTTP/UI/CLI/callable entry point), and skip it for pure-logic or library changes with no bootable surface. It is **modality-agnostic** — a new integration test that boots and drives the new path is the canonical way to satisfy it (durable, preferred); a live verifier drive (boot, exercise, assert, discard) is the fallback for thin-suite repos or bugs that only surface in the real wiring. The verifier returns **BLOCKED** (not a silent fall-back to inspection) when the surface cannot be booted, so the unmet exercise is visible and routed rather than hidden.
 
 ## Defaults
 

--- a/dist/codex/plugins/manifest-dev/skills/figure-out/tasks/CODING.md
+++ b/dist/codex/plugins/manifest-dev/skills/figure-out/tasks/CODING.md
@@ -3,7 +3,7 @@
 Angles that are easy to under-weight on code tasks. Considerations, not an agenda — most won't apply to a given task. Surface the load-bearing ones; ignore the rest. Priority stays yours.
 
 ## Blind-spot probes
-- **Verification design** — How will we know this works? Does the design need a test seam, hook, or observability it doesn't have yet — and would adding that change what we build? (If it's self-verifying, say so and move on.)
+- **Verification design** *(default press when there's a runnable surface)* — Before naming the read, settle the *exercise approach*: how does the new behavior actually get run — booted how, driven how — and which new paths are risky enough to need it? Does the design need a test seam, hook, or observability it doesn't have yet — and would adding that change what we build? Establish the approach, not the enumerated test plan (that's /define's to encode). (Self-verifying, or no runnable surface — say so and move on.)
 - **Failure visibility** — When this breaks in production, how would anyone know? Is there a metric, log, or alert, or does it fail silently?
 - **Consumer blast radius** — Who depends on what's changing, and how do they find out it changed?
 - **Silent regression** — What behavior could change while the existing tests still pass?

--- a/dist/codex/plugins/manifest-dev/skills/figure-out/tasks/FEATURE.md
+++ b/dist/codex/plugins/manifest-dev/skills/figure-out/tasks/FEATURE.md
@@ -3,7 +3,7 @@
 Angles that are easy to under-weight on new functionality. Considerations, not an agenda — most won't apply. Press the load-bearing ones; priority stays yours. Composes with `CODING.md`.
 
 ## Blind-spot probes
-- **Beyond the happy path** — Sharpens the base's verification probe: does the verification cover the feature's real use cases, or just the demo flow?
+- **Beyond the happy path** *(default press when there's a runnable surface)* — Sharpens the base's verification-design probe: is the feature *exercised* — run end-to-end against its real use cases — or only inspected as present in the diff? Settle which new paths get driven, not just the demo flow. Approach, not the enumerated plan.
 - **Partial failure** — What state is left behind if it fails halfway through?
 - **Orphaned resources** — Does this create data or state that grows unbounded with no cleanup path?
 - **Rollback** — If this ships and goes wrong, how is it reversed — flag, migration rollback, manual revert?

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,10 +1,10 @@
 {
-  "source_commit": "fff02a04ed0b4754501f6f890f0168061ce9b02f",
+  "source_commit": "7182baff42c06790853053dd2a336612399e505e",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-06-20T13:47:19Z",
+  "synced_at": "2026-06-22T05:37:58Z",
   "notes": "Plugin-native OpenCode distribution with package-local skills registered via skills.paths, package-local AGENTS.md registered via instructions, and plugin-owned cfg.command wrappers for source user-invocable skills. No installer, no component-namespaces.json, and no generated/copied command files. Current upstream OpenCode exposes skills through the skill tool; slash autocomplete is command-backed, so the plugin registers wrappers dynamically from bundled SKILL.md frontmatter while preserving existing user/project commands."
 }

--- a/dist/opencode/plugin/package.json
+++ b/dist/opencode/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doodledood/manifest-dev-opencode",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "OpenCode plugin that registers the manifest-dev skills payload, user-invocable slash-command wrappers, and AGENTS.md context from this repo clone. Install by adding this directory's path to the `plugin` array in opencode.json.",
   "type": "module",
   "main": "index.js",

--- a/dist/opencode/skills/define/tasks/CODING.md
+++ b/dist/opencode/skills/define/tasks/CODING.md
@@ -31,7 +31,7 @@ Each gate is a **dimension** of the `review-code` skill (one ref per dimension, 
 | Contract correctness | contracts | no LOW+ | When code calls external/internal APIs, changes public interfaces, or crosses service boundaries |
 | Type safety | type-safety | no LOW+ | When using typed languages (TypeScript, Python with type hints, Java/Kotlin, Go, Rust, C#) |
 
-**Encoding:** each dimension gate is verified by a general-purpose subagent (there is no `verify.agent` field) whose `verify.prompt` tells that verifier to **activate** the `review-code` skill for the dimension at the row's threshold — e.g. *"Activate the review-code skill with dimension=code-bugs and review the change. PASS only if no LOW-or-higher findings."* (Do not say "spawn a general-purpose agent" — the verifier already is one; a nested spawn drops the PASS/FAIL/BLOCKED contract.) See `define/SKILL.md` → "Encoding gates".
+**Encoding:** each dimension gate is verified by a general-purpose subagent (there is no `verify.agent` field) whose `verify.prompt` tells that verifier to **activate** the `manifest-dev:review-code` skill for the dimension at the row's threshold — e.g. *"Activate the manifest-dev:review-code skill with dimension=code-bugs and review the change. PASS only if no LOW-or-higher findings."* (Do not say "spawn a general-purpose agent" — the verifier already is one; a nested spawn drops the PASS/FAIL/BLOCKED contract.) See `define/SKILL.md` → "Encoding gates".
 
 ## Project Gates
 
@@ -39,7 +39,13 @@ AGENTS.md specifies project gates (typecheck, lint, test, format). These become 
 
 ## E2E Verification
 
-**E2E encoding**: E2E verification encodes as Global Invariants (INV-G*), not as deliverable ACs or separate deliverables. Each e2e test case gets its own INV-G*, specifying the scenario and expected outcome.
+**E2E encoding — route by scope, not blanket INV-G**: don't enumerate every e2e case as its own INV-G. Match the encoding to what you want independently fix-targeted:
+
+- **Single-deliverable behavioral check** (the new path of one Deliverable, run end-to-end) → a **deliverable AC** on that Deliverable, not a Global Invariant. It accepts that deliverable's behavior; it isn't a property spanning the whole manifest.
+- **Genuinely cross-cutting e2e** (a scenario that spans multiple Deliverables) → an **INV-G***, specifying the scenario and expected outcome.
+- **Comprehensive edge-case matrix** → **test code under the existing project test-run gate**, not enumerated as manifest criteria.
+
+Principle: **manifest criteria are for what you want independently fix-targeted; the suite is for breadth.** Encode a scenario as its own criterion when an isolated PASS/FAIL gives precise repair targeting; otherwise let the suite carry it. Don't turn the manifest into a test-case list.
 
 **E2E phasing**: E2e tests are slow and often deploy-dependent — assign them a later phase than fast automated checks. Manual e2e goes in an even later phase. Only use manual when automated E2E is truly not feasible and user confirms no test data exists.
 

--- a/dist/opencode/skills/define/tasks/FEATURE.md
+++ b/dist/opencode/skills/define/tasks/FEATURE.md
@@ -9,6 +9,9 @@ New functionality: features, APIs, enhancements.
 | Requirements traceability | general-purpose | no MEDIUM+ — every specified requirement maps to implementation; nothing lost between spec and code |
 | Behavior completeness | general-purpose | no MEDIUM+ — all specified use cases and interactions implemented, not just the happy path |
 | Error experience | general-purpose | no MEDIUM+ — feature failures produce clear, actionable feedback to the user, not silent failures or raw stack traces |
+| Behavioral exercise | general-purpose | no MEDIUM+ — the new path is *exercised* (run, asserting the outcome), not just confirmed present in the diff |
+
+The first three gates *inspect* the artifact; **Behavioral exercise** *runs* it — additive, not a substitute, since they catch different failure modes (a case never implemented vs. one implemented but wired wrong / doesn't run). Encode it **conditional-but-default**: emit it by default when the feature has a runnable surface (HTTP/UI/CLI/callable entry point), and skip it for pure-logic or library changes with no bootable surface. It is **modality-agnostic** — a new integration test that boots and drives the new path is the canonical way to satisfy it (durable, preferred); a live verifier drive (boot, exercise, assert, discard) is the fallback for thin-suite repos or bugs that only surface in the real wiring. The verifier returns **BLOCKED** (not a silent fall-back to inspection) when the surface cannot be booted, so the unmet exercise is visible and routed rather than hidden.
 
 ## Defaults
 

--- a/dist/opencode/skills/figure-out/tasks/CODING.md
+++ b/dist/opencode/skills/figure-out/tasks/CODING.md
@@ -3,7 +3,7 @@
 Angles that are easy to under-weight on code tasks. Considerations, not an agenda — most won't apply to a given task. Surface the load-bearing ones; ignore the rest. Priority stays yours.
 
 ## Blind-spot probes
-- **Verification design** — How will we know this works? Does the design need a test seam, hook, or observability it doesn't have yet — and would adding that change what we build? (If it's self-verifying, say so and move on.)
+- **Verification design** *(default press when there's a runnable surface)* — Before naming the read, settle the *exercise approach*: how does the new behavior actually get run — booted how, driven how — and which new paths are risky enough to need it? Does the design need a test seam, hook, or observability it doesn't have yet — and would adding that change what we build? Establish the approach, not the enumerated test plan (that's /define's to encode). (Self-verifying, or no runnable surface — say so and move on.)
 - **Failure visibility** — When this breaks in production, how would anyone know? Is there a metric, log, or alert, or does it fail silently?
 - **Consumer blast radius** — Who depends on what's changing, and how do they find out it changed?
 - **Silent regression** — What behavior could change while the existing tests still pass?

--- a/dist/opencode/skills/figure-out/tasks/FEATURE.md
+++ b/dist/opencode/skills/figure-out/tasks/FEATURE.md
@@ -3,7 +3,7 @@
 Angles that are easy to under-weight on new functionality. Considerations, not an agenda — most won't apply. Press the load-bearing ones; priority stays yours. Composes with `CODING.md`.
 
 ## Blind-spot probes
-- **Beyond the happy path** — Sharpens the base's verification probe: does the verification cover the feature's real use cases, or just the demo flow?
+- **Beyond the happy path** *(default press when there's a runnable surface)* — Sharpens the base's verification-design probe: is the feature *exercised* — run end-to-end against its real use cases — or only inspected as present in the diff? Settle which new paths get driven, not just the demo flow. Approach, not the enumerated plan.
 - **Partial failure** — What state is left behind if it fails halfway through?
 - **Orphaned resources** — Does this create data or state that grows unbounded with no cleanup path?
 - **Rollback** — If this ships and goes wrong, how is it reversed — flag, migration rollback, manual revert?

--- a/dist/pi/.sync-meta.json
+++ b/dist/pi/.sync-meta.json
@@ -1,11 +1,11 @@
 {
-  "source_commit": "fff02a04ed0b4754501f6f890f0168061ce9b02f",
+  "source_commit": "7182baff42c06790853053dd2a336612399e505e",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
   "target": "pi",
-  "synced_at": "2026-06-20T13:47:19Z",
+  "synced_at": "2026-06-22T05:37:58Z",
   "notes": "Full re-sync of the Pi target. dist/pi/skills/ regenerated from source as the compatible shared-skill set of exactly 13 skills: from manifest-dev (core) check-pr, define, figure-out, figure-out-team, poll-slack, review-code; from manifest-dev-tools adr, handoff, prompt-engineering, review-pr, review-prompt, teach-me, walk-pr. Excluded per pi-cli.md: do/done/escalate (runtime-owned outcomes) and auto/babysit-pr (extension-command wrappers). Body adaptation applied to define's completion handoff template and Pi-only skill id stripping: dropped the Claude 'Session: ~/.claude/projects/<dir>/${CLAUDE_SESSION_ID}.jsonl' line (Pi has no per-session file the agent locates at runtime) and the multi-line '/goal' unattended-execution backstop block wherever it appears (define's handoff and figure-out's autonomous.md; Pi has no /goal command); the '/do <manifest-path>' foreground handoff line is kept and resolves to the native Pi extension command; plugin-qualified skill ids are stripped to bare Pi skill names. review-code's 13 dimension references preserved. No agents anywhere (manifest-dev ships none): component-namespaces.json records agents == {} with an agents_note, and Pi verification is runtime-owned JSON subprocess fanout whose verify.prompt can activate a skill (no verify.agent field). component-namespaces.json skills map exactly equals the 13 skills with core/tools ownership; keeps runtime_owned_skills (do/done/escalate), extension_wrappers (auto/babysit-pr), commands (do/auto/babysit-pr), tools {}, runtime_internal, and empty runtime_dependencies. README reflects the two-package runtime (@doodledood/manifest-dev-pi for /do and /auto plus the shared Harness-level Do runtime; @doodledood/manifest-dev-pi-tools for /babysit-pr), shared skills, no verify.agent field, no --manifest-verifier-agent flag, install via 'pi install git:github.com/doodledood/manifest-dev@main', and manifest-dev-owned JSON subprocess verifier fanout with no separate verifier fanout package required. Repo-root package.json and pi/extensions/ left source-owned."
 }

--- a/dist/pi/skills/define/tasks/CODING.md
+++ b/dist/pi/skills/define/tasks/CODING.md
@@ -31,7 +31,7 @@ Each gate is a **dimension** of the `review-code` skill (one ref per dimension, 
 | Contract correctness | contracts | no LOW+ | When code calls external/internal APIs, changes public interfaces, or crosses service boundaries |
 | Type safety | type-safety | no LOW+ | When using typed languages (TypeScript, Python with type hints, Java/Kotlin, Go, Rust, C#) |
 
-**Encoding:** each dimension gate is verified by a general-purpose subagent (there is no `verify.agent` field) whose `verify.prompt` tells that verifier to **activate** the `review-code` skill for the dimension at the row's threshold — e.g. *"Activate the review-code skill with dimension=code-bugs and review the change. PASS only if no LOW-or-higher findings."* (Do not say "spawn a general-purpose agent" — the verifier already is one; a nested spawn drops the PASS/FAIL/BLOCKED contract.) See `define/SKILL.md` → "Encoding gates".
+**Encoding:** each dimension gate is verified by a general-purpose subagent (there is no `verify.agent` field) whose `verify.prompt` tells that verifier to **activate** the `manifest-dev:review-code` skill for the dimension at the row's threshold — e.g. *"Activate the manifest-dev:review-code skill with dimension=code-bugs and review the change. PASS only if no LOW-or-higher findings."* (Do not say "spawn a general-purpose agent" — the verifier already is one; a nested spawn drops the PASS/FAIL/BLOCKED contract.) See `define/SKILL.md` → "Encoding gates".
 
 ## Project Gates
 
@@ -39,7 +39,13 @@ CLAUDE.md specifies project gates (typecheck, lint, test, format). These become 
 
 ## E2E Verification
 
-**E2E encoding**: E2E verification encodes as Global Invariants (INV-G*), not as deliverable ACs or separate deliverables. Each e2e test case gets its own INV-G*, specifying the scenario and expected outcome.
+**E2E encoding — route by scope, not blanket INV-G**: don't enumerate every e2e case as its own INV-G. Match the encoding to what you want independently fix-targeted:
+
+- **Single-deliverable behavioral check** (the new path of one Deliverable, run end-to-end) → a **deliverable AC** on that Deliverable, not a Global Invariant. It accepts that deliverable's behavior; it isn't a property spanning the whole manifest.
+- **Genuinely cross-cutting e2e** (a scenario that spans multiple Deliverables) → an **INV-G***, specifying the scenario and expected outcome.
+- **Comprehensive edge-case matrix** → **test code under the existing project test-run gate**, not enumerated as manifest criteria.
+
+Principle: **manifest criteria are for what you want independently fix-targeted; the suite is for breadth.** Encode a scenario as its own criterion when an isolated PASS/FAIL gives precise repair targeting; otherwise let the suite carry it. Don't turn the manifest into a test-case list.
 
 **E2E phasing**: E2e tests are slow and often deploy-dependent — assign them a later phase than fast automated checks. Manual e2e goes in an even later phase. Only use manual when automated E2E is truly not feasible and user confirms no test data exists.
 

--- a/dist/pi/skills/define/tasks/FEATURE.md
+++ b/dist/pi/skills/define/tasks/FEATURE.md
@@ -9,6 +9,9 @@ New functionality: features, APIs, enhancements.
 | Requirements traceability | general-purpose | no MEDIUM+ — every specified requirement maps to implementation; nothing lost between spec and code |
 | Behavior completeness | general-purpose | no MEDIUM+ — all specified use cases and interactions implemented, not just the happy path |
 | Error experience | general-purpose | no MEDIUM+ — feature failures produce clear, actionable feedback to the user, not silent failures or raw stack traces |
+| Behavioral exercise | general-purpose | no MEDIUM+ — the new path is *exercised* (run, asserting the outcome), not just confirmed present in the diff |
+
+The first three gates *inspect* the artifact; **Behavioral exercise** *runs* it — additive, not a substitute, since they catch different failure modes (a case never implemented vs. one implemented but wired wrong / doesn't run). Encode it **conditional-but-default**: emit it by default when the feature has a runnable surface (HTTP/UI/CLI/callable entry point), and skip it for pure-logic or library changes with no bootable surface. It is **modality-agnostic** — a new integration test that boots and drives the new path is the canonical way to satisfy it (durable, preferred); a live verifier drive (boot, exercise, assert, discard) is the fallback for thin-suite repos or bugs that only surface in the real wiring. The verifier returns **BLOCKED** (not a silent fall-back to inspection) when the surface cannot be booted, so the unmet exercise is visible and routed rather than hidden.
 
 ## Defaults
 

--- a/dist/pi/skills/figure-out/tasks/CODING.md
+++ b/dist/pi/skills/figure-out/tasks/CODING.md
@@ -3,7 +3,7 @@
 Angles that are easy to under-weight on code tasks. Considerations, not an agenda — most won't apply to a given task. Surface the load-bearing ones; ignore the rest. Priority stays yours.
 
 ## Blind-spot probes
-- **Verification design** — How will we know this works? Does the design need a test seam, hook, or observability it doesn't have yet — and would adding that change what we build? (If it's self-verifying, say so and move on.)
+- **Verification design** *(default press when there's a runnable surface)* — Before naming the read, settle the *exercise approach*: how does the new behavior actually get run — booted how, driven how — and which new paths are risky enough to need it? Does the design need a test seam, hook, or observability it doesn't have yet — and would adding that change what we build? Establish the approach, not the enumerated test plan (that's /define's to encode). (Self-verifying, or no runnable surface — say so and move on.)
 - **Failure visibility** — When this breaks in production, how would anyone know? Is there a metric, log, or alert, or does it fail silently?
 - **Consumer blast radius** — Who depends on what's changing, and how do they find out it changed?
 - **Silent regression** — What behavior could change while the existing tests still pass?

--- a/dist/pi/skills/figure-out/tasks/FEATURE.md
+++ b/dist/pi/skills/figure-out/tasks/FEATURE.md
@@ -3,7 +3,7 @@
 Angles that are easy to under-weight on new functionality. Considerations, not an agenda — most won't apply. Press the load-bearing ones; priority stays yours. Composes with `CODING.md`.
 
 ## Blind-spot probes
-- **Beyond the happy path** — Sharpens the base's verification probe: does the verification cover the feature's real use cases, or just the demo flow?
+- **Beyond the happy path** *(default press when there's a runnable surface)* — Sharpens the base's verification-design probe: is the feature *exercised* — run end-to-end against its real use cases — or only inspected as present in the diff? Settle which new paths get driven, not just the demo flow. Approach, not the enumerated plan.
 - **Partial failure** — What state is left behind if it fails halfway through?
 - **Orphaned resources** — Does this create data or state that grows unbounded with no cleanup path?
 - **Rollback** — If this ships and goes wrong, how is it reversed — flag, migration rollback, manual revert?


### PR DESCRIPTION
## What & why

Makes **"actually run the new behavior"** a default expectation across the manifest-dev workflow. Today verification defaults to *artifact-centric* checks: `review-code` is read-only/diff-scoped, and runtime exercise (E2E) is framed as a conditional, slow, later-phase opt-in. That leaves a real bug class under-covered by default — defects green on static review *and* the existing unit suite, visible only when the **new** path is actually driven (route-ordering, wired-but-broken).

Reached via a `/figure-out` session. The fix is deliberately small — three task-file guidance changes, **no new skills, no plan-file, no manifest-as-test-list**.

## Changes

1. **figure-out probes** (`skills/figure-out/tasks/FEATURE.md`, `CODING.md`) — elevate the verification-design angle from one optional probe to a **default press when there's a runnable surface**. figure-out establishes the *exercise approach* (booted how, which new paths are risky, is there a test seam) — **not** the enumerated plan, which stays `/define`'s job. Probes remain terse awareness angles.

2. **`/define` FEATURE** (`skills/define/tasks/FEATURE.md`) — add an **additive** "Behavioral exercise" Quality Gate that *runs* the new path and asserts the outcome, alongside (not replacing) the three existing inspect gates. Conditional-but-default (fires when a runnable surface exists, skips for pure-logic/library changes), modality-agnostic (a new integration test that boots+drives the path is canonical; live verifier drive is the fallback), and returns **BLOCKED** rather than silently falling back to inspection when the surface can't be booted.

3. **`/define` CODING** (`skills/define/tasks/CODING.md`) — replace the blunt "each e2e case → INV-G" rule with **scope-driven routing**: single-deliverable behavioral check → deliverable AC; cross-cutting e2e → INV-G; broad edge-case matrix → test code under the existing project test-run gate. Principle: *manifest criteria are for what you want independently fix-targeted; the suite is for breadth.*

Plus: bump `manifest-dev` 2.12.0 → 2.13.0, regenerate `dist/` for all CLIs (Codex/OpenCode/Pi), archive the manifest under `.manifest/`.

## Verification

Built and verified via `/auto` (figure-out → define → do). All 10 manifest gates PASS — change-intent, prompt quality (review-prompt), CLAUDE.md adherence, per-deliverable content ACs, version bump, lint/format/typecheck (ruff/black/mypy), and dist-in-sync (idempotent re-sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1ebGWvHfk27YjzEXUPuk5

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1ebGWvHfk27YjzEXUPuk5)_