### PR TITLE
docs(review-pr): prove extension-contract sufficiency

### DIFF
--- a/.claude/skills/sync-tools/references/pi-cli.md
+++ b/.claude/skills/sync-tools/references/pi-cli.md
@@ -45,7 +45,7 @@ The Pi package manifest shape is:
 ```json
 {
   "name": "@doodledood/manifest-dev-pi",
-  "version": "6.10.0",
+  "version": "6.10.1",
   "private": true,
   "type": "module",
   "keywords": ["pi-package", "manifest-dev", "agent-skills"],

--- a/claude-plugins/manifest-dev-tools/.claude-plugin/plugin.json
+++ b/claude-plugins/manifest-dev-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev-tools",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Tools for prompts and PRs alongside the manifest workflow. Includes collaborative PR walkthroughs, autonomous PR review with independent per-gate manifest verification, author-side PR babysitting that forwards /do verification policy, gap-calibrated prompt engineering, cross-boundary context handoff, incremental teaching, and a re-pitch corrective for messages that didn't land.",
   "keywords": [
     "post-processing",

--- a/claude-plugins/manifest-dev-tools/skills/review-pr/references/JUDGMENT_PASS.md
+++ b/claude-plugins/manifest-dev-tools/skills/review-pr/references/JUDGMENT_PASS.md
@@ -33,7 +33,7 @@ Each trigger carries what it **fires on** (concrete evidence) and what it **neve
 - **Never:** one unused parameter or a single narrow helper — that is a defect-dimension / dead-code concern, not this pass.
 
 ### 4. Solution-shape
-- **Fires on:** a materially simpler or more direct solution to the *same* pain is concretely nameable — the one-line-upstream fix, the existing primitive that removes the whole mechanism.
+- **Fires on:** a materially simpler or more direct solution to the *same* pain is concretely nameable — the one-line-upstream fix, the existing primitive that removes the whole mechanism. When a change modifies a shared core, runtime, or framework, test whether the whole capability is expressible through the existing extension surface instead. The evidence is the specific contract members — hooks, tool interfaces, options, middleware, or public functions — that together supply every capability the feature needs. If even one required capability is missing, this ground does not fire.
 - **Never:** "I'd architect it differently," with no concretely simpler solution to point at.
 
 ### 5. Omission-vs-pain

--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,10 +1,10 @@
 {
-  "source_commit": "04eabf1b08e846bbca9003a71e292e5f5247f2cb",
+  "source_commit": "8c9543dae3cda9d2dbf1dfb997a8aed92c95e50f",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-08-12T10:27:44Z",
+  "synced_at": "2026-08-12T13:28:38Z",
   "notes": "Records which source commit this tree was generated from. Per-CLI conversion rules \u2014 qualifier handling, context-file naming, tool-name mapping \u2014 live in the sync-tools reference for this CLI, which is the only place that states them."
 }

--- a/dist/codex/plugins/manifest-dev-tools/.codex-plugin/plugin.json
+++ b/dist/codex/plugins/manifest-dev-tools/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "manifest-dev-tools",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "manifest-dev companion tooling for Codex: /babysit-pr with verification-policy forwarding, independently per-gate /review-pr manifest mode, /walk-pr, /teach-me, /handoff, /re-pitch, and prompt engineering.",
   "skills": "./skills/",
   "keywords": [

--- a/dist/codex/plugins/manifest-dev-tools/skills/review-pr/references/JUDGMENT_PASS.md
+++ b/dist/codex/plugins/manifest-dev-tools/skills/review-pr/references/JUDGMENT_PASS.md
@@ -33,7 +33,7 @@ Each trigger carries what it **fires on** (concrete evidence) and what it **neve
 - **Never:** one unused parameter or a single narrow helper — that is a defect-dimension / dead-code concern, not this pass.
 
 ### 4. Solution-shape
-- **Fires on:** a materially simpler or more direct solution to the *same* pain is concretely nameable — the one-line-upstream fix, the existing primitive that removes the whole mechanism.
+- **Fires on:** a materially simpler or more direct solution to the *same* pain is concretely nameable — the one-line-upstream fix, the existing primitive that removes the whole mechanism. When a change modifies a shared core, runtime, or framework, test whether the whole capability is expressible through the existing extension surface instead. The evidence is the specific contract members — hooks, tool interfaces, options, middleware, or public functions — that together supply every capability the feature needs. If even one required capability is missing, this ground does not fire.
 - **Never:** "I'd architect it differently," with no concretely simpler solution to point at.
 
 ### 5. Omission-vs-pain

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,10 +1,10 @@
 {
-  "source_commit": "04eabf1b08e846bbca9003a71e292e5f5247f2cb",
+  "source_commit": "8c9543dae3cda9d2dbf1dfb997a8aed92c95e50f",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-08-12T10:27:44Z",
+  "synced_at": "2026-08-12T13:28:38Z",
   "notes": "Records which source commit this tree was generated from. Per-CLI conversion rules \u2014 qualifier handling, context-file naming, tool-name mapping \u2014 live in the sync-tools reference for this CLI, which is the only place that states them."
 }

--- a/dist/opencode/skills/review-pr/references/JUDGMENT_PASS.md
+++ b/dist/opencode/skills/review-pr/references/JUDGMENT_PASS.md
@@ -33,7 +33,7 @@ Each trigger carries what it **fires on** (concrete evidence) and what it **neve
 - **Never:** one unused parameter or a single narrow helper — that is a defect-dimension / dead-code concern, not this pass.
 
 ### 4. Solution-shape
-- **Fires on:** a materially simpler or more direct solution to the *same* pain is concretely nameable — the one-line-upstream fix, the existing primitive that removes the whole mechanism.
+- **Fires on:** a materially simpler or more direct solution to the *same* pain is concretely nameable — the one-line-upstream fix, the existing primitive that removes the whole mechanism. When a change modifies a shared core, runtime, or framework, test whether the whole capability is expressible through the existing extension surface instead. The evidence is the specific contract members — hooks, tool interfaces, options, middleware, or public functions — that together supply every capability the feature needs. If even one required capability is missing, this ground does not fire.
 - **Never:** "I'd architect it differently," with no concretely simpler solution to point at.
 
 ### 5. Omission-vs-pain

--- a/dist/pi/.sync-meta.json
+++ b/dist/pi/.sync-meta.json
@@ -1,11 +1,11 @@
 {
-  "source_commit": "04eabf1b08e846bbca9003a71e292e5f5247f2cb",
+  "source_commit": "8c9543dae3cda9d2dbf1dfb997a8aed92c95e50f",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
   "target": "pi",
-  "synced_at": "2026-08-12T10:27:44Z",
+  "synced_at": "2026-08-12T13:28:38Z",
   "notes": "Records which source commit this tree was generated from. Per-CLI conversion rules \u2014 qualifier handling, context-file naming, tool-name mapping \u2014 live in the sync-tools reference for this CLI, which is the only place that states them."
 }

--- a/dist/pi/skills/review-pr/references/JUDGMENT_PASS.md
+++ b/dist/pi/skills/review-pr/references/JUDGMENT_PASS.md
@@ -33,7 +33,7 @@ Each trigger carries what it **fires on** (concrete evidence) and what it **neve
 - **Never:** one unused parameter or a single narrow helper — that is a defect-dimension / dead-code concern, not this pass.
 
 ### 4. Solution-shape
-- **Fires on:** a materially simpler or more direct solution to the *same* pain is concretely nameable — the one-line-upstream fix, the existing primitive that removes the whole mechanism.
+- **Fires on:** a materially simpler or more direct solution to the *same* pain is concretely nameable — the one-line-upstream fix, the existing primitive that removes the whole mechanism. When a change modifies a shared core, runtime, or framework, test whether the whole capability is expressible through the existing extension surface instead. The evidence is the specific contract members — hooks, tool interfaces, options, middleware, or public functions — that together supply every capability the feature needs. If even one required capability is missing, this ground does not fire.
 - **Never:** "I'd architect it differently," with no concretely simpler solution to point at.
 
 ### 5. Omission-vs-pain

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doodledood/manifest-dev-pi",
-  "version": "6.10.0",
+  "version": "6.10.1",
   "private": true,
   "description": "Pi package surface for manifest-dev shared skills and prompt-template aliases (/do, /auto, /babysit-pr).",
   "type": "module",


### PR DESCRIPTION
## What

Sharpen the judgment pass's existing Solution-shape trigger so it can prove when a capability added inside a shared core is already fully expressible through the core's public extension surface.

## Why

The existing “existing primitive” wording permits this finding but does not direct the reviewer to inspect the extension contract or name the contract members that make the alternative fully sufficient. That leaves a strong, mechanically demonstrable review observation looking like architecture taste.

## Design

- Keep this inside the existing Solution-shape trigger.
- Require the named hooks, tool interfaces, options, middleware, or public functions to collectively supply every capability the feature needs.
- Do not fire this ground when even one required capability is missing.
- Preserve the explicit “I'd architect it differently” exclusion and the judgment pass's non-blocking question form.
- Sync the canonical wording to Codex, OpenCode, and Pi distributions; bump manifest-dev-tools to 4.2.1 and the Pi package to 6.10.1.

## Verification

- Independent consolidated prompt review: Excellent, no issues.
- Independent change-intent review: zero Low-or-higher findings.
- Ruff, Black, and mypy passed.
- 53/53 pytest tests passed.
- Canonical and distributed judgment-pass references are byte-identical; version and sync provenance checks passed.
