### PR TITLE
sync-tools: re-stamp sync-meta source_commit to a main-reachable SHA

### DIFF
--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,9 +1,9 @@
 {
-  "source_commit": "f53474c45a7791ef45a839d982083708b75b47da",
+  "source_commit": "4b014ebef32253524dccbcbb2ca0dec6b73041bf",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-07-03T14:04:20Z"
+  "synced_at": "2026-07-03T14:21:00Z"
 }

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,10 +1,10 @@
 {
-  "source_commit": "f53474c45a7791ef45a839d982083708b75b47da",
+  "source_commit": "4b014ebef32253524dccbcbb2ca0dec6b73041bf",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-07-03T14:04:20Z",
+  "synced_at": "2026-07-03T14:21:00Z",
   "notes": "Plugin-native OpenCode distribution with package-local skills registered via skills.paths, package-local AGENTS.md registered via instructions, and plugin-owned cfg.command wrappers for source user-invocable skills. Universal goal-setting backstop guidance is preserved as capability language; no target-only /goal rule is introduced."
 }

--- a/dist/pi/.sync-meta.json
+++ b/dist/pi/.sync-meta.json
@@ -1,11 +1,11 @@
 {
-  "source_commit": "f53474c45a7791ef45a839d982083708b75b47da",
+  "source_commit": "4b014ebef32253524dccbcbb2ca0dec6b73041bf",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
   "target": "pi",
-  "synced_at": "2026-07-03T14:04:20Z",
+  "synced_at": "2026-07-03T14:21:00Z",
   "notes": "Targeted Pi sync for skill-only package architecture. dist/pi ships the full compatible workflow skill set plus prompt-template aliases for /do, /auto, and /babysit-pr. Body adaptation applied: Claude session JSONL line omitted where applicable, plugin-qualified skill ids stripped to bare names, and universal goal-setting backstop guidance preserved in mechanism-neutral wording. Pi no longer ships manifest-dev TypeScript extensions, package-owned verifier scheduling, package-owned done/escalation gates, verifier-only flags, or a tools subpackage. Repo-root package.json is source-owned and loads dist/pi skills/prompts."
 }


### PR DESCRIPTION
Post-merge audit of the dist sync state found one defect: all three `dist/*/.sync-meta.json` files recorded `source_commit: f53474c`, a commit that lived only on the squash-merged feature branches (#211/#212) and never landed on main. It's unreachable from main's history and won't exist on fresh clones.

**Impact:** content is verified current — the source-payload diff (`claude-plugins/manifest-dev/`, `claude-plugins/manifest-dev-tools/`) from that snapshot to main HEAD is empty, and every dist counterpart of the session's edited files is byte-identical to source. The sync-tools skill also self-heals (unreachable SHA → full-sync fallback). But the diff-first optimization would be silently dead until re-stamped.

**Fix:** metadata-only — `source_commit` re-stamped to `4b014eb` (main HEAD, semantically exact given the empty diff), `synced_at` refreshed.

**Process note for future syncs:** recording the source SHA in a follow-up dist commit is incompatible with squash-merging — the recorded SHA never reaches main. Either re-stamp after merge (this PR) or record a SHA that will survive the merge strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019P6DKzDCksXdqsVCYuBe95

---
_Generated by [Claude Code](https://claude.ai/code/session_019P6DKzDCksXdqsVCYuBe95)_