### PR TITLE
Bump plugin versions for fog discipline; recover fog on log resume

### DIFF
--- a/claude-plugins/manifest-dev/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Tell Claude what done looks like, let it work, check the result. /define interviews you and writes a Manifest — Deliverables with Acceptance Criteria, Global Invariants, Approach. /do executes the Manifest and verifies inline by spawning a subagent per Acceptance Criterion and Global Invariant. For unattended runs, establish a host-native goal-setting backstop whose completion contract is a manifest gate ledger with fresh PASS evidence for every Acceptance Criterion and Global Invariant; /do owns the manifest-completion backstop when invoked standalone; parent workflows such as /auto own broader continuation contracts whose terminal success is outcome-gated by the manifest and /do verifier ledger, with the autonomous Read bar carried as a phase checkpoint when figure-out runs. /figure-out is the truth-convergent thinking partner /define auto-invokes when the problem space is foggy. /figure-out-team extends that discipline to multi-party async Slack conversations. Verify blocks are three fields — prompt, model, phase — verified by a general-purpose subagent that can activate a skill. /auto chains the whole flow autonomously; --babysit <pr-url> tends an existing PR to mergeable without local manifest-dev setup.",
   "keywords": [
     "manifest",

--- a/claude-plugins/manifest-dev/skills/figure-out/references/LOG.md
+++ b/claude-plugins/manifest-dev/skills/figure-out/references/LOG.md
@@ -16,7 +16,7 @@ Append only. Never rewrite, reorder, compress, or delete prior entries. If an ol
 
 Append after each meaningful user turn or evidence-gathering pass, before asking the next question. Meaningful means the investigation gained evidence, found a surprise, changed its read, opened or closed a thread, or identified a new crux. Skip pure acknowledgements and empty procedural chatter.
 
-When resuming an existing log, read enough of it to recover open threads and the current line of investigation before pressing forward.
+When resuming an existing log, read enough of it to recover open threads, fog, and the current line of investigation before pressing forward.
 
 ## Entry Shape
 

--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "da8b59b20bd348f101cc25b1ffabb4fe28eab08e",
+  "source_commit": "f53474c45a7791ef45a839d982083708b75b47da",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-07-03T13:18:45Z"
+  "synced_at": "2026-07-03T14:04:20Z"
 }

