### PR TITLE
Point dist sync metadata at a commit that exists

### DIFF
--- a/dist/codex/.sync-meta.json
+++ b/dist/codex/.sync-meta.json
@@ -1,10 +1,10 @@
 {
-  "source_commit": "840b461d68f202a86c1e0c7460a2bdd149a68996",
+  "source_commit": "cd839cb0881c7f8a4e246f60266c4df629f895f0",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-08-20T08:08:33Z",
+  "synced_at": "2026-08-20T08:17:08Z",
   "notes": "Records which source commit this tree was generated from. Per-CLI conversion rules \u2014 qualifier handling, context-file naming, tool-name mapping \u2014 live in the sync-tools reference for this CLI, which is the only place that states them."
 }

--- a/dist/opencode/.sync-meta.json
+++ b/dist/opencode/.sync-meta.json
@@ -1,10 +1,10 @@
 {
-  "source_commit": "840b461d68f202a86c1e0c7460a2bdd149a68996",
+  "source_commit": "cd839cb0881c7f8a4e246f60266c4df629f895f0",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
-  "synced_at": "2026-08-20T08:08:33Z",
+  "synced_at": "2026-08-20T08:17:08Z",
   "notes": "Records which source commit this tree was generated from. Per-CLI conversion rules \u2014 qualifier handling, context-file naming, tool-name mapping \u2014 live in the sync-tools reference for this CLI, which is the only place that states them."
 }

--- a/dist/pi/.sync-meta.json
+++ b/dist/pi/.sync-meta.json
@@ -1,11 +1,11 @@
 {
-  "source_commit": "840b461d68f202a86c1e0c7460a2bdd149a68996",
+  "source_commit": "cd839cb0881c7f8a4e246f60266c4df629f895f0",
   "source_path": "claude-plugins/manifest-dev",
   "source_paths": [
     "claude-plugins/manifest-dev",
     "claude-plugins/manifest-dev-tools"
   ],
   "target": "pi",
-  "synced_at": "2026-08-20T08:08:33Z",
+  "synced_at": "2026-08-20T08:17:08Z",
   "notes": "Records which source commit this tree was generated from. Per-CLI conversion rules \u2014 qualifier handling, context-file naming, tool-name mapping \u2014 live in the sync-tools reference for this CLI, which is the only place that states them."
 }


### PR DESCRIPTION
## What

All three `.sync-meta.json` files recorded `840b461d`, a branch commit the squash merge of #287 replaced — so the field whose whole job is to record which source commit a tree was generated from named a commit unreachable from `main`. Repointed at `cd839cb0` with a fresh timestamp.

A sync run would have handled this correctly on its own: an unreachable recorded SHA is one of the documented conditions for falling back to a full re-sync. The record was still wrong, and a stale pointer is exactly the thing that can mask real drift.

## The verification behind it

Checked the distributions against the merged sources before changing anything, both directions:

- **Nothing missing.** Every file under `claude-plugins/manifest-dev/skills` and `claude-plugins/manifest-dev-tools/skills` is present in all three distributions.
- **Every difference is authorized.** Nine files differ beyond the qualifier strip, and each is a transform a rule names: the `CLAUDE.md` → `AGENTS.md` remap on operational text (`define/tasks/CODING.md`, `figure-out/references/team.md`), the per-CLI tool-name mappings (`WebFetch`/`WebSearch` → `webfetch`/`websearch` on OpenCode and `shell_command`/`web_search` on Codex, `AskUserQuestion` → the question tool), Pi's generic context-file wording, and `review-pr`'s hidden marker keeping its plugin qualifier because it sits inside an HTML comment and must stay byte-identical across hosts.
- **No misses in the other direction.** No source token a target's rules rewrite survives in that payload. Every remaining `CLAUDE.md` mention is comparative or research text the rules deliberately leave — including `review-code/references/prose-value.md`'s `CLAUDE.md / AGENTS.md` pair, which a past sync had collapsed to `AGENTS.md / AGENTS.md` and which is intact here.
- **Versions and namespaces.** Plugin `9.3.0` mirrored into the Codex and OpenCode manifests, Pi package `7.3.0`, and `dist/pi/component-namespaces.json` matches the shipped skill set exactly — nothing listed-but-absent, nothing present-but-unlisted.

`ruff && black --check && mypy && pytest` green, 72 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5Ept8nG4QorNNhXMCG5Zi)_