### PR TITLE
Adopt the shared coding conventions in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,3 +219,32 @@ Bump plugin version if plugin files changed.
 Ratified steering preferences for this repo. Each states the preference, why it holds, and when it should yield — weigh them rather than obey them.
 
 - **Default manifests here to no PR-lifecycle gates.** Pull requests in this repo run no CI and have a single maintainer as the only reviewer, so lifecycle criteria spend verification effort on nothing. Include them once a pull request carries required status checks, or a reviewer whose approval gates the merge.
+
+## Coding Conventions
+
+### Solution design
+
+In any domain — code, process, tooling, docs, prompts — prefer the design that prevents a class of problems over the quick one that merely works today. And treat every problem you touch as one you should not meet again: leave the system so that class of problem cannot return, or costs less when it does.
+
+- The cheapest class of bugs to prevent is the code never written — before designing, ask whether the requirement itself is needed, and say so when it isn't.
+- Design so a class of bugs cannot occur, whether or not one has occurred yet: illegal states unrepresentable, the invariant enforced where it cannot be bypassed, one source of truth instead of two that can disagree. This is the default for new code as much as for a fix — the design that closes the class beats the patch that handles the instance in front of you.
+- Among designs that close the class, take the one with the fewest moving parts and the least hidden coupling — unless the user asks to optimize for a different priority. Machinery heavier than the class it closes is over-engineering, not design.
+- Fail loud. No fallback, catch-and-continue, or default value that masks a failure unless degraded operation is explicitly wanted — silent wrong behavior costs more than a crash.
+- When the structural fix is out of reach of the change at hand, fix the instance and name the design that would close the class — don't ship the patch as if it settled the matter.
+- After fixing a bug, sweep for sibling instances of the same defect pattern before calling it done — the class includes the copies that already shipped.
+- A rule that lives as a sentence someone must remember is a check waiting to be written — when a convention can be enforced by a type, lint, test, or CI gate, propose the enforcement. Price it like any machinery: worth building where failure is expensive or the surface is shared, not on a solo surface already verified locally.
+- A new dependency is a recurring cost, not a one-time one — prefer the standard library or what the repo already uses, and justify any addition.
+- Clean the touched area enough for a durable fix; propose broader refactors separately.
+
+### What counts as verified
+
+- Evidence ranks: unit/integration tests > a written verification script > manual checking. Prefer targeted checks to full-suite reruns, and exhaust the automated options before asking the user to verify by hand.
+- Code with existing test files gets its tests added or updated there, covering the layers the change actually touches — unit and integration where both apply.
+- For e2e or integration work, write the verification script inline when feasible.
+- Say plainly what you did not verify.
+
+### Git and pull requests
+
+- Conventional commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`. Branches `feature/*`, `fix/*` unless the project says otherwise.
+- Prefer several coherent medium PRs to one monolith when the work naturally splits. Slice vertically — one feature stage end-to-end, handler + service + entity + tests — not horizontally, where each slice carries no logic of its own and only makes sense combined. Small mechanical changes (renames, config, migrations, boilerplate) ride along with the logic that needs them; a sweeping mechanical refactor can still earn its own PR for reviewability. Don't grow a PR past its natural scope — split instead.
+- Open PRs substantially complete. The title names the real scope — the workflow and modules touched, not the immediate symptom. The description leads with what the change does and why it needed this design — the cross-module flow, the non-obvious decisions, the invariants preserved — not a file-by-file list.


### PR DESCRIPTION
## What this does

The coding conventions — design against a class of bugs rather than patch the instance, what counts as verified, how commits and pull requests are shaped — live in `doodledood/pi-plugins` at `setup/CODING_CONVENTIONS.md`. They were split out of the maintainer's user-level `AGENTS.md`, which also carries operating posture personal to his machine and does not belong in a repo.

Environments that do not load a user-level context file, Claude Code on the web among them, saw none of it — sessions here ran on `CLAUDE.md` alone, which says nothing about what counts as verified or how to close a class of bugs, because those rules were never supposed to live here.

A `sync-coding-conventions` skill in `doodledood/second-brain` merges the conventions into each fleet repo's context file. This is the pass for this repo.

## The section

`## Coding Conventions`, appended to `CLAUDE.md` (`AGENTS.md` is a symlink onto it, so one section covers both), with the source's headings demoted one level so they nest under the file's own title.

Nothing marks it as generated — no provenance line, no markers. A context file is one document to the agent reading it, and the heading is the anchor a re-run finds. Changes go to `setup/CODING_CONVENTIONS.md`, and **a project rule wins any conflict with a convention** — the Public Repository Discipline, the ADR convention ownership, the versioning rules, and Taste are all untouched and all still govern.

## Reconciliation

Nothing collided, and no edit outside the section. `Before PR` refines what counts as verified for this codebase, and the section's `Solution design` — close the class, fail loud, fewest moving parts — is the same instinct `Taste` encodes for steering preferences, stated generally.

An earlier revision of this PR removed `## File Operations` as a duplicate. That was wrong once the scope narrowed: the `cp`/`mv` rule lives in the operating-posture half, which is not shared, so removing it here would have deleted a rule nothing replaces. It is restored and this PR leaves it alone.

## Verified

`sync.py` reported the splice and passed its post-write check against the intended text. The diff against `main` is 29 added lines in `CLAUDE.md` and nothing else — nothing under `claude-plugins/`, so the `ruff && black && mypy && pytest` gate and the plugin version bump do not apply.

Per `## Public Repository Discipline`, neither the commit trailer nor this description carries a session link.