--- a/dist/codex/plugins/manifest-dev/.codex-plugin/plugin.json
+++ b/dist/codex/plugins/manifest-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev",
-  "version": "3.0.2",
+  "version": "3.2.0",
   "description": "Manifest-driven workflows for Codex: /define interviews and writes a Manifest; /do executes it and verifies inline. Includes the review-code skill (one quality dimension per invocation).",
   "skills": "./skills/",
   "keywords": [

--- a/dist/codex/plugins/manifest-dev/skills/figure-out/references/LOG.md
+++ b/dist/codex/plugins/manifest-dev/skills/figure-out/references/LOG.md
@@ -16,7 +16,7 @@ Append only. Never rewrite, reorder, compress, or delete prior entries. If an ol
 
 Append after each meaningful user turn or evidence-gathering pass, before asking the next question. Meaningful means the investigation gained evidence, found a surprise, changed its read, opened or closed a thread, or identified a new crux. Skip pure acknowledgements and empty procedural chatter.
 
-When resuming an existing log, read enough of it to recover open threads and the current line of investigation before pressing forward.
+When resuming an existing log, read enough of it to recover open threads, fog, and the current line of investigation before pressing forward.
 
 ## Entry Shape
 

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,10 +1,10 @@
 {
-  "source_commit": "da8b59b20bd348f101cc25b1ffabb4fe28eab08e",
+  "source_commit": "f53474c45a7791ef45a839d982083708b75b47da",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-07-03T13:18:45Z",
+  "synced_at": "2026-07-03T14:04:20Z",
   "notes": "Plugin-native OpenCode distribution with package-local skills registered via skills.paths, package-local AGENTS.md registered via instructions, and plugin-owned cfg.command wrappers for source user-invocable skills. Universal goal-setting backstop guidance is preserved as capability language; no target-only /goal rule is introduced."
 }

--- a/dist/opencode/plugin/package.json
+++ b/dist/opencode/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doodledood/manifest-dev-opencode",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "OpenCode plugin that registers the manifest-dev skills payload, user-invocable slash-command wrappers, and AGENTS.md context from this repo clone. Install by adding this directory's path to the `plugin` array in opencode.json.",
   "type": "module",
   "main": "index.js",

--- a/dist/opencode/skills/figure-out/references/LOG.md
+++ b/dist/opencode/skills/figure-out/references/LOG.md
@@ -16,7 +16,7 @@ Append only. Never rewrite, reorder, compress, or delete prior entries. If an ol
 
 Append after each meaningful user turn or evidence-gathering pass, before asking the next question. Meaningful means the investigation gained evidence, found a surprise, changed its read, opened or closed a thread, or identified a new crux. Skip pure acknowledgements and empty procedural chatter.
 
-When resuming an existing log, read enough of it to recover open threads and the current line of investigation before pressing forward.
+When resuming an existing log, read enough of it to recover open threads, fog, and the current line of investigation before pressing forward.
 
 ## Entry Shape
 

--- a/dist/pi/.sync-meta.json
+++ b/dist/pi/.sync-meta.json
@@ -1,11 +1,11 @@
 {
-  "source_commit": "da8b59b20bd348f101cc25b1ffabb4fe28eab08e",
+  "source_commit": "f53474c45a7791ef45a839d982083708b75b47da",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
   "target": "pi",
-  "synced_at": "2026-07-03T13:18:45Z",
+  "synced_at": "2026-07-03T14:04:20Z",
   "notes": "Targeted Pi sync for skill-only package architecture. dist/pi ships the full compatible workflow skill set plus prompt-template aliases for /do, /auto, and /babysit-pr. Body adaptation applied: Claude session JSONL line omitted where applicable, plugin-qualified skill ids stripped to bare names, and universal goal-setting backstop guidance preserved in mechanism-neutral wording. Pi no longer ships manifest-dev TypeScript extensions, package-owned verifier scheduling, package-owned done/escalation gates, verifier-only flags, or a tools subpackage. Repo-root package.json is source-owned and loads dist/pi skills/prompts."
 }

--- a/dist/pi/skills/figure-out/references/LOG.md
+++ b/dist/pi/skills/figure-out/references/LOG.md
@@ -16,7 +16,7 @@ Append only. Never rewrite, reorder, compress, or delete prior entries. If an ol
 
 Append after each meaningful user turn or evidence-gathering pass, before asking the next question. Meaningful means the investigation gained evidence, found a surprise, changed its read, opened or closed a thread, or identified a new crux. Skip pure acknowledgements and empty procedural chatter.
 
-When resuming an existing log, read enough of it to recover open threads and the current line of investigation before pressing forward.
+When resuming an existing log, read enough of it to recover open threads, fog, and the current line of investigation before pressing forward.
 
 ## Entry Shape
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doodledood/manifest-dev-pi",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "private": true,
   "description": "Pi package surface for manifest-dev shared skills and prompt-template aliases (/do, /auto, /babysit-pr).",
   "type": "module",


### PR DESCRIPTION
Follow-up to #211, which shipped the fog-discipline feature set without version bumps.

**Version bumps**
- `claude-plugins/manifest-dev/.claude-plugin/plugin.json`: 3.1.0 → **3.2.0** (feature-level change: fog behavior line, sharp/fog log split, ADR publication-boundary rule, Fog glossary term)
- `dist/opencode/plugin/package.json`: 3.1.0 → **3.2.0** (mirrors source per sync rule)
- `dist/codex/plugins/manifest-dev/.codex-plugin/plugin.json`: 3.0.2 → **3.2.0** (was already lagging behind source; aligned)
- root `package.json` (Pi package surface): 1.0.3 → **1.1.0** (its `dist/pi` skill resources gained the feature)
- `manifest-dev-tools` (1.0.1): untouched — its payload didn't change in #211

**One-line fix** (change-intent reviewer catch, post-merge): `references/LOG.md`'s resume instruction predated the sharp/fog split and told a resuming session to recover only "open threads" — now narrowed to sharp-only, which definitionally excluded fog from resume recovery, the exact loss the split exists to prevent. Now reads "recover open threads, fog, and the current line of investigation". Propagated verbatim to all three dist targets with sync-meta refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019P6DKzDCksXdqsVCYuBe95

---
_Generated by [Claude Code](https://claude.ai/code/session_019P6DKzDCksXdqsVCYuBe95)_