### PR TITLE
State the altitude rule as what the document is for, not as churn avoidance

### DIFF
--- a/claude-plugins/manifest-dev/skills/init-context/references/NORTH_STAR_FORMAT.md
+++ b/claude-plugins/manifest-dev/skills/init-context/references/NORTH_STAR_FORMAT.md
@@ -125,10 +125,11 @@ it's for sets who copy is written to — the copy is not in here. The promise bo
 marketing may claim — the campaigns are not in here. Live metric readings never enter
 the document: states carry dates, and staleness is read from them.
 
-Position text carries no details: a change in an example, a name, a number, or a path
-must never force this document to change. Write positions at the altitude that survives
-such changes, and let provenance notes carry compact pointers to where the specifics
-live.
+Position text stays at the altitude the document works at: a North Star is an alignment
+surface, so concrete work-level specifics — an example, a name, a number, a path — do
+not belong in a position, however stable or true they are. Name the shape, and let
+provenance notes carry compact pointers to where the specifics live. Such a document
+also churns less as details move, but altitude is the test, not churn.
 
 ## Document skeleton
 

--- a/dist/codex/plugins/manifest-dev/skills/init-context/references/NORTH_STAR_FORMAT.md
+++ b/dist/codex/plugins/manifest-dev/skills/init-context/references/NORTH_STAR_FORMAT.md
@@ -125,10 +125,11 @@ it's for sets who copy is written to — the copy is not in here. The promise bo
 marketing may claim — the campaigns are not in here. Live metric readings never enter
 the document: states carry dates, and staleness is read from them.
 
-Position text carries no details: a change in an example, a name, a number, or a path
-must never force this document to change. Write positions at the altitude that survives
-such changes, and let provenance notes carry compact pointers to where the specifics
-live.
+Position text stays at the altitude the document works at: a North Star is an alignment
+surface, so concrete work-level specifics — an example, a name, a number, a path — do
+not belong in a position, however stable or true they are. Name the shape, and let
+provenance notes carry compact pointers to where the specifics live. Such a document
+also churns less as details move, but altitude is the test, not churn.
 
 ## Document skeleton
 

--- a/dist/opencode/skills/init-context/references/NORTH_STAR_FORMAT.md
+++ b/dist/opencode/skills/init-context/references/NORTH_STAR_FORMAT.md
@@ -125,10 +125,11 @@ it's for sets who copy is written to — the copy is not in here. The promise bo
 marketing may claim — the campaigns are not in here. Live metric readings never enter
 the document: states carry dates, and staleness is read from them.
 
-Position text carries no details: a change in an example, a name, a number, or a path
-must never force this document to change. Write positions at the altitude that survives
-such changes, and let provenance notes carry compact pointers to where the specifics
-live.
+Position text stays at the altitude the document works at: a North Star is an alignment
+surface, so concrete work-level specifics — an example, a name, a number, a path — do
+not belong in a position, however stable or true they are. Name the shape, and let
+provenance notes carry compact pointers to where the specifics live. Such a document
+also churns less as details move, but altitude is the test, not churn.
 
 ## Document skeleton
 

--- a/dist/pi/skills/init-context/references/NORTH_STAR_FORMAT.md
+++ b/dist/pi/skills/init-context/references/NORTH_STAR_FORMAT.md
@@ -125,10 +125,11 @@ it's for sets who copy is written to — the copy is not in here. The promise bo
 marketing may claim — the campaigns are not in here. Live metric readings never enter
 the document: states carry dates, and staleness is read from them.
 
-Position text carries no details: a change in an example, a name, a number, or a path
-must never force this document to change. Write positions at the altitude that survives
-such changes, and let provenance notes carry compact pointers to where the specifics
-live.
+Position text stays at the altitude the document works at: a North Star is an alignment
+surface, so concrete work-level specifics — an example, a name, a number, a path — do
+not belong in a position, however stable or true they are. Name the shape, and let
+provenance notes carry compact pointers to where the specifics live. Such a document
+also churns less as details move, but altitude is the test, not churn.
 
 ## Document skeleton
 

--- a/docs/NORTH_STAR_CONVENTIONS.md
+++ b/docs/NORTH_STAR_CONVENTIONS.md
@@ -108,10 +108,11 @@ it's for sets who copy is written to — the copy is not in here. The promise bo
 marketing may claim — the campaigns are not in here. Live metric readings never enter
 the document: states carry dates, and staleness is read from them.
 
-Position text carries no details: a change in an example, a name, a number, or a path
-must never force this document to change. Write positions at the altitude that survives
-such changes, and let provenance notes carry compact pointers to where the specifics
-live.
+Position text stays at the altitude the document works at: a North Star is an alignment
+surface, so concrete work-level specifics — an example, a name, a number, a path — do
+not belong in a position, however stable or true they are. Name the shape, and let
+provenance notes carry compact pointers to where the specifics live. Such a document
+also churns less as details move, but altitude is the test, not churn.
 
 ## Document skeleton
 


### PR DESCRIPTION
The altitude rule came from an owner's ruling, and the wording written for it in #285 argued the wrong thing.

## What it said, and what was meant

It said a change in a detail *"must never force this document to change"* — a maintenance argument, with altitude as the means to it. The ruling was about purpose: **a North Star is an alignment surface, so concrete work-level specifics do not belong in a position at all.**

## The two readings diverge on a real case

Under churn avoidance, a concrete detail nobody expects to change is fine — it will never force an edit, so the stated reason does not reach it. Under the ruling it is still wrong, because it is the wrong altitude for the document regardless of how stable it is.

That is why the restated rule says *"however stable or true they are"* and names altitude as the test:

> Position text stays at the altitude the document works at: a North Star is an alignment surface, so concrete work-level specifics — an example, a name, a number, a path — do not belong in a position, however stable or true they are. Name the shape, and let provenance notes carry compact pointers to where the specifics live. Such a document also churns less as details move, but altitude is the test, not churn.

Churn is kept as what it actually is: a consequence of writing at the right altitude, not the reason to.

It also sits better beside the sentence already opening that section — *"The North Star is what a decision is checked against, never where work is done"* — which is the same purpose argument.

## Fork parity

This repo's own `docs/NORTH_STAR_CONVENTIONS.md` is a fork of that default, so the change is ported into it in the same commit. `test_project_conventions_forks` fails otherwise — which is the check from #287 working exactly as intended, on the first change after it shipped.

## Scope

One paragraph in `references/NORTH_STAR_FORMAT.md`, the same paragraph in this repo's conventions fork, propagated to the three `dist/` trees. 72/72 tests pass. Four over-length lines flagged by my width check predate this change and arrived with #287; left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vZoikGMGWwTzczf492nBh

---
_Generated by [Claude Code](https://claude.ai/code/session_018vZoikGMGWwTzczf492nBh)